### PR TITLE
Mhd

### DIFF
--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -63,6 +63,12 @@ struct gkyl_moment {
   double lower[3], upper[3]; // lower, upper bounds
   int cells[3]; // config-space cells
 
+  void *c2p_ctx; // context for mapc2p function
+  // pointer to mapc2p function: xc are the computational space
+  // coordinates and on output xp are the corresponding physical space
+  // coordinates.
+  void (*mapc2p)(double t, const double *xc, double *xp, void *ctx);
+
   double cfl_frac; // CFL fraction to use
 
   enum gkyl_moment_fluid_scheme fluid_scheme; // scheme to update fluid equations

--- a/apps/moment.c
+++ b/apps/moment.c
@@ -7,6 +7,7 @@
 #include <gkyl_array.h>
 #include <gkyl_array_ops.h>
 #include <gkyl_array_rio.h>
+#include <gkyl_eval_on_nodes.h>
 #include <gkyl_fv_proj.h>
 #include <gkyl_moment.h>
 #include <gkyl_moment_em_coupling.h>
@@ -92,6 +93,13 @@ struct gkyl_moment_app {
     
   struct gkyl_rect_grid grid; // grid
   struct gkyl_range local, local_ext; // local, local-ext ranges
+
+  bool has_mapc2p; // flag to indicate if we have mapc2p
+  void *c2p_ctx; // context for mapc2p function
+  // pointer to mapc2p function
+  void (*mapc2p)(double t, const double *xc, double *xp, void *ctx);
+
+  struct gkyl_array *c2p; // DG field representing coordinate mapping
 
   struct skin_ghost_ranges skin_ghost; // conf-space skin/ghost
 
@@ -654,13 +662,40 @@ gkyl_moment_app_new(struct gkyl_moment mom)
   struct gkyl_moment_app *app = gkyl_malloc(sizeof(gkyl_moment_app));
 
   int ndim = app->ndim = mom.ndim;
+  strcpy(app->name, mom.name);
+  app->tcurr = 0.0; // reset on init
 
-  // create grid and ranges
+  // create grid and ranges (grid is in computational space)
   int ghost[3] = { 2, 2, 2 };
   gkyl_rect_grid_init(&app->grid, ndim, mom.lower, mom.upper, mom.cells);
   gkyl_create_grid_ranges(&app->grid, ghost, &app->local_ext, &app->local);
 
   skin_ghost_ranges_init(&app->skin_ghost, &app->local_ext, ghost);
+
+  app->has_mapc2p = mom.mapc2p ? true : false;
+
+  if (app->has_mapc2p) {
+    // initialize computational to physical space mapping
+    app->c2p_ctx = mom.c2p_ctx;
+    app->mapc2p = mom.mapc2p;
+
+    // we project mapc2p on p=1 basis functions
+    struct gkyl_basis basis;
+    gkyl_cart_modal_tensor(&basis, ndim, 1);
+
+    // initialize DG field representing mapping
+    app->c2p = mkarr(ndim*basis.num_basis, app->local_ext.volume);
+    gkyl_eval_on_nodes *ev_c2p = gkyl_eval_on_nodes_new(&app->grid, &basis, ndim, mom.mapc2p, mom.c2p_ctx);
+    gkyl_eval_on_nodes_advance(ev_c2p, 0.0, &app->local_ext, app->c2p);
+    gkyl_eval_on_nodes_release(ev_c2p);
+
+    // write DG projection of mapc2p to file
+    const char *fmt = "%s-mapc2p.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name);
+    char fileNm[sz+1]; // ensures no buffer overflow  
+    snprintf(fileNm, sizeof fileNm, fmt, app->name);
+    gkyl_grid_sub_array_write(&app->grid, &app->local, app->c2p, fileNm);
+  }
 
   double cfl_frac = mom.cfl_frac == 0 ? 0.95 : mom.cfl_frac;
   app->cfl = 1.0*cfl_frac;
@@ -691,9 +726,6 @@ gkyl_moment_app_new(struct gkyl_moment mom)
     app->update_sources = 1; // only update if field and species are present
     moment_coupling_init(app, &app->sources);
   }
-
-  strcpy(app->name, mom.name);
-  app->tcurr = 0.0; // reset on init
 
   // initialize stat object to all zeros
   app->stat = (struct gkyl_moment_stat) {
@@ -970,6 +1002,9 @@ gkyl_moment_app_stat_write(const gkyl_moment_app* app)
 void
 gkyl_moment_app_release(gkyl_moment_app* app)
 {
+  if (app->has_mapc2p)
+    gkyl_array_release(app->c2p);
+  
   for (int i=0; i<app->num_species; ++i)
     moment_species_release(&app->species[i]);
   free(app->species);

--- a/regression/rt_euler_axi_sodshock.c
+++ b/regression/rt_euler_axi_sodshock.c
@@ -1,0 +1,135 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_const.h>
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_euler.h>
+#include <rt_arg_parse.h>
+
+struct euler_ctx {
+  double gas_gamma; // gas constant
+};
+
+void
+evalEulerInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct euler_ctx *app = ctx;
+  double gas_gamma = app->gas_gamma;
+
+  double r = xn[0]; // radial coordinate
+
+  double rhol = 3.0, ul = 0.0, pl = 3.0;
+  double rhor = 1.0, ur = 0.0, pr = 1.0;
+
+  double rho = rhor, u = ur, p = pr;
+  if (r<1.5) {
+    rho = rhol;
+    u = ul;
+    p = pl;
+  }
+
+  fout[0] = rho;
+  fout[1] = rho*u; fout[2] = 0.0; fout[3] = 0.0;
+  fout[4] = p/(gas_gamma-1) + 0.5*rho*u*u;
+}
+
+// map (r,theta) -> (x,y)
+void
+mapc2p(double t, const double *xc, double* GKYL_RESTRICT xp, void *ctx)
+{
+  double r = xc[0], th = xc[1];
+  xp[0] = r*cos(th); xp[1] = r*sin(th);
+}
+
+struct euler_ctx
+euler_ctx(void)
+{
+  return (struct euler_ctx) { .gas_gamma = 1.4 };
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  struct euler_ctx ctx = euler_ctx(); // context for init functions
+
+  // equation object
+  struct gkyl_wv_eqn *euler = gkyl_wv_euler_new(ctx.gas_gamma);
+
+  struct gkyl_moment_species fluid = {
+    .name = "euler",
+
+    .equation = euler,
+    .evolve = 1,
+    .ctx = &ctx,
+    .init = evalEulerInit,
+
+    .bcx = { GKYL_MOMENT_COPY, GKYL_MOMENT_COPY },
+  };
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "euler_axis_sodshock",
+
+    .ndim = 2,
+    // grid in computational space
+    .lower = { 1.0, 0.0 },
+    .upper = { 2.0, 2*GKYL_PI },
+    .cells = { 32, 32*6 },
+
+    .mapc2p = mapc2p, // mapping of computational to physical space
+    
+    .cfl_frac = 0.9,
+
+    .num_species = 1,
+    .species = { fluid },
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(app_inp);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = 0.1;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((tcurr < tend) && (step <= num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(euler);
+  gkyl_moment_app_release(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+  
+  return 0;
+}

--- a/regression/rt_euler_axi_sodshock.c
+++ b/regression/rt_euler_axi_sodshock.c
@@ -76,9 +76,12 @@ main(int argc, char **argv)
     // grid in computational space
     .lower = { 1.0, 0.0 },
     .upper = { 2.0, 2*GKYL_PI },
-    .cells = { 32, 32*6 },
+    .cells = { 128, 4 },
 
     .mapc2p = mapc2p, // mapping of computational to physical space
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 1 },
     
     .cfl_frac = 0.9,
 

--- a/regression/rt_eval_on_nodes.c
+++ b/regression/rt_eval_on_nodes.c
@@ -69,9 +69,9 @@ void mapc2p(double t, const double *xn, double* GKYL_RESTRICT fout, void *ctx)
 
 void gaussian(double t, const double *xn, double* GKYL_RESTRICT fout, void *ctx)
 {
-  double xp[2], vth = 0.5, xc = 2.5;
+  double xp[2], vth = 0.5, xc = 0.0, yc = 2.5;
   mapc2p(t, xn, xp, 0);
-  double r2 = (xp[0]-xc)*(xp[0]-xc) + xp[1]*xp[1];
+  double r2 = (xp[0]-xc)*(xp[0]-xc) + (xp[1]-yc)*(xp[1]-yc);
   fout[0] = exp(-r2/(2*vth*vth));
 }
 
@@ -130,6 +130,66 @@ test_eval_2(enum gkyl_basis_type type)
   gkyl_array_release(rtheta);
 }
 
+void shock(double t, const double *xc, double* GKYL_RESTRICT xp, void *ctx)
+{
+  xp[0] = xc[0] > 2.5 ? 1.0 : 0.0;
+}
+
+void
+test_eval_3(enum gkyl_basis_type type)
+{
+  int poly_order = 1;
+  double lower[] = {1.0, 0.0}, upper[] = {4.0, 2.0*M_PI};
+  int cells[] = {8, 8};
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, 2, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  if (type == GKYL_BASIS_MODAL_SERENDIPITY)
+    gkyl_cart_modal_serendip(&basis, 2, poly_order);
+  else
+    gkyl_cart_modal_tensor(&basis, 2, poly_order);
+
+  // create array range: no ghost-cells 
+  struct gkyl_range arr_range;
+  gkyl_range_init_from_shape(&arr_range, 2, cells);
+
+  // create DG expansion of mapping
+  gkyl_eval_on_nodes *eval_mapc2p = gkyl_eval_on_nodes_new(&grid, &basis, 2, mapc2p, 0);
+  struct gkyl_array *rtheta = gkyl_array_new(GKYL_DOUBLE, 2*basis.num_basis, arr_range.volume);
+  gkyl_eval_on_nodes_advance(eval_mapc2p, 0.0, &arr_range, rtheta);
+
+  // ICs on mapped grid
+  gkyl_proj_on_basis *proj_ic = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, 1, shock, 0);
+  struct gkyl_array *f = gkyl_array_new(GKYL_DOUBLE, basis.num_basis, arr_range.volume);
+  gkyl_proj_on_basis_advance(proj_ic, 0.0, &arr_range, f);
+
+  // construct file name and write data out
+  const char *fmt[] = {
+    [GKYL_BASIS_MODAL_SERENDIPITY] = "%s-ser.gkyl",
+    [GKYL_BASIS_MODAL_TENSOR] = "%s-ten.gkyl",
+  };
+
+  do {
+    int sz = snprintf(0, 0, fmt[type], "rt_eval_on_nodes_rtheta_shock");
+    char fileNm[sz+1]; // ensures no buffer overflow  
+    snprintf(fileNm, sizeof fileNm, fmt[type], "rt_eval_on_nodes_rtheta_shock");
+    gkyl_grid_sub_array_write(&grid, &arr_range, rtheta, fileNm);
+  } while (0);
+
+  do {
+    int sz = snprintf(0, 0, fmt[type], "rt_eval_on_nodes_f_shock");
+    char fileNm[sz+1]; // ensures no buffer overflow  
+    snprintf(fileNm, sizeof fileNm, fmt[type], "rt_eval_on_nodes_f_shock");
+    gkyl_grid_sub_array_write(&grid, &arr_range, f, fileNm);
+  } while (0);
+  
+  gkyl_eval_on_nodes_release(eval_mapc2p);
+  gkyl_proj_on_basis_release(proj_ic);
+  gkyl_array_release(rtheta);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -138,6 +198,9 @@ main(int argc, char **argv)
 
   test_eval_2(GKYL_BASIS_MODAL_SERENDIPITY);
   test_eval_2(GKYL_BASIS_MODAL_TENSOR);
+
+  test_eval_3(GKYL_BASIS_MODAL_SERENDIPITY);
+  test_eval_3(GKYL_BASIS_MODAL_TENSOR);  
 
   return 0;
 }

--- a/regression/rt_mhd_brio_wu.c
+++ b/regression/rt_mhd_brio_wu.c
@@ -1,0 +1,125 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_mhd.h>
+#include <rt_arg_parse.h>
+
+struct mhd_ctx {
+  double gas_gamma; // gas constant
+};
+
+void
+evalMhdInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct mhd_ctx *app = ctx;
+  double x = xn[0];
+  double gas_gamma = app->gas_gamma;
+
+  double bx = 0.75;
+  double rhol = 1.0, rhor = 0.125;
+  double byl = 1.0, byr = -1.0;
+  double pl = 1.0, pr = 0.1;
+
+  double rho = rhor, by = byr, p = pr;
+  if (x<0.5) {
+    rho = rhol;
+    by = byl;
+    p = pl;
+  }
+
+  fout[0] = rho;
+  fout[1] = 0.0; fout[2] = 0.0; fout[3] = 0.0;
+  fout[4] = p/(gas_gamma-1) + 0.5*(bx*bx + by*by);
+  fout[5] = bx; fout[6] = by; fout[7] = 0.0;
+}
+
+struct mhd_ctx
+mhd_ctx(void)
+{
+  return (struct mhd_ctx) { .gas_gamma = 2.0 };
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  struct mhd_ctx ctx = mhd_ctx(); // context for init functions
+
+  // equation object
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma);
+
+  struct gkyl_moment_species fluid = {
+    .name = "mhd",
+
+    .equation = mhd,
+    .evolve = 1,
+    .ctx = &ctx,
+    .init = evalMhdInit,
+
+    .bcx = { GKYL_MOMENT_COPY, GKYL_MOMENT_COPY },
+  };
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "mhd_bio_wu",
+
+    .ndim = 1,
+    .lower = { 0.0 },
+    .upper = { 1.0 }, 
+    .cells = { 512 },
+
+    .cfl_frac = 0.1,
+
+    .num_species = 1,
+    .species = { fluid },
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(app_inp);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = 0.1;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((tcurr < tend) && (step <= num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(mhd);
+  gkyl_moment_app_release(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+  
+  return 0;
+}

--- a/unit/ctest_wave_geom.c
+++ b/unit/ctest_wave_geom.c
@@ -1,0 +1,99 @@
+#include <acutest.h>
+
+#include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
+#include <gkyl_wave_geom.h>
+
+static void
+nomapc2p(double t, const double *xc, double *xp, void *ctx)
+{
+  int *ndim = ctx;
+  for (int i=0; i<(*ndim); ++i) xp[i] = xc[i];
+}
+
+void
+test_wv_geom_1d_1()
+{
+  int ndim = 1;
+  double lower[] = {0.0}, upper[] = {1.0};
+  int cells[] = {10};
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // create range
+  struct gkyl_range range;
+  gkyl_range_init_from_shape(&range, ndim, cells);
+
+  struct gkyl_wave_geom *wg = gkyl_wave_geom_new(&grid, &range, nomapc2p, &ndim);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  
+  while (gkyl_range_iter_next(&iter)) {
+    const struct gkyl_wave_cell_geom *cg = gkyl_wave_geom_get(wg, iter.idx);
+
+    TEST_CHECK( gkyl_compare_double( cg->kappa, 1.0, 1e-15) );
+    TEST_CHECK( cg->lenr[0] == 1.0 );
+
+    TEST_CHECK( cg->norm[0][0] == 1.0 );
+    TEST_CHECK( cg->tau1[0][1] == 1.0 );
+    TEST_CHECK( cg->tau2[0][2] == 1.0 );
+  }
+
+  gkyl_wave_geom_release(wg);
+}
+
+static void
+mapc2p(double t, const double *xc, double *xp, void *ctx)
+{
+  // quadratic mapping
+  int *ndim = ctx;
+  for (int i=0; i<(*ndim); ++i) xp[i] = xc[i]*xc[i];
+}
+
+void
+test_wv_geom_1d_2()
+{
+  int ndim = 1;
+  double lower[] = {0.0}, upper[] = {1.0};
+  int cells[] = {2};
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // create range
+  struct gkyl_range range;
+  gkyl_range_init_from_shape(&range, ndim, cells);
+
+  struct gkyl_wave_geom *wg = gkyl_wave_geom_new(&grid, &range, mapc2p, &ndim);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+
+  // cell 1
+  do {
+    const struct gkyl_wave_cell_geom *cg = gkyl_wave_geom_get(wg, (int[]) { range.lower[0]+0 } );
+    TEST_CHECK( gkyl_compare_double( cg->kappa, 0.5*0.5/0.5, 1e-15) );
+    TEST_CHECK( cg->lenr[0] == 1.0 );
+    TEST_CHECK( cg->norm[0][0] == 1.0 );
+    TEST_CHECK( cg->tau1[0][1] == 1.0 );
+    TEST_CHECK( cg->tau2[0][2] == 1.0 );
+  } while (0);
+
+  // cell 2
+  do {
+    const struct gkyl_wave_cell_geom *cg = gkyl_wave_geom_get(wg, (int[]) { range.lower[0]+1 } );
+    TEST_CHECK( gkyl_compare_double( cg->kappa, (1-0.5*0.5)/0.5, 1e-15) );
+    TEST_CHECK( cg->lenr[0] == 1.0 );
+    TEST_CHECK( cg->norm[0][0] == 1.0 );
+    TEST_CHECK( cg->tau1[0][1] == 1.0 );
+    TEST_CHECK( cg->tau2[0][2] == 1.0 );
+  } while (0);  
+
+  gkyl_wave_geom_release(wg);
+}
+
+TEST_LIST = {
+  { "wv_geom_1d_1", test_wv_geom_1d_1 },
+  { "wv_geom_1d_2", test_wv_geom_1d_2 },
+  { NULL, NULL },
+};

--- a/unit/ctest_wv_euler.c
+++ b/unit/ctest_wv_euler.c
@@ -62,15 +62,24 @@ test_euler_waves()
   double vr[5] = { 0.1, 1.0, 2.0, 3.0, 0.15};
 
   double ql[5], qr[5];
+  double ql_local[5], qr_local[5];
   calcq(gas_gamma, vl, ql); calcq(gas_gamma, vr, qr);
 
-  double delta[5];
-  for (int i=0; i<5; ++i) delta[i] = qr[i]-ql[i];
-
   for (int d=0; d<3; ++d) {
-    double speeds[3], waves[3*5];
-    gkyl_wv_eqn_waves(euler, d, delta, ql, qr, waves, speeds);
+    double speeds[3], waves[3*5], waves_local[3*5];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(euler, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(euler, d, 0, 0, 0, qr, qr_local);
 
+    double delta[5];
+    for (int i=0; i<5; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(euler, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<3; ++mw)
+      gkyl_wv_eqn_rotate_to_global(euler, d, 0, 0, 0, &waves_local[mw*5], &waves[mw*5]);
+    
     double apdq[5], amdq[5];
     gkyl_wv_eqn_qfluct(euler, d, ql, qr, waves, speeds, amdq, apdq);
     
@@ -96,14 +105,23 @@ test_euler_waves_2()
   double vr[5] = { 0.01, 1.0, 2.0, 3.0, 15.0};
 
   double ql[5], qr[5];
+  double ql_local[5], qr_local[5];
   calcq(gas_gamma, vl, ql); calcq(gas_gamma, vr, qr);
 
-  double delta[5];
-  for (int i=0; i<5; ++i) delta[i] = qr[i]-ql[i];
-
   for (int d=0; d<3; ++d) {
-    double speeds[3], waves[3*5];
-    gkyl_wv_eqn_waves(euler, d, delta, ql, qr, waves, speeds);
+    double speeds[3], waves[3*5], waves_local[3*5];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(euler, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(euler, d, 0, 0, 0, qr, qr_local);
+
+    double delta[5];
+    for (int i=0; i<5; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(euler, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<3; ++mw)
+      gkyl_wv_eqn_rotate_to_global(euler, d, 0, 0, 0, &waves_local[mw*5], &waves[mw*5]);
 
     double apdq[5], amdq[5];
     gkyl_wv_eqn_qfluct(euler, d, ql, qr, waves, speeds, amdq, apdq);

--- a/unit/ctest_wv_iso_euler.c
+++ b/unit/ctest_wv_iso_euler.c
@@ -56,15 +56,24 @@ test_iso_euler_waves()
   double vr[4] = { 0.1, 1.0, 2.0, 3.0};
 
   double ql[4], qr[4];
+  double ql_local[4], qr_local[4];
   calcq(vl, ql); calcq(vr, qr);
 
-  double delta[4];
-  for (int i=0; i<4; ++i) delta[i] = qr[i]-ql[i];
-
   for (int d=0; d<3; ++d) {
-    double speeds[3], waves[3*4];
-    gkyl_wv_eqn_waves(iso_euler, d, delta, ql, qr, waves, speeds);
+    double speeds[3], waves[3*4], waves_local[3*4];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(iso_euler, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(iso_euler, d, 0, 0, 0, qr, qr_local);
 
+    double delta[4];
+    for (int i=0; i<4; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(iso_euler, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<3; ++mw)
+      gkyl_wv_eqn_rotate_to_global(iso_euler, d, 0, 0, 0, &waves_local[mw*4], &waves[mw*4]);
+    
     double apdq[4], amdq[4];
     gkyl_wv_eqn_qfluct(iso_euler, d, ql, qr, waves, speeds, amdq, apdq);
     
@@ -90,14 +99,23 @@ test_iso_euler_waves_2()
   double vr[4] = { 0.01, 1.0, 2.0, 3.0};
 
   double ql[4], qr[4];
+  double ql_local[4], qr_local[4];
   calcq(vl, ql); calcq(vr, qr);
 
-  double delta[4];
-  for (int i=0; i<4; ++i) delta[i] = qr[i]-ql[i];
-
   for (int d=0; d<3; ++d) {
-    double speeds[3], waves[3*4];
-    gkyl_wv_eqn_waves(iso_euler, d, delta, ql, qr, waves, speeds);
+    double speeds[3], waves[3*4], waves_local[3*4];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(iso_euler, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(iso_euler, d, 0, 0, 0, qr, qr_local);
+
+    double delta[4];
+    for (int i=0; i<4; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(iso_euler, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<3; ++mw)
+      gkyl_wv_eqn_rotate_to_global(iso_euler, d, 0, 0, 0, &waves_local[mw*4], &waves[mw*4]);
 
     double apdq[4], amdq[4];
     gkyl_wv_eqn_qfluct(iso_euler, d, ql, qr, waves, speeds, amdq, apdq);

--- a/unit/ctest_wv_maxwell.c
+++ b/unit/ctest_wv_maxwell.c
@@ -84,13 +84,23 @@ test_maxwell_waves()
 
   double ql[8] = { 0.0, 1.0, 0.0, 1.0, -0.75, 0.0, 0.0, 0.0};
   double qr[8] = { 0.0, -1.0, 0.0, 1.0, 0.75, 0.0, 0.0, 0.0};
-
-  double delta[8];
-  for (int i=0; i<8; ++i) delta[i] = qr[i]-ql[i];
+  double ql_local[8] = { 0.0, 1.0, 0.0, 1.0, -0.75, 0.0, 0.0, 0.0};
+  double qr_local[8] = { 0.0, -1.0, 0.0, 1.0, 0.75, 0.0, 0.0, 0.0};
 
   for (int d=0; d<3; ++d) {
-    double speeds[6], waves[6*8];
-    gkyl_wv_eqn_waves(maxwell, d, delta, ql, qr, waves, speeds);
+    double speeds[6], waves[6*8], waves_local[6*8];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(maxwell, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(maxwell, d, 0, 0, 0, qr, qr_local);
+
+    double delta[8];
+    for (int i=0; i<8; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(maxwell, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<6; ++mw)
+      gkyl_wv_eqn_rotate_to_global(maxwell, d, 0, 0, 0, &waves_local[mw*8], &waves[mw*8]);
 
     double apdq[8], amdq[8];
     gkyl_wv_eqn_qfluct(maxwell, d, ql, qr, waves, speeds, amdq, apdq);

--- a/unit/ctest_wv_mhd.c
+++ b/unit/ctest_wv_mhd.c
@@ -1,0 +1,111 @@
+#include <acutest.h>
+#include <gkyl_prim_mhd.h>
+#include <gkyl_wv_mhd.h>
+
+void
+calcq(double gas_gamma, const double pv[8], double q[8])
+{
+  double rho = pv[0], u = pv[1], v = pv[2], w = pv[3], pr = pv[4];
+  q[0] = rho;
+  q[1] = rho*u; q[2] = rho*v; q[3] = rho*w;
+  q[5] = pv[5]; q[6] = pv[6]; q[7] = pv[7];  // B field
+  double pb = 0.5*(pv[5]*pv[5]+pv[6]*pv[6]+pv[7]*pv[7]); // magnetic pressure
+  q[4] = pr/(gas_gamma-1) + 0.5*rho*(u*u+v*v+w*w) + pb;
+}
+
+/* Check flux function implementation */
+void
+test_mhd_basic()
+{
+  double gas_gamma = 1.4;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma);
+
+  TEST_CHECK( mhd->num_equations == 8 );
+  TEST_CHECK( mhd->num_waves == 7 );
+
+  double rho = 1.0, u = 0.1, v = 0.2, w = 0.3, pr = 1.5;
+  double bx = 0.11, by = 0.22, bz = 0.33;
+  double q[8], pv[8] = { rho, u, v, w, pr, bx, by, bz };
+  calcq(gas_gamma, pv, q);
+  double pb = 0.5*(bx*bx+by*by+bz*bz);
+  double u_dot_b = u*bx+v*by+w*bz;
+  double E = q[4];
+
+  TEST_CHECK ( pr == gkyl_mhd_pressure(gas_gamma, q) );
+
+  double flux[8];
+ 
+  gkyl_mhd_flux(0, gas_gamma, q, flux);
+  TEST_CHECK( flux[0] == rho*u );
+  TEST_CHECK( gkyl_compare(flux[1], rho*u*u - bx*bx + pr + pb, 1e-15) );
+  TEST_CHECK( flux[2] == rho*u*v - bx*by );
+  TEST_CHECK( flux[3] == rho*u*w - bx*bz );
+  TEST_CHECK( flux[4] == (E+pr+pb)*u-bx*u_dot_b);
+  TEST_CHECK( flux[5] == 0.0 );
+  TEST_CHECK( flux[6] == u*by - v*bx );
+  TEST_CHECK( flux[7] == u*bz - w*bx );
+
+  gkyl_mhd_flux(1, gas_gamma, q, flux);
+  TEST_CHECK( flux[0] == rho*v );
+  TEST_CHECK( flux[1] == rho*v*u - bx*by );
+  TEST_CHECK( gkyl_compare(flux[2], rho*v*v - by*by + pr +pb, 1e-15) );
+  TEST_CHECK( flux[3] == rho*v*w - by*bz);
+  TEST_CHECK( flux[4] == (E+pr+pb)*v-by*u_dot_b );
+  TEST_CHECK( flux[5] == v*bx - u*by );
+  TEST_CHECK( flux[6] == 0.0 );
+  TEST_CHECK( flux[7] == v*bz - w*by );
+
+  gkyl_mhd_flux(2, gas_gamma, q, flux);
+  TEST_CHECK( flux[0] == rho*w );
+  TEST_CHECK( flux[1] == rho*w*u - bx*bz );
+  TEST_CHECK( flux[2] == rho*w*v - by*bz);
+  TEST_CHECK( gkyl_compare(flux[3], rho*w*w - bz*bz + pr + pb, 1e-15) );
+  TEST_CHECK( flux[4] == (E+pr+pb)*w-bz*u_dot_b );
+  TEST_CHECK( flux[5] == w*bx - u*bz );
+  TEST_CHECK( flux[6] == w*by - v*bz );
+  TEST_CHECK( flux[6] == 0.0 );
+  
+  gkyl_wv_eqn_release(mhd);
+}
+
+/* check if sum of left/right going fluctuations sum to jump in flux */
+void
+test_mhd_waves()
+{
+  double gas_gamma = 1.4;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma);
+
+  double ql[8], qr[8];
+  double delta[8];
+
+  // Bx must be the same since presently the wv_mhd does not have the divB wave
+  double vl[8] = { 1.0,  0.1,  0.2,  0.3,  1.5, 0.4, 0.4,  0.3};
+  double vr[8] = { 1.1, 0.13, 0.25, 0.34, 1.54, 0.4, 0.44, 0.34};
+
+  calcq(gas_gamma, vl, ql); calcq(gas_gamma, vr, qr);
+
+  for (int i=0; i<8; ++i) delta[i] = qr[i]-ql[i];
+
+  for (int d=0; d<1; ++d) {
+    double speeds[7], waves[7*8];
+    gkyl_wv_eqn_waves(mhd, d, delta, ql, qr, waves, speeds);
+
+    double apdq[8], amdq[8];
+    gkyl_wv_eqn_qfluct(mhd, d, ql, qr, waves, speeds, amdq, apdq);
+    
+    double fl[8], fr[8];
+    gkyl_mhd_flux(d, gas_gamma, ql, fl);
+    gkyl_mhd_flux(d, gas_gamma, qr, fr);
+
+    for (int i=0; i<8; ++i)
+      TEST_CHECK( gkyl_compare(fr[i]-fl[i], amdq[i]+apdq[i], 1e-8) );
+  }
+    
+  gkyl_wv_eqn_release(mhd);
+}
+
+TEST_LIST = {
+  { "mhd_basic", test_mhd_basic },
+  { "mhd_waves", test_mhd_waves },
+  { NULL, NULL },
+};

--- a/unit/ctest_wv_ten_moment.c
+++ b/unit/ctest_wv_ten_moment.c
@@ -122,14 +122,23 @@ test_ten_moment_waves()
   double vr[10] = { 0.1, 1.0, 2.0, 3.0, 0.1, 0.0, 0.0, 0.2, 0.0, 0.3};
 
   double ql[10], qr[10];
+  double ql_local[10], qr_local[10];
   calcq(vl, ql); calcq(vr, qr);
 
-  double delta[10];
-  for (int i=0; i<10; ++i) delta[i] = qr[i]-ql[i];
-
   for (int d=0; d<3; ++d) {
-    double speeds[5], waves[5*10];
-    gkyl_wv_eqn_waves(ten_moment, d, delta, ql, qr, waves, speeds);
+    double speeds[5], waves[5*10], waves_local[5*10];
+    // rotate to local tangent-normal frame
+    gkyl_wv_eqn_rotate_to_local(ten_moment, d, 0, 0, 0, ql, ql_local);
+    gkyl_wv_eqn_rotate_to_local(ten_moment, d, 0, 0, 0, qr, qr_local);
+
+    double delta[10];
+    for (int i=0; i<10; ++i) delta[i] = qr_local[i]-ql_local[i];
+    
+    gkyl_wv_eqn_waves(ten_moment, d, delta, ql_local, qr_local, waves_local, speeds);
+
+    // rotate waves back to global frame
+    for (int mw=0; mw<5; ++mw)
+      gkyl_wv_eqn_rotate_to_global(ten_moment, d, 0, 0, 0, &waves_local[mw*10], &waves[mw*10]);
 
     double apdq[10], amdq[10];
     gkyl_wv_eqn_qfluct(ten_moment, d, ql, qr, waves, speeds, amdq, apdq);

--- a/zero/gkyl_eqn_type.h
+++ b/zero/gkyl_eqn_type.h
@@ -6,6 +6,7 @@ enum gkyl_eqn_type {
   GKYL_EQN_ISO_EULER, // Isothermal Euler equations
   GKYL_EQN_TEN_MOMENT, // Ten-moment (with pressure tensor)
   GKYL_EQN_MAXWELL, // Maxwell equations
+  GKYL_EQN_MHD,  // Ideal MHD equations
 };
 
 // Identifiers for specific field object types

--- a/zero/gkyl_prim_mhd.h
+++ b/zero/gkyl_prim_mhd.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/**
+ * Compute the fluid pressure given the conserved variables.
+ *
+ * @param gas_gamma Gas adiabatic constant
+ * @param q Conserved variables
+ */
+static inline double gkyl_mhd_pressure(double gas_gamma, const double q[8])
+{
+  return (gas_gamma-1) *
+         (q[4] - 0.5*(q[1]*q[1]+q[2]*q[2]+q[3]*q[3])/q[0]
+               - 0.5*(q[5]*q[5]+q[6]*q[6]+q[7]*q[7]));
+}
+
+/**
+ * Compute maximum absolute speed.
+ *
+ * @param dir Direction 
+ * @param gas_gamma Gas adiabatic constant
+ * @param q Conserved variables
+ * @return Maximum absolute speed for given q
+ */
+double gkyl_mhd_max_abs_speed(int dir, double gas_gamma,
+                              const const double q[8]);
+
+/**
+ * Compute flux in direction 'dir'.
+ *
+ * @param dir Direction to compute flux
+ * @param gas_gamma Gas adiabatic constant
+ * @param Conserved variables
+ * @param flux On output, the flux in direction 'dir'
+ */
+void gkyl_mhd_flux(int dir, double gas_gamma, const double q[8],
+                   double flux[8]);

--- a/zero/gkyl_wave_geom.h
+++ b/zero/gkyl_wave_geom.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_evalf_def.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
+#include <gkyl_util.h>
+
+// Geometry information for a single cell: recall a cell "owns" the
+// faces on the lower side of cell
+struct gkyl_wave_cell_geom {
+  double kappa; // ratio of cell-volume in phy to comp space
+  double lenr[GKYL_MAX_CDIM]; // ratio of face-area in phys to comp space for "lower" faces
+  double norm[GKYL_MAX_CDIM][GKYL_MAX_CDIM]; // norm[d] is the normal to face perp to direction 'd'
+  // tau1[d] X tau2[d] = norm[d] are tangents to face perp to direction 'd'
+  double tau1[GKYL_MAX_CDIM][GKYL_MAX_CDIM];
+  double tau2[GKYL_MAX_CDIM][GKYL_MAX_CDIM];
+};
+
+// geometry information over a range of cells
+struct gkyl_wave_geom {
+  struct gkyl_range range; // range over which geometry is defined
+  struct gkyl_array *geom; // geometry in each cell
+};
+
+/**
+ * Create a new wave geometry object. 
+ *
+ * @param grid Grid on which geometry lives
+ * @param range Range on which geometry should be constructed
+ * @param mapc2p Mapping from computational to physical space
+ * @param ctx Context for use in mapping
+ */
+struct gkyl_wave_geom* gkyl_wave_geom_new(const struct gkyl_rect_grid *grid,
+  struct gkyl_range *range, evalf_t mapc2p, void *ctx);
+
+/**
+ * Get pointer to geometry in a cell given by idx into the range over
+ * which the geometry was constructed.
+ */
+const struct gkyl_wave_cell_geom* gkyl_wave_geom_get(const struct gkyl_wave_geom *wg, const int *idx);
+
+/**
+ * Release geometry object.
+ *
+ * @param wg Wave geometry object to release.
+ */
+void gkyl_wave_geom_release(struct gkyl_wave_geom *wg);

--- a/zero/gkyl_wave_prop.h
+++ b/zero/gkyl_wave_prop.h
@@ -2,9 +2,11 @@
 
 #include <gkyl_array.h>
 #include <gkyl_basis.h>
-#include <gkyl_wv_eqn.h>
+#include <gkyl_evalf_def.h>
 #include <gkyl_range.h>
 #include <gkyl_rect_grid.h>
+#include <gkyl_wave_geom.h>
+#include <gkyl_wv_eqn.h>
 
 // Limiters
 enum gkyl_wave_limiter {
@@ -22,9 +24,10 @@ struct gkyl_wave_prop_status {
   double dt_suggested; // suggested time-step
 };
 
-// Object type
+// Object type for updater
 typedef struct gkyl_wave_prop gkyl_wave_prop;
 
+// Parameters for constructor
 struct gkyl_wave_prop_inp {
   const struct gkyl_rect_grid *grid; // grid on which to solve equations
   const struct gkyl_wv_eqn *equation; // equation solver
@@ -32,6 +35,9 @@ struct gkyl_wave_prop_inp {
   int num_up_dirs; // number of update directions
   int update_dirs[GKYL_MAX_DIM]; // directions to update
   double cfl; // CFL number to use
+
+  evalf_t mapc2p; // mapping from computation to physical space
+  void *ctx; // context for mapping
 };
 
 /**

--- a/zero/gkyl_wv_mhd.h
+++ b/zero/gkyl_wv_mhd.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gkyl_wv_eqn.h>
+
+/**
+ * Create a new ideal MHD equation object.
+ *
+ * @param gas_gamma Gas adiabatic constant
+ * @return Pointer to mhd equation object.
+ */
+struct gkyl_wv_eqn* gkyl_wv_mhd_new(double gas_gamma);
+
+/**
+ * Get gas adiabatic constant.
+ *
+ * @param wv mhd equation object
+ * @return Get gas adiabatic constant
+ */
+double gkyl_wv_mhd_gas_gamma(const struct gkyl_wv_eqn* wv);

--- a/zero/gkylzero.h
+++ b/zero/gkylzero.h
@@ -45,6 +45,7 @@ extern "C" {
 #include <gkyl_vargm.h>
 #include <gkyl_vlasov.h>
 #include <gkyl_vlasov_mom.h>
+#include <gkyl_wave_geom.h>
 #include <gkyl_wave_prop.h>
 #include <gkyl_wv_eqn.h>
 #include <gkyl_wv_euler.h>

--- a/zero/prim_mhd.c
+++ b/zero/prim_mhd.c
@@ -1,0 +1,66 @@
+#include <math.h>
+#include <float.h>
+
+#include <gkyl_prim_mhd.h>
+
+static const int dir_shuffle[][6] = {
+  {1, 2, 3, 5, 6, 7},
+  {2, 3, 1, 6, 7, 5},
+  {3, 1, 2, 7, 5, 6}
+};
+
+#define RHO (0)
+#define M1 (d[0])
+#define M2 (d[1])
+#define M3 (d[2])
+#define ER (4)
+#define B1 (d[3])
+#define B2 (d[4])
+#define B3 (d[5])
+
+#define sq(x) ((x)*(x))
+
+double
+gkyl_mhd_max_abs_speed(int dir, double gas_gamma, const double q[8])
+{
+  int const *const d = dir_shuffle[dir];
+
+  double u1 = q[M1] / q[RHO];
+  double u2 = q[M2] / q[RHO];
+  double u3 = q[M3] / q[RHO];
+  double k = q[RHO] * (u1*u1 + u2*u2 + u3*u3) / 2; // bulk kinetic energy
+  double B1_sq = sq(q[B1]);
+  double B_sq = B1_sq + sq(q[B2]) + sq(q[B3]);
+  double pb = B_sq / 2; // magnetic pressure
+  double p = (gas_gamma-1) * (q[ER] - k - pb); // plasma pressure
+
+  double a_sq = gas_gamma * p / q[RHO]; // sound speed
+  double ca_sq = B_sq / q[RHO];  // Alfven speed
+  double ca1_sq = B1_sq / q[RHO];  // Alfven speed due to normal B field
+  // fast speed
+  double cf = sqrt(a_sq+ca_sq + sqrt(sq(a_sq + ca_sq) - 4*a_sq*ca1_sq)) / 2;
+
+  return fabs(u1) + cf;
+}
+
+void
+gkyl_mhd_flux(int dir, double gas_gamma, const double q[8], double flux[8])
+{
+  int const *const d = dir_shuffle[dir];
+
+  double u1 = q[M1] / q[RHO];
+  double u2 = q[M2] / q[RHO];
+  double u3 = q[M3] / q[RHO];
+  double k = q[RHO] * (u1*u1 + u2*u2 + u3*u3) / 2;  // bulk kinetic energy
+  double pb = (sq(q[B1]) + sq(q[B2]) + sq(q[B3])) / 2; // magnetic pressure
+  double p = (gas_gamma-1) * (q[ER] - k - pb); // plasma pressure
+
+  flux[RHO] = q[M1];
+  flux[M1] = u1*q[M1] - q[B1]*q[B1] + p + pb;
+  flux[M2] = u1*q[M2] - q[B1]*q[B2];
+  flux[M3] = u1*q[M3] - q[B1]*q[B3];
+  flux[ER] = u1*(q[ER]+p+pb) - q[B1]*(u1*q[B1]+u2*q[B2]+u3*q[B3]);
+  flux[B1] = 0;
+  flux[B2] = u1*q[B2] - u2*q[B1];
+  flux[B3] = u1*q[B3] - u3*q[B1];
+}

--- a/zero/wave_geom.c
+++ b/zero/wave_geom.c
@@ -1,0 +1,95 @@
+#include <gkyl_alloc.h>
+#include <gkyl_array.h>
+#include <gkyl_util.h>
+#include <gkyl_wave_geom.h>
+
+#include <math.h>
+
+static void
+nomapc2p(double t, const double *xc, double *xp, void *ctx)
+{
+  for (int i=0; i<GKYL_MAX_CDIM; ++i) xp[i] = xc[i];
+}
+
+// Computes 1D geometry
+static void
+calc_geom_1d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx, struct gkyl_wave_cell_geom *geo)
+{
+  double xlc[GKYL_MAX_CDIM], xrc[GKYL_MAX_CDIM];
+  double xlp[GKYL_MAX_CDIM], xrp[GKYL_MAX_CDIM];
+
+  xlc[0] = xc[0]-0.5*dx[0]; // left node
+  xrc[0] = xc[0]+0.5*dx[0]; // right node
+
+  // compute coordinates of left/right nodes
+  mapc2p(0.0, xlc, xlp, ctx);
+  mapc2p(0.0, xrc, xrp, ctx);
+
+  geo->kappa = fabs(xrp[0]-xlp[0])/dx[0];
+  geo->lenr[0] = 1.0;
+
+  geo->norm[0][0] = 1.0; geo->norm[0][1] = 0.0; geo->norm[0][2] = 0.0;
+  geo->tau1[0][0] = 0.0; geo->tau1[0][1] = 1.0; geo->tau1[0][2] = 0.0;
+  geo->tau2[0][0] = 0.0; geo->tau2[0][1] = 0.0; geo->tau2[0][2] = 1.0;
+}
+
+static void
+calc_geom_2d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx, struct gkyl_wave_cell_geom *geo)
+{
+}
+
+static void
+calc_geom_3d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx, struct gkyl_wave_cell_geom *geo)
+{
+}
+
+struct gkyl_wave_geom*
+gkyl_wave_geom_new(const struct gkyl_rect_grid *grid, struct gkyl_range *range,
+  evalf_t mapc2p, void *ctx)
+{
+  struct gkyl_wave_geom *wg = gkyl_malloc(sizeof(struct gkyl_wave_geom));
+
+  wg->range = *range;
+  wg->geom = gkyl_array_new(GKYL_USER, sizeof(struct gkyl_wave_cell_geom), range->volume);
+
+  double xc[GKYL_MAX_CDIM];
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  while (gkyl_range_iter_next(&iter)) {
+
+    gkyl_rect_grid_cell_center(grid, iter.idx, xc);
+
+    struct gkyl_wave_cell_geom *geo = gkyl_array_fetch(wg->geom, gkyl_range_idx(range, iter.idx));
+    // compute geometry based on grid dimensions
+    switch (grid->ndim) {
+      case 1:
+        calc_geom_1d(grid->dx, xc, mapc2p ? mapc2p : nomapc2p, ctx, geo);
+        break;
+
+      case 2:
+        calc_geom_2d(grid->dx, xc, mapc2p ? mapc2p : nomapc2p, ctx, geo);
+        break;
+
+      case 3:
+        calc_geom_3d(grid->dx, xc, mapc2p ? mapc2p : nomapc2p, ctx, geo);
+        break;
+    };   
+  }
+
+  return wg;
+}
+
+
+const struct gkyl_wave_cell_geom*
+gkyl_wave_geom_get(const struct gkyl_wave_geom *wg, const int *idx)
+{
+  return gkyl_array_cfetch(wg->geom, gkyl_range_idx(&wg->range, idx));
+}
+
+void
+gkyl_wave_geom_release(struct gkyl_wave_geom *wg)
+{
+  gkyl_array_release(wg->geom);
+  gkyl_free(wg);
+}

--- a/zero/wave_prop.c
+++ b/zero/wave_prop.c
@@ -6,6 +6,7 @@
 #include <gkyl_array_ops.h>
 #include <gkyl_rect_decomp.h>
 #include <gkyl_util.h>
+#include <gkyl_wave_geom.h>
 #include <gkyl_wave_prop.h>
 
 struct gkyl_wave_prop {
@@ -16,6 +17,8 @@ struct gkyl_wave_prop {
   enum gkyl_wave_limiter limiter; // limiter to use
   double cfl; // CFL number
   const struct gkyl_wv_eqn *equation; // equation object
+
+  struct gkyl_wave_geom *geom; // geometry object
 
   // data for 1D slice update
   struct gkyl_array *waves, *speeds, *flux2;
@@ -102,6 +105,9 @@ gkyl_wave_prop_new(struct gkyl_wave_prop_inp winp)
   up->waves = gkyl_array_new(GKYL_DOUBLE, meqn*mwaves, max_1d);
   up->speeds = gkyl_array_new(GKYL_DOUBLE, mwaves, max_1d);
   up->flux2 = gkyl_array_new(GKYL_DOUBLE, meqn, max_1d);
+
+  // construct geometry
+  up->geom = gkyl_wave_geom_new(&up->grid, &ext_range, winp.mapc2p, winp.ctx);
 
   return up;
 }
@@ -204,7 +210,10 @@ gkyl_wave_prop_advance(const gkyl_wave_prop *wv,
   int meqn = wv->equation->num_equations, mwaves = wv->equation->num_waves;
 
   double cfla = 0.0, cfl = wv->cfl, cflm = 1.1*cfl;
-  double delta[meqn], amdq[meqn], apdq[meqn];
+
+  double ql_local[meqn], qr_local[meqn];
+  double waves_local[meqn*mwaves];
+  double delta[meqn], amdq[meqn], apdq[meqn];  
 
   int idxl[GKYL_MAX_DIM], idxr[GKYL_MAX_DIM];
 
@@ -243,13 +252,21 @@ gkyl_wave_prop_advance(const gkyl_wave_prop *wv,
 
         const double *qinl = gkyl_array_cfetch(qin, lidx);
         const double *qinr = gkyl_array_cfetch(qin, ridx);
-
-        double *waves = gkyl_array_fetch(wv->waves, sidx);
         double *s = gkyl_array_fetch(wv->speeds, sidx);
 
-        calc_jump(meqn, qinl, qinr, delta);
+        // rotate to local tangent-normal frame
+        gkyl_wv_eqn_rotate_to_local(wv->equation, dir, 0, 0, 0, qinl, ql_local);
+        gkyl_wv_eqn_rotate_to_local(wv->equation, dir, 0, 0, 0, qinr, qr_local);
 
-        gkyl_wv_eqn_waves(wv->equation, dir, delta, qinl, qinr, waves, s);
+        calc_jump(meqn, ql_local, qr_local, delta);
+        gkyl_wv_eqn_waves(wv->equation, dir, delta, ql_local, qr_local, waves_local, s);
+
+        double *waves = gkyl_array_fetch(wv->waves, sidx);
+        // rotate waves back to global frame
+        for (int mw=0; mw<mwaves; ++mw)
+          gkyl_wv_eqn_rotate_to_global(wv->equation, dir, 0, 0, 0,
+            &waves_local[mw*meqn], &waves[mw*meqn]);
+        
         gkyl_wv_eqn_qfluct(wv->equation, dir, qinl, qinr, waves, s, amdq, apdq);
 
         double *qoutl = gkyl_array_fetch(qout, lidx);
@@ -338,6 +355,7 @@ gkyl_wave_prop_release(gkyl_wave_prop* up)
   gkyl_array_release(up->waves);
   gkyl_array_release(up->speeds);
   gkyl_array_release(up->flux2);
+  gkyl_wave_geom_release(up->geom);
   
   free(up);
 }

--- a/zero/wscript
+++ b/zero/wscript
@@ -27,6 +27,7 @@ def build(bld):
     prim_iso_euler.c
     prim_maxwell.c
     prim_ten_moment.c
+    prim_mhd.c
     proj_on_basis.c
     range.c
     rect_apply_bc.c
@@ -41,6 +42,7 @@ def build(bld):
     wv_iso_euler.c
     wv_maxwell.c
     wv_ten_moment.c
+    wv_mhd.c
     """
 
     # For now building static library. Probably should build shared

--- a/zero/wv_eqn.c
+++ b/zero/wv_eqn.c
@@ -29,6 +29,22 @@ gkyl_wv_eqn_max_speed(const struct gkyl_wv_eqn *eqn, int dir, const double *q)
 }
 
 void
+gkyl_wv_eqn_rotate_to_local(const struct gkyl_wv_eqn *eqn,
+  int dir,  const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qglobal, double *GKYL_RESTRICT qlocal)
+{
+  return eqn->rotate_to_local_func(dir, tau1, tau2, norm, qglobal, qlocal);
+}
+
+void
+gkyl_wv_eqn_rotate_to_global(const struct gkyl_wv_eqn *eqn,
+  int dir,  const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qlocal, double *GKYL_RESTRICT qglobal)
+{
+  return eqn->rotate_to_global_func(dir, tau1, tau2, norm, qlocal, qglobal);
+}
+
+void
 gkyl_wv_eqn_release(const struct gkyl_wv_eqn* eqn)
 {
   gkyl_ref_count_dec(&eqn->ref_count);

--- a/zero/wv_euler.c
+++ b/zero/wv_euler.c
@@ -28,13 +28,58 @@ euler_free(const struct gkyl_ref_count *ref)
   gkyl_free(euler);
 }
 
+static inline void
+rot_to_local_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qglobal, double *GKYL_RESTRICT qlocal)
+{
+  const int *d = dir_shuffle[dir];  
+  qlocal[0] = qglobal[0];
+  qlocal[1] = qglobal[RHOU];
+  qlocal[2] = qglobal[RHOV];
+  qlocal[3] = qglobal[RHOW];
+  qlocal[4] = qglobal[4];
+}
+
+static inline void
+rot_to_global_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qlocal, double *GKYL_RESTRICT qglobal)
+{
+  const int *d = dir_shuffle[dir];  
+  qglobal[0] = qlocal[0];
+  qglobal[RHOU] = qlocal[1];
+  qglobal[RHOV] = qlocal[2];
+  qglobal[RHOW] = qlocal[3];
+  qglobal[4] = qlocal[4];
+}
+
+static inline void
+rot_to_local(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qglobal, double *GKYL_RESTRICT qlocal)
+{
+  qlocal[0] = qglobal[0];
+  qlocal[1] = qglobal[1]*norm[0] + qglobal[2]*norm[1] + qglobal[3]*norm[2];
+  qlocal[2] = qglobal[1]*tau1[0] + qglobal[2]*tau1[1] + qglobal[3]*tau1[2];
+  qlocal[3] = qglobal[1]*tau2[0] + qglobal[2]*tau2[1] + qglobal[3]*tau2[2];
+  qlocal[4] = qglobal[4];
+}
+
+static inline void
+rot_to_global(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qlocal, double *GKYL_RESTRICT qglobal)
+{
+  qglobal[0] = qlocal[0];
+  qglobal[1] = qlocal[1]*norm[0] + qlocal[2]*tau1[0] + qlocal[3]*tau2[0];
+  qglobal[2] = qlocal[1]*norm[1] + qlocal[2]*tau1[1] + qlocal[3]*tau2[1];
+  qglobal[3] = qlocal[1]*norm[2] + qlocal[2]*tau1[2] + qlocal[3]*tau2[2];
+  qglobal[4] = qlocal[4];
+}
+
 // Waves and speeds using Roe averaging
 static double
 wave_roe(const struct gkyl_wv_eqn *eqn, 
   int dir, const double *delta, const double *ql, const double *qr, double *waves, double *s)
 {
   const struct wv_euler *euler = container_of(eqn, struct wv_euler, eqn);
-  const int *d = dir_shuffle[dir];
   double gas_gamma = euler->gas_gamma;
   double g1 = gas_gamma - 1;
 
@@ -45,9 +90,9 @@ wave_roe(const struct gkyl_wv_eqn *eqn,
   double srrhol = sqrt(rhol), srrhor = sqrt(rhor);
   double ravgl1 = 1/srrhol, ravgr1 = 1/srrhor;
   double ravg2 = 1/(srrhol+srrhor);
-  double u = (ql[RHOU]*ravgl1 + qr[RHOU]*ravgr1)*ravg2;
-  double v = (ql[RHOV]*ravgl1 + qr[RHOV]*ravgr1)*ravg2;
-  double w = (ql[RHOW]*ravgl1 + qr[RHOW]*ravgr1)*ravg2;
+  double u = (ql[1]*ravgl1 + qr[1]*ravgr1)*ravg2;
+  double v = (ql[2]*ravgl1 + qr[2]*ravgr1)*ravg2;
+  double w = (ql[3]*ravgl1 + qr[3]*ravgr1)*ravg2;
   double enth = ((ql[4]+pl)*ravgl1 + (qr[4]+pr)*ravgr1)*ravg2;
 
   // See http://ammar-hakim.org/sj/euler-eigensystem.html for notation
@@ -58,37 +103,37 @@ wave_roe(const struct gkyl_wv_eqn *eqn,
   double g1a2 = g1/aa2, euv = enth-q2;
 
   // Compute projections of jump
-  double a4 = g1a2*(euv*delta[0] + u*delta[RHOU] + v*delta[RHOV] + w*delta[RHOW] - delta[4]);
-  double a2 = delta[RHOV] - v*delta[0];
-  double a3 = delta[RHOW] - w*delta[0];
-  double a5 = 0.5*(delta[RHOU] + (a-u)*delta[0] - a*a4)/a;
+  double a4 = g1a2*(euv*delta[0] + u*delta[1] + v*delta[2] + w*delta[3] - delta[4]);
+  double a2 = delta[2] - v*delta[0];
+  double a3 = delta[3] - w*delta[0];
+  double a5 = 0.5*(delta[1] + (a-u)*delta[0] - a*a4)/a;
   double a1 = delta[0] - a4 - a5;
 
   double *wv;
   // Wave 1: eigenvalue is u-c
   wv = &waves[0];
   wv[0] = a1;
-  wv[RHOU] = a1*(u-a);
-  wv[RHOV] = a1*v;
-  wv[RHOW] = a1*w;
+  wv[1] = a1*(u-a);
+  wv[2] = a1*v;
+  wv[3] = a1*w;
   wv[4] = a1*(enth-u*a);
   s[0] = u-a;
 
   // Wave 2: eigenvalue is u, u, u three waves are lumped into one
   wv = &waves[5];
   wv[0] = a4;
-  wv[RHOU] = a4*u;
-  wv[RHOV] = a4*v + a2;
-  wv[RHOW] = a4*w + a3;
+  wv[1] = a4*u;
+  wv[2] = a4*v + a2;
+  wv[3] = a4*w + a3;
   wv[4] = a4*0.5*q2 + a2*v + a3*w;
   s[1] = u;
 
   // Wave 3: eigenvalue is u+c
   wv = &waves[10];
   wv[0] = a5;
-  wv[RHOU] = a5*(u+a);
-  wv[RHOV] = a5*v;
-  wv[RHOW] = a5*w;
+  wv[1] = a5*(u+a);
+  wv[2] = a5*v;
+  wv[3] = a5*w;
   wv[4] = a5*(enth+u*a);
   s[2] = u+a;
   
@@ -129,6 +174,8 @@ gkyl_wv_euler_new(double gas_gamma)
   euler->eqn.waves_func = wave_roe;
   euler->eqn.qfluct_func = qfluct_roe;
   euler->eqn.max_speed_func = max_speed;
+  euler->eqn.rotate_to_local_func = rot_to_local_rect;
+  euler->eqn.rotate_to_global_func = rot_to_global_rect;
 
   euler->eqn.ref_count = (struct gkyl_ref_count) { euler_free, 1 };
 

--- a/zero/wv_iso_euler.c
+++ b/zero/wv_iso_euler.c
@@ -28,13 +28,54 @@ iso_euler_free(const struct gkyl_ref_count *ref)
   gkyl_free(iso_euler);
 }
 
+static void
+rot_to_local_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *qglobal, double *qlocal)
+{
+  const int *d = dir_shuffle[dir];  
+  qlocal[0] = qglobal[0];
+  qlocal[1] = qglobal[RHOU];
+  qlocal[2] = qglobal[RHOV];
+  qlocal[3] = qglobal[RHOW];
+}
+
+static void
+rot_to_global_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *qlocal, double *qglobal)
+{
+  const int *d = dir_shuffle[dir];  
+  qglobal[0] = qlocal[0];
+  qglobal[RHOU] = qlocal[1];
+  qglobal[RHOV] = qlocal[2];
+  qglobal[RHOW] = qlocal[3];
+}
+
+static inline void
+rot_to_local(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qglobal, double *GKYL_RESTRICT qlocal)
+{
+  qlocal[0] = qglobal[0];
+  qlocal[1] = qglobal[1]*norm[0] + qglobal[2]*norm[1] + qglobal[3]*norm[2];
+  qlocal[2] = qglobal[1]*tau1[0] + qglobal[2]*tau1[1] + qglobal[3]*tau1[2];
+  qlocal[3] = qglobal[1]*tau2[0] + qglobal[2]*tau2[1] + qglobal[3]*tau2[2];
+}
+
+static inline void
+rot_to_global(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qlocal, double *GKYL_RESTRICT qglobal)
+{
+  qglobal[0] = qlocal[0];
+  qglobal[1] = qlocal[1]*norm[0] + qlocal[2]*tau1[0] + qlocal[3]*tau2[0];
+  qglobal[2] = qlocal[1]*norm[1] + qlocal[2]*tau1[1] + qlocal[3]*tau2[1];
+  qglobal[3] = qlocal[1]*norm[2] + qlocal[2]*tau1[2] + qlocal[3]*tau2[2];
+}
+
 // Waves and speeds using Roe averaging
 static double
 wave_roe(const struct gkyl_wv_eqn *eqn, 
   int dir, const double *delta, const double *ql, const double *qr, double *waves, double *s)
 {
   const struct wv_iso_euler *iso_euler = container_of(eqn, struct wv_iso_euler, eqn);
-  const int *d = dir_shuffle[dir];
   double vt = iso_euler->vt;
 
   double rhol = ql[0], rhor = qr[0];
@@ -43,39 +84,39 @@ wave_roe(const struct gkyl_wv_eqn *eqn,
   double srrhol = sqrt(rhol), srrhor = sqrt(rhor);
   double ravgl1 = 1/srrhol, ravgr1 = 1/srrhor;
   double ravg2 = 1/(srrhol+srrhor);
-  double u = (ql[RHOU]*ravgl1 + qr[RHOU]*ravgr1)*ravg2;
-  double v = (ql[RHOV]*ravgl1 + qr[RHOV]*ravgr1)*ravg2;
-  double w = (ql[RHOW]*ravgl1 + qr[RHOW]*ravgr1)*ravg2;
+  double u = (ql[1]*ravgl1 + qr[1]*ravgr1)*ravg2;
+  double v = (ql[2]*ravgl1 + qr[2]*ravgr1)*ravg2;
+  double w = (ql[3]*ravgl1 + qr[3]*ravgr1)*ravg2;
 
   // Compute projections of jump
-  double a0 = delta[0]*(vt+u)/vt/2.0-delta[RHOU]/vt/2.0;
-  double a1 = delta[RHOV]-delta[0]*v;
-  double a2 = delta[RHOW]-delta[0]*w;
-  double a3 = delta[0]*(vt-u)/vt/2.0+delta[RHOU]/vt/2.0;
+  double a0 = delta[0]*(vt+u)/vt/2.0-delta[1]/vt/2.0;
+  double a1 = delta[2]-delta[0]*v;
+  double a2 = delta[3]-delta[0]*w;
+  double a3 = delta[0]*(vt-u)/vt/2.0+delta[1]/vt/2.0;
 
   double *wv;
   // Wave 1: eigenvalue is u-vt
   wv = &waves[0];
   wv[0] = a0;
-  wv[RHOU] = a0*(u-vt);
-  wv[RHOV] = a0*v;
-  wv[RHOW] = a0*w;
+  wv[1] = a0*(u-vt);
+  wv[2] = a0*v;
+  wv[3] = a0*w;
   s[0] = u-vt;
 
   // Wave 2: eigenvalue is u & u, two waves are lumped into one
   wv = &waves[4];
   wv[0] = 0.0;
-  wv[RHOU] = 0.0;
-  wv[RHOV] = a1;
-  wv[RHOW] = a2;
+  wv[1] = 0.0;
+  wv[2] = a1;
+  wv[3] = a2;
   s[1] = u;
 
   // Wave 3: eigenvalue is u+vt
   wv = &waves[8];
   wv[0] = a3;
-  wv[RHOU] = a3*(u+vt);
-  wv[RHOV] = a3*v;
-  wv[RHOW] = a3*w;
+  wv[1] = a3*(u+vt);
+  wv[2] = a3*v;
+  wv[3] = a3*w;
   s[2] = u+vt;
   
   return fabs(u)+vt;
@@ -115,6 +156,8 @@ gkyl_wv_iso_euler_new(double vt)
   iso_euler->eqn.waves_func = wave_roe;
   iso_euler->eqn.qfluct_func = qfluct_roe;
   iso_euler->eqn.max_speed_func = max_speed;
+  iso_euler->eqn.rotate_to_local_func = rot_to_local_rect;
+  iso_euler->eqn.rotate_to_global_func = rot_to_global_rect;
 
   iso_euler->eqn.ref_count = (struct gkyl_ref_count) { iso_euler_free, 1 };
 

--- a/zero/wv_maxwell.c
+++ b/zero/wv_maxwell.c
@@ -31,6 +31,70 @@ maxwell_free(const struct gkyl_ref_count *ref)
   gkyl_free(maxwell);
 }
 
+static void
+rot_to_local_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *qglobal, double *qlocal)
+{
+  const int *d = dir_shuffle[dir];  
+  qlocal[0] = qglobal[EX];
+  qlocal[1] = qglobal[EY];
+  qlocal[2] = qglobal[EZ];
+  qlocal[3] = qglobal[BX];
+  qlocal[4] = qglobal[BY];
+  qlocal[5] = qglobal[BZ];
+  qlocal[6] = qglobal[6];
+  qlocal[7] = qglobal[7];
+}
+
+static void
+rot_to_global_rect(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *qlocal, double *qglobal)
+{
+  const int *d = dir_shuffle[dir];  
+  qglobal[EX] = qlocal[0];
+  qglobal[EY] = qlocal[1];
+  qglobal[EZ] = qlocal[2];
+  qglobal[BX] = qlocal[3];
+  qglobal[BY] = qlocal[4];
+  qglobal[BZ] = qlocal[5];
+  qglobal[6] = qlocal[6];
+  qglobal[7] = qlocal[7];
+}
+
+static inline void
+rot_to_local(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qglobal, double *GKYL_RESTRICT qlocal)
+{
+  // Rotate E to local coordinates
+  qlocal[0] = qglobal[0]*norm[0] + qglobal[1]*norm[1] + qglobal[2]*norm[2];
+  qlocal[1] = qglobal[0]*tau1[0] + qglobal[1]*tau1[1] + qglobal[2]*tau1[2];
+  qlocal[2] = qglobal[0]*tau2[0] + qglobal[1]*tau2[1] + qglobal[2]*tau2[2];
+  // Rotate B to local coordinates
+  qlocal[3] = qglobal[3]*norm[0] + qglobal[4]*norm[1] + qglobal[5]*norm[2];
+  qlocal[4] = qglobal[3]*tau1[0] + qglobal[4]*tau1[1] + qglobal[5]*tau1[2];
+  qlocal[5] = qglobal[3]*tau2[0] + qglobal[4]*tau2[1] + qglobal[5]*tau2[2];
+  // Correction potentials are scalars and unchanged
+  qlocal[6] = qglobal[6];
+  qlocal[7] = qglobal[7];
+}
+
+static inline void
+rot_to_global(int dir, const double *tau1, const double *tau2, const double *norm,
+  const double *GKYL_RESTRICT qlocal, double *GKYL_RESTRICT qglobal)
+{
+  // Rotate E back to global coordinates
+  qglobal[0] = qlocal[0]*norm[0] + qlocal[1]*tau1[0] + qlocal[2]*tau2[0];
+  qglobal[1] = qlocal[0]*norm[1] + qlocal[1]*tau1[1] + qlocal[2]*tau2[1];
+  qglobal[2] = qlocal[0]*norm[2] + qlocal[1]*tau1[2] + qlocal[2]*tau2[2];
+  // Rotate B back to global coordinates
+  qglobal[3] = qlocal[3]*norm[0] + qlocal[4]*tau1[0] + qlocal[5]*tau2[0];
+  qglobal[4] = qlocal[3]*norm[1] + qlocal[4]*tau1[1] + qlocal[5]*tau2[1];
+  qglobal[5] = qlocal[3]*norm[2] + qlocal[4]*tau1[2] + qlocal[5]*tau2[2];
+  // Correction potentials are scalars and unchanged
+  qglobal[6] = qlocal[6];
+  qglobal[7] = qlocal[7];
+}
+
 // Waves and speeds using Roe averaging
 static double
 wave(const struct gkyl_wv_eqn *eqn, 
@@ -40,19 +104,17 @@ wave(const struct gkyl_wv_eqn *eqn,
 
   double c = maxwell->c, c1 = 1/c;
   double e_fact = maxwell->e_fact, b_fact = maxwell->b_fact;
-  
-  const int *d = dir_shuffle[dir];
     
   // compute projections of jump
   // Note correction potentials are scalars and no dir_shuffle required
-  double a1 = 0.5*(delta[BX]-delta[7]*c1);
-  double a2 = 0.5*(delta[BX]+delta[7]*c1);
-  double a3 = 0.5*(delta[EX]-delta[6]*c);
-  double a4 = 0.5*(delta[EX]+delta[6]*c);
-  double a5 = 0.5*(delta[EY]-delta[BZ]*c);
-  double a6 = 0.5*(delta[BY]*c+delta[EZ]);
-  double a7 = 0.5*(delta[BZ]*c+delta[EY]);
-  double a8 = 0.5*(delta[EZ]-delta[BY]*c);
+  double a1 = 0.5*(delta[3]-delta[7]*c1);
+  double a2 = 0.5*(delta[3]+delta[7]*c1);
+  double a3 = 0.5*(delta[0]-delta[6]*c);
+  double a4 = 0.5*(delta[0]+delta[6]*c);
+  double a5 = 0.5*(delta[1]-delta[5]*c);
+  double a6 = 0.5*(delta[4]*c+delta[2]);
+  double a7 = 0.5*(delta[5]*c+delta[1]);
+  double a8 = 0.5*(delta[2]-delta[4]*c);
 
   // set waves to 0.0 as most entries vanish
   for (int i=0; i<8*6; ++i) waves[i] = 0.0;
@@ -61,42 +123,42 @@ wave(const struct gkyl_wv_eqn *eqn,
 
   // wave 1:
   w = &waves[0*8];
-  w[BX] = a1;
+  w[3] = a1;
   w[7] = -a1*c;
   s[0] = -c*b_fact;
 
   // wave 2:
   w = &waves[1*8];
-  w[BX] = a2;
+  w[3] = a2;
   w[7] = a2*c;
   s[1] = c*b_fact;
 
   // wave 3:
   w = &waves[2*8];
-  w[EX] = a3;
+  w[0] = a3;
   w[6] = -a3*c1;
   s[2] = -c*e_fact;
 
   // wave 4:
   w = &waves[3*8];
-  w[EX] = a4;
+  w[0] = a4;
   w[6] = a4*c1;
   s[3] = c*e_fact;
 
   // wave 5: (two waves with EV -c, -c lumped into one)
   w = &waves[4*8];
-  w[EY] = a5;
-  w[EZ] = a6;
-  w[BY] = a6*c1;
-  w[BZ] = -a5*c1;
+  w[1] = a5;
+  w[2] = a6;
+  w[4] = a6*c1;
+  w[5] = -a5*c1;
   s[4] = -c;
 
   // wave 6: (two waves with EV c, c lumped into one)
   w = &waves[5*8];
-  w[EY] = a7;
-  w[EZ] = a8;
-  w[BY] = -a8*c1;
-  w[BZ] = a7*c1;
+  w[1] = a7;
+  w[2] = a8;
+  w[4] = -a8*c1;
+  w[5] = a7*c1;
   s[5] = c;
   
   return c;
@@ -145,6 +207,8 @@ gkyl_wv_maxwell_new(double c, double e_fact, double b_fact)
   maxwell->eqn.waves_func = wave;
   maxwell->eqn.qfluct_func = qfluct;
   maxwell->eqn.max_speed_func = max_speed;
+  maxwell->eqn.rotate_to_local_func = rot_to_local_rect;
+  maxwell->eqn.rotate_to_global_func = rot_to_global_rect;
 
   maxwell->eqn.ref_count = (struct gkyl_ref_count) { maxwell_free, 1 };
 

--- a/zero/wv_mhd.c
+++ b/zero/wv_mhd.c
@@ -1,0 +1,323 @@
+#include <math.h>
+#include <float.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_prim_mhd.h>
+#include <gkyl_wv_mhd.h>
+
+static const int dir_shuffle[][6] = {
+  {1, 2, 3, 5, 6, 7},
+  {2, 3, 1, 6, 7, 5},
+  {3, 1, 2, 7, 5, 6}
+};
+
+// Make indexing cleaner with the dir_shuffle
+#define DN (0)
+#define MX (idx[0])
+#define MY (idx[1])
+#define MZ (idx[2])
+#define ER (4)
+#define BX (idx[3])
+#define BY (idx[4])
+#define BZ (idx[5])
+
+#define sq(x) ((x)*(x))
+
+struct wv_mhd {
+  struct gkyl_wv_eqn eqn; // base object
+  double gas_gamma; // gas adiabatic constant
+};
+
+static void
+mhd_free(const struct gkyl_ref_count *ref)
+{
+  struct gkyl_wv_eqn *base = container_of(ref, struct gkyl_wv_eqn, ref_count);
+  struct wv_mhd *mhd = container_of(base, struct wv_mhd, eqn);
+  gkyl_free(mhd);
+}
+
+// Computing waves and waves speeds from Roe linearization.
+// Following Cargo & Gallice 1997 section 4.2.
+static double
+wave_roe(const struct gkyl_wv_eqn *eqn, int dir, const double *dQ,
+         const double *ql, const double *qr, double *waves, double *ev)
+{
+  const struct wv_mhd *mhd = container_of(eqn, struct wv_mhd, eqn);
+  const int *idx = dir_shuffle[dir];
+  double gamma = mhd->gas_gamma;
+
+  // Compute primitive states
+  double ul = ql[MX] / ql[DN], ur = qr[MX] / qr[DN];
+  double vl = ql[MY] / ql[DN], vr = qr[MY] / qr[DN];
+  double wl = ql[MZ] / ql[DN], wr = qr[MZ] / qr[DN];
+  double pl = gkyl_mhd_pressure(gamma, ql);
+  double pr = gkyl_mhd_pressure(gamma, qr);
+  double pbl = 0.5 * (sq(ql[BX]) + sq(ql[BY]) + sq(ql[BZ]));
+  double pbr = 0.5 * (sq(qr[BX]) + sq(qr[BY]) + sq(qr[BZ]));
+  // total enthalpy (density) in CG97 eq. 2.2
+  double Hl = (ql[ER] + pl + pbl) / ql[DN];
+  double Hr = (qr[ER] + pr + pbr) / qr[DN];
+
+  // Compute Roe averages of primitive states
+  double srrhol = sqrt(ql[DN]);
+  double srrhor = sqrt(qr[DN]);
+  double sl = srrhol / (srrhol + srrhor);
+  double sr = srrhor / (srrhol + srrhor);
+
+  double rho = srrhol * srrhor;
+  double u = sl * ul + sr * ur;
+  double v = sl * vl + sr * vr;
+  double w = sl * wl + sr * wr;
+  double H = sl * Hl + sr * Hr;  // total enthalpy
+  double Bx = sr * ql[BX] + sl * qr[BX];
+  double By = sr * ql[BY] + sl * qr[BY];
+  double Bz = sr * ql[BZ] + sl * qr[BZ];
+
+  // CG97 eq. 4.12; FIXME: dBx is included as needed by 8-wave scheme
+  double X = (sq(dQ[BX]) + sq(dQ[BY]) + sq(dQ[BZ])) / (2*sq(srrhol+srrhor));
+
+  // CG97 eq 4.17, wave speeds
+  double ca2 = Bx*Bx/rho; // for alfven speed due to normal B field
+  double b2 = (Bx*Bx+By*By+Bz*Bz) / rho; // for alfven speed due to full B field
+  double v2 = u*u+v*v+w*w;
+  double Hgas = H - b2;  // enthalpy of the gas
+  double a2 = (2-gamma)*X + (gamma-1)*(Hgas-0.5*v2);  // for sound speed
+
+  double astar2 = a2 + b2;
+  double cf2 = (astar2 + sqrt(sq(astar2)-4*a2*ca2)) / 2;  // fast wave speed
+  double cs2 = (astar2 - sqrt(sq(astar2)-4*a2*ca2)) / 2;  // slow wave speed
+
+  double a = sqrt(a2);  // sound speed
+  double ca = sqrt(ca2);  // alfven speed due to normal B field
+  double cf = sqrt(cf2);  // fast magnetosonic speed
+  double cs = sqrt(cs2);  // slow magnetosonic speed
+
+  // CG97 eq 4.21, S, beta, and alpha
+  double S = Bx >=0? 1: -1;
+
+  double Bt = sqrt(By*By+Bz*Bz);
+  double betay, betaz;
+  if (Bt>0) {
+    betay = By / Bt;
+    betaz = Bz / Bt;
+  } else {
+    betay = betaz = 1/sqrt(2);
+  }
+
+  double alphaf2 = (a2 - cs2) / (cf2 - cs2);
+  double alphas2 = (cf2 - a2) / (cf2 - cs2);
+  double alphaf = sqrt(alphaf2);
+  double alphas = sqrt(alphas2);
+
+  // For each eigensolution of the Roe linearizing matrix, compute:
+  // 0. Eigenvalue, which is the wave speed. The results are stored in ev array
+  //    and sorted by their values, that is,
+  //    u-c_fast < u-c_alfven < u-c_slow < u < u+c_slow < u+c_alfven < u+c_fast
+  // 1. Projection coefficient of jumps in conservative state on to the
+  //    left-eigenvector according to CG97 eq. 4.20.
+  // 2. The wave (fluctuations) due to this mode.
+  double drho = dQ[DN];
+  double du = ur - ul;
+  double dv = vr - vl;
+  double dw = wr - wl;
+  double dp = pr - pl;
+  double dBy = dQ[BY];
+  double dBz = dQ[BZ];
+
+  const int meqns = 8;
+  for (int i=0; i<meqns*7; ++i) waves[i] = 0.0;
+  double *wv;
+  double eta[7];
+
+  /////////////////////////////////////////////////////////////
+  // Fast magnetosonic modes
+
+  // For projection coefficients in eq. 4.20 for magnetosonic waves
+  double t1 = alphaf * (X*drho + dp);
+  double t2 = alphas * cs * rho * S * (betay*dv + betaz*dw);
+  double t3 = alphaf * cf * rho * du;
+  double t4 = alphas * sqrt(rho) * a * (betay*dBy + betaz*dBz);
+  // for right eigenvectors for magnetosonic waves in eq. 4.19
+  double t5 = alphas * cs * S * (v*betay + w*betaz);
+  double t6 = alphas * a * Bt / sqrt(rho);
+
+  ev[0] = u - cf;
+  // Coefficients of projection onto the left-eigenvector
+  eta[0] = (t1 + t2 - t3 + t4) / 2; // eq. 4.20
+  eta[0] /= a2; // merge a2 in right-eigenvector in 4.19 into coefficents
+  // Fluctuations due to this mode
+  wv = &waves[0*meqns];
+  wv[DN] = eta[0]*alphaf;
+  wv[MX] = eta[0]*(alphaf*(u - cf));
+  wv[MY] = eta[0]*(alphaf*v + alphas*cs*betay*S);
+  wv[MZ] = eta[0]*(alphaf*w + alphas*cs*betaz*S);
+  wv[ER] = eta[0]*(alphaf*(Hgas-u*cf)+t5+t6); // -t6 in CG97 typo? +t6 in SG08
+  wv[BY] = eta[0]*alphas*a*betay/sqrt(rho);
+  wv[BZ] = eta[0]*alphas*a*betaz/sqrt(rho);
+
+  ev[6] = u + cf;
+  // Coefficients of projection onto the left-eigenvector
+  eta[6] = (t1 - t2 + t3 + t4) / 2; // eq. 4.20
+  eta[6] /= a2; // merge a2 in right-eigenvector in 4.19 into coefficents
+  // Fluctuations due to this mode
+  wv = &waves[6*meqns];
+  wv[DN] = eta[6]*alphaf;
+  wv[MX] = eta[6]*(alphaf*(u + cf));
+  wv[MY] = eta[6]*(alphaf*v - alphas*cs*betay*S);
+  wv[MZ] = eta[6]*(alphaf*w - alphas*cs*betaz*S);
+  wv[ER] = eta[6]*(alphaf*(Hgas+u*cf)-t5+t6); // -t6 in CG97 typo? +t6 in SG08
+  wv[BY] = eta[6]*alphas*a*betay/sqrt(rho);
+  wv[BZ] = eta[6]*alphas*a*betaz/sqrt(rho);
+
+  /////////////////////////////////////////////////////////////
+  // Alfven waves
+
+  // For projection coefficients in eq. 4.20 for alfven waves
+  double t7 = betay*dw - betaz*dv;
+  double t8 = (S/sqrt(rho)) * (betay*dBz-betaz*dBy);
+
+  ev[1] = u - ca;
+  // Coefficients of projection onto the left-eigenvector
+  eta[1] = (t7 + t8) / 2; // eg. 4.20
+  eta[1] *= rho; // merge rho in right-eigenvector in 4.18 into coefficents
+  wv = &waves[1*meqns];
+  // Fluctuations due to this mode
+  wv[MY] = -eta[1]*betaz;
+  wv[MZ] = eta[1]*betay;
+  wv[ER] = -eta[1]*(v*betaz - w*betay);
+  wv[BY] = -eta[1]*S*betaz/sqrt(rho);
+  wv[BZ] = eta[1]*S*betay/sqrt(rho);
+
+  ev[5] = u + ca;
+  // Coefficients of projection onto the left-eigenvector
+  eta[5] = (-t7 + t8) / 2; // eq. 4.20
+  eta[5] *= rho; // merge rho in right-eigenvector in 4.18 into coefficents
+  wv = &waves[5*meqns];
+  // Fluctuations due to this mode
+  wv[MY] = eta[5]*betaz;
+  wv[MZ] = -eta[5]*betay;
+  wv[ER] = +eta[5]*(v*betaz - w*betay);
+  wv[BY] = -eta[5]*S*betaz/sqrt(rho);
+  wv[BZ] = eta[5]*S*betay/sqrt(rho);
+
+  /////////////////////////////////////////////////////////////
+  // Slow magnetosonic waves
+
+  // For projection coefficients in eq. 4.20 for magnetosonic waves
+  // Compared to the fast wave coefficients, alphas/alphaf & cs/cf are switched
+  t1 = alphas * (X*drho + dp);
+  t2 = alphaf * cf * rho * S * (betay*dv + betaz*dw);
+  t3 = alphas * cs * rho * du;
+  t4 = alphaf * sqrt(rho) * a * (betay*dBy + betaz*dBz);
+  // for right eigenvectors for magnetosonic waves in eq. 4.19
+  t5 = alphaf * cf * S * (v*betay + w*betaz);
+  t6 = alphaf * a * Bt / sqrt(rho);
+
+  ev[2] = u - cs;
+  // Coefficients of projection onto the left-eigenvector
+  eta[2] = (t1 - t2 - t3 - t4) / 2; // eq. 4.20
+  eta[2] /= a2; // merge a2 in right-eigenvector in 4.19 into coefficents
+  // Fluctuations due to this mode
+  wv = &waves[2*meqns];
+  wv[DN] = eta[2]*alphas;
+  wv[MX] = eta[2]*(alphas*(u - cs));
+  wv[MY] = eta[2]*(alphas*v - alphaf*cf*betay*S);
+  wv[MZ] = eta[2]*(alphas*w - alphaf*cf*betaz*S);
+  wv[ER] = eta[2]*(alphas*(Hgas-u*cs) - t5 - t6);
+  wv[BY] = -eta[2]*alphaf*a*betay/sqrt(rho);
+  wv[BZ] = -eta[2]*alphaf*a*betaz/sqrt(rho);
+
+  ev[4] = u + cs;
+  // Coefficients of projection onto the left-eigenvector
+  eta[4] = (t1 + t2 + t3 - t4) / 2; // eq. 4.20
+  eta[4] /= a2; // merge a2 in right-eigenvector in 4.19 into coefficents
+  // Fluctuations due to this mode
+  wv = &waves[4*meqns];
+  wv[DN] = eta[4]*alphas;
+  wv[MX] = eta[4]*(alphas*(u + cs));
+  wv[MY] = eta[4]*(alphas*v + alphaf*cf*betay*S);
+  wv[MZ] = eta[4]*(alphas*w + alphaf*cf*betaz*S);
+  wv[ER] = eta[4]*(alphas*(Hgas+u*cs) + t5 - t6);
+  wv[BY] = -eta[4]*alphaf*a*betay/sqrt(rho);
+  wv[BZ] = -eta[4]*alphaf*a*betaz/sqrt(rho);
+
+  /////////////////////////////////////////////////////////////
+  // Enropy wave; TODO: merge divB wave
+  ev[3] = u;
+  // Coefficients of projection onto the left-eigenvector
+  eta[3] = (a2 - X) * drho - dp; // eq. 4.20
+  eta[3] /= a2; // merge a2 in right-eigenvector in 4.18 into coefficents
+  // Fluctuations due to this mode
+  wv = &waves[3*meqns];
+  wv[DN] = eta[3];
+  wv[MX] = eta[3]*u;
+  wv[MY] = eta[3]*v;
+  wv[MZ] = eta[3]*w;
+  wv[ER] = eta[3]*(v2/2 + X*(gamma-2)/(gamma-1));
+
+  /* printf("\n"); */
+  /* printf("u=%f, a=%f, ca=%f, cs=%f, cf=%f\n", u, a, ca, cs, cf); */
+  /* printf("alphaf=%f, alphas=%f, betay=%f, betaz=%f\n", */
+  /*        alphaf, alphas, betay, betaz); */
+  /* for(int i=0;i<7;++i) */
+  /*   printf("[%d], eta=%10g, ev=%10g\n", i, eta[i], ev[i]); */
+
+  return fabs(u) + cf;
+}
+
+static void
+qfluct_roe(const struct gkyl_wv_eqn *eqn, int dir, const double *ql,
+           const double *qr, const double *waves, const double *s, double *amdq,
+           double *apdq)
+{
+  const double *w0 = &waves[0*8], *w1 = &waves[1*8], *w2 = &waves[2*8];
+  const double *w3 = &waves[3*8], *w4 = &waves[4*8], *w5 = &waves[5*8];
+  const double *w6 = &waves[6*8];
+
+  double s0m = fmin(0.0, s[0]), s1m = fmin(0.0, s[1]), s2m = fmin(0.0, s[2]);
+  double s3m = fmin(0.0, s[3]), s4m = fmin(0.0, s[4]), s5m = fmin(0.0, s[5]);
+  double s6m = fmin(0.0, s[6]);
+
+  double s0p = fmax(0.0, s[0]), s1p = fmax(0.0, s[1]), s2p = fmax(0.0, s[2]);
+  double s3p = fmax(0.0, s[3]), s4p = fmax(0.0, s[4]), s5p = fmax(0.0, s[5]);
+  double s6p = fmax(0.0, s[6]);
+
+  for (int i=0; i<8; ++i) {
+    amdq[i] = s0m*w0[i] + s1m*w1[i] + s2m*w2[i] + s3m*w3[i] + s4m*w4[i]
+            + s5m*w5[i] + s5m*w6[i];
+    apdq[i] = s0p*w0[i] + s1p*w1[i] + s2p*w2[i] + s3p*w3[i] + s4p*w4[i]
+            + s5p*w5[i] + s6p*w6[i];
+  }
+}
+
+static double
+max_speed(const struct gkyl_wv_eqn *eqn, int dir, const double *q)
+{
+  const struct wv_mhd *mhd = container_of(eqn, struct wv_mhd, eqn);
+  return gkyl_mhd_max_abs_speed(dir, mhd->gas_gamma, q);
+}
+
+struct gkyl_wv_eqn*
+gkyl_wv_mhd_new(double gas_gamma)
+{
+  struct wv_mhd *mhd = gkyl_malloc(sizeof(struct wv_mhd));
+
+  mhd->eqn.type = GKYL_EQN_MHD;
+  mhd->eqn.num_equations = 8;
+  mhd->eqn.num_waves = 7;
+  mhd->gas_gamma = gas_gamma;
+  mhd->eqn.waves_func = wave_roe;
+  mhd->eqn.qfluct_func = qfluct_roe;
+  mhd->eqn.max_speed_func = max_speed;
+
+  mhd->eqn.ref_count = (struct gkyl_ref_count) { mhd_free, 1 };
+
+  return &mhd->eqn;
+}
+
+double
+gkyl_wv_mhd_gas_gamma(const struct gkyl_wv_eqn* eqn)
+{
+  const struct wv_mhd *mhd = container_of(eqn, struct wv_mhd, eqn);
+  return mhd->gas_gamma;
+}


### PR DESCRIPTION
The work was tedious and very error-prone, but now we have a basic Roe solver for ideal MHD based on [Cargo and Gallice (1997)](https://doi.org/10.1006/jcph.1997.5773). LeVeque's wave-propagation scheme is used but we surely can turn to flux difference form if needed.

- Fixed typoes in Cargo and Gallice (1997).
- Possible improvements
  - Handling unusual cases better.
  - Include divB wave and implement divB sources for Powell's 8-wave scheme.
  - More tests.
  - Reduce duplicate computation.
  - Entropy fix.
  - Positivity-preserving scheme like LF or HLLE.