### PR TITLE
MHD GLM div(B) cleaning work-in-progress before pausing the hackweek

### DIFF
--- a/regression/rt_mhd_brio_wu.c
+++ b/regression/rt_mhd_brio_wu.c
@@ -48,8 +48,7 @@ main(int argc, char **argv)
   struct mhd_ctx ctx = mhd_ctx(); // context for init functions
 
   // equation object
-  int has_eight_waves = 0;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, has_eight_waves);
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, "none");
 
   struct gkyl_moment_species fluid = {
     .name = "mhd",

--- a/regression/rt_mhd_brio_wu.c
+++ b/regression/rt_mhd_brio_wu.c
@@ -48,7 +48,8 @@ main(int argc, char **argv)
   struct mhd_ctx ctx = mhd_ctx(); // context for init functions
 
   // equation object
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma);
+  int has_eight_waves = 0;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, has_eight_waves);
 
   struct gkyl_moment_species fluid = {
     .name = "mhd",

--- a/regression/rt_mhd_brio_wu.c
+++ b/regression/rt_mhd_brio_wu.c
@@ -63,14 +63,14 @@ main(int argc, char **argv)
 
   // VM app
   struct gkyl_moment app_inp = {
-    .name = "mhd_bio_wu",
+    .name = "mhd_brio_wu",
 
     .ndim = 1,
     .lower = { 0.0 },
     .upper = { 1.0 }, 
-    .cells = { 512 },
+    .cells = { 400 },
 
-    .cfl_frac = 0.1,
+    .cfl_frac = 0.8,
 
     .num_species = 1,
     .species = { fluid },

--- a/regression/rt_mhd_ot.c
+++ b/regression/rt_mhd_ot.c
@@ -1,0 +1,147 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_mhd.h>
+#include <rt_arg_parse.h>
+
+struct mhd_ctx {
+  double gas_gamma; // gas constant
+};
+
+void
+calcq(double gas_gamma, const double pv[8], double q[8])
+{
+  double rho = pv[0], u = pv[1], v = pv[2], w = pv[3], pr = pv[4];
+  q[0] = rho;
+  q[1] = rho*u; q[2] = rho*v; q[3] = rho*w;
+  q[5] = pv[5]; q[6] = pv[6]; q[7] = pv[7];  // B field
+  double pb = 0.5*(pv[5]*pv[5]+pv[6]*pv[6]+pv[7]*pv[7]); // magnetic pressure
+  q[4] = pr/(gas_gamma-1) + 0.5*rho*(u*u+v*v+w*w) + pb;
+}
+
+void
+evalMhdInit(double t, const double* GKYL_RESTRICT xn,
+            double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct mhd_ctx *app = ctx;
+  double x = xn[0], y =xn[1];
+  double gas_gamma = app->gas_gamma;
+
+  double rho = 25/(36*M_PI);
+  double p = 5/(12*M_PI);
+  double vx = -sin(2*M_PI*y);
+  double vy = sin(2*M_PI*x);
+  double vz = 0;
+  double B0 = 1/sqrt(4*M_PI);
+  double Bx = -B0*sin(4*M_PI*x);
+  double By = B0*sin(4*M_PI*y);
+  double Bz = 0;
+  double v[8] = {rho, vx, vy, vz, p, Bx, By, Bz};
+
+  calcq(gas_gamma, v, fout);
+  fout[8] = 0; // for glm scheme
+}
+
+struct mhd_ctx
+mhd_ctx(void)
+{
+  return (struct mhd_ctx) { .gas_gamma = 5./3. };
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  struct mhd_ctx ctx = mhd_ctx(); // context for init functions
+
+  // equation object
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, "glm");
+
+  struct gkyl_moment_species fluid = {
+    .name = "mhd",
+
+    .equation = mhd,
+    .evolve = 1,
+    .ctx = &ctx,
+    .init = evalMhdInit,
+
+    .bcx = { GKYL_MOMENT_COPY, GKYL_MOMENT_COPY },
+    .bcy = { GKYL_MOMENT_COPY, GKYL_MOMENT_COPY },
+  };
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "mhd_ot_glm",
+
+    .ndim = 2,
+    .lower = { 0.0, 0.0 },
+    .upper = { 1.0, 1.0 }, 
+    .cells = { 512, 512 },
+
+    .cfl_frac = 0.4,
+
+    .num_species = 1,
+    .species = { fluid },
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(app_inp);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = 0.2;
+  double tframe = 0.1;  // time interval between outputs
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  double tout_next = tcurr + tframe;
+  int frame = 1;
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((tcurr < tend) && (step <= num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    if (tcurr>=tout_next) {
+      printf(">>>>> Writing frame %d at t=%g\n", frame, tcurr);
+      gkyl_moment_app_write(app, tcurr, frame);
+      frame += 1;
+      tout_next += tframe;
+    }
+
+    step += 1;
+  }
+
+  frame = frame + 1;
+  gkyl_moment_app_write(app, tcurr, frame);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(mhd);
+  gkyl_moment_app_release(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+  
+  return 0;
+}

--- a/regression/rt_mhd_rj2.c
+++ b/regression/rt_mhd_rj2.c
@@ -1,0 +1,130 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_mhd.h>
+#include <rt_arg_parse.h>
+
+struct mhd_ctx {
+  double gas_gamma; // gas constant
+};
+
+void
+calcq(double gas_gamma, const double pv[8], double q[8])
+{
+  double rho = pv[0], u = pv[1], v = pv[2], w = pv[3], pr = pv[4];
+  q[0] = rho;
+  q[1] = rho*u; q[2] = rho*v; q[3] = rho*w;
+  q[5] = pv[5]; q[6] = pv[6]; q[7] = pv[7];  // B field
+  double pb = 0.5*(pv[5]*pv[5]+pv[6]*pv[6]+pv[7]*pv[7]); // magnetic pressure
+  q[4] = pr/(gas_gamma-1) + 0.5*rho*(u*u+v*v+w*w) + pb;
+}
+
+/* Ryu & Jones (1995), the second test in Sec 4 and fig 2a, with all 7 waves. */
+void
+evalMhdInit(double t, const double* GKYL_RESTRICT xn,
+            double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct mhd_ctx *app = ctx;
+  double x = xn[0];
+  double gas_gamma = app->gas_gamma;
+
+  // primitive variables, rho, V, E, B
+  double tmp = 1 / sqrt(4*M_PI);
+  double vl[8] = {1.08, 1.2, 0.01, 0.5, 0.95, 2*tmp, 3.6*tmp, 2*tmp};
+  double vr[8] = {1,    0,   0,    0,   1,    2*tmp, 4*tmp,   2*tmp};
+  
+  calcq(gas_gamma, vr, fout);
+  if (x<0.5)
+    calcq(gas_gamma, vl, fout);
+}
+
+struct mhd_ctx
+mhd_ctx(void)
+{
+  return (struct mhd_ctx) { .gas_gamma = 5./3. };
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  struct mhd_ctx ctx = mhd_ctx(); // context for init functions
+
+  // equation object
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, "none");
+
+  struct gkyl_moment_species fluid = {
+    .name = "mhd",
+
+    .equation = mhd,
+    .evolve = 1,
+    .ctx = &ctx,
+    .init = evalMhdInit,
+
+    .bcx = { GKYL_MOMENT_COPY, GKYL_MOMENT_COPY },
+  };
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "mhd_rj2",
+
+    .ndim = 1,
+    .lower = { 0.0 },
+    .upper = { 1.0 }, 
+    .cells = { 512 },
+
+    .cfl_frac = 0.8,
+
+    .num_species = 1,
+    .species = { fluid },
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(app_inp);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = 0.2;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((tcurr < tend) && (step <= num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(mhd);
+  gkyl_moment_app_release(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+  
+  return 0;
+}

--- a/unit/ctest_wv_mhd.c
+++ b/unit/ctest_wv_mhd.c
@@ -18,7 +18,8 @@ void
 test_mhd_basic()
 {
   double gas_gamma = 1.4;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma);
+  int has_eight_waves = 0;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, has_eight_waves);
 
   TEST_CHECK( mhd->num_equations == 8 );
   TEST_CHECK( mhd->num_waves == 7 );
@@ -73,7 +74,8 @@ void
 test_mhd_waves()
 {
   double gas_gamma = 1.4;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma);
+  int has_eight_waves = 0;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, has_eight_waves);
 
   double ql[8], qr[8];
   double delta[8];

--- a/unit/ctest_wv_mhd.c
+++ b/unit/ctest_wv_mhd.c
@@ -104,57 +104,8 @@ test_mhd_waves()
   gkyl_wv_eqn_release(mhd);
 }
 
-/* check if sum of left/right going fluctuations sum to jump in flux */
-void
-test_glm_mhd_waves()
-{
-  double gas_gamma = 1.4;
-  double glm_ch = 1;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, "glm");
-
-  double ql[9], qr[9];
-  double delta[9];
-
-  /* double vl[9] = { 1.0,  0.1,  0.2,  0.3,  1.5, 0.3, 0.4, 0.3, 0.2}; */
-  /* double vr[9] = { 1.1, 0.13, 0.25, 0.34, 1.54, 0.4, 0.5, 0.2, 0.2}; */
-  double vl[9] = { 1, 0, 0, 0, 10, 1, 0, 0, 2};
-  double vr[9] = { 1, 0, 0, 0, 10, 2, 0, 0, 3};
-
-  calcq(gas_gamma, vl, ql); calcq(gas_gamma, vr, qr);
-  ql[8] = vl[8];
-  qr[8] = vr[8];
-
-  for (int i=0; i<9; ++i) delta[i] = qr[i]-ql[i];
-
-  for (int d=0; d<1; ++d) {
-    double speeds[9], waves[9*9];
-    gkyl_wv_eqn_waves(mhd, d, delta, ql, qr, waves, speeds);
-
-    double apdq[9], amdq[9];
-    gkyl_wv_eqn_qfluct(mhd, d, ql, qr, waves, speeds, amdq, apdq);
-    
-    double fl[9], fr[9];
-    gkyl_glm_mhd_flux(d, gas_gamma, glm_ch, ql, fl);
-    gkyl_glm_mhd_flux(d, gas_gamma, glm_ch, qr, fr);
-
-    printf("\n");
-    for (int i=0; i<9; ++i)
-    {
-      int a = gkyl_compare(fr[i]-fl[i], amdq[i]+apdq[i], 1e-9);
-      printf("[%d] equal? %d; df=%f, sum(A*dq)=%f; f %g, %g\n",
-          i, a, fr[i]-fl[i], amdq[i]+apdq[i], fl[i], fr[i]);
-    }
-
-    for (int i=0; i<9; ++i)
-      TEST_CHECK( gkyl_compare(fr[i]-fl[i], amdq[i]+apdq[i], 1e-9) );
-  }
-    
-  gkyl_wv_eqn_release(mhd);
-}
-
 TEST_LIST = {
   { "mhd_basic", test_mhd_basic },
   { "mhd_waves", test_mhd_waves },
-  { "glm_mhd_waves", test_glm_mhd_waves },
   { NULL, NULL },
 };

--- a/unit/ctest_wv_mhd.c
+++ b/unit/ctest_wv_mhd.c
@@ -18,8 +18,7 @@ void
 test_mhd_basic()
 {
   double gas_gamma = 1.4;
-  int has_eight_waves = 0;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, has_eight_waves);
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, "none");
 
   TEST_CHECK( mhd->num_equations == 8 );
   TEST_CHECK( mhd->num_waves == 7 );
@@ -74,8 +73,7 @@ void
 test_mhd_waves()
 {
   double gas_gamma = 1.4;
-  int has_eight_waves = 0;
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, has_eight_waves);
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, "none");
 
   double ql[8], qr[8];
   double delta[8];

--- a/unit/ctest_wv_mhd.c
+++ b/unit/ctest_wv_mhd.c
@@ -104,8 +104,57 @@ test_mhd_waves()
   gkyl_wv_eqn_release(mhd);
 }
 
+/* check if sum of left/right going fluctuations sum to jump in flux */
+void
+test_glm_mhd_waves()
+{
+  double gas_gamma = 1.4;
+  double glm_ch = 1;
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(gas_gamma, "glm");
+
+  double ql[9], qr[9];
+  double delta[9];
+
+  /* double vl[9] = { 1.0,  0.1,  0.2,  0.3,  1.5, 0.3, 0.4, 0.3, 0.2}; */
+  /* double vr[9] = { 1.1, 0.13, 0.25, 0.34, 1.54, 0.4, 0.5, 0.2, 0.2}; */
+  double vl[9] = { 1, 0, 0, 0, 10, 1, 0, 0, 2};
+  double vr[9] = { 1, 0, 0, 0, 10, 2, 0, 0, 3};
+
+  calcq(gas_gamma, vl, ql); calcq(gas_gamma, vr, qr);
+  ql[8] = vl[8];
+  qr[8] = vr[8];
+
+  for (int i=0; i<9; ++i) delta[i] = qr[i]-ql[i];
+
+  for (int d=0; d<1; ++d) {
+    double speeds[9], waves[9*9];
+    gkyl_wv_eqn_waves(mhd, d, delta, ql, qr, waves, speeds);
+
+    double apdq[9], amdq[9];
+    gkyl_wv_eqn_qfluct(mhd, d, ql, qr, waves, speeds, amdq, apdq);
+    
+    double fl[9], fr[9];
+    gkyl_glm_mhd_flux(d, gas_gamma, glm_ch, ql, fl);
+    gkyl_glm_mhd_flux(d, gas_gamma, glm_ch, qr, fr);
+
+    printf("\n");
+    for (int i=0; i<9; ++i)
+    {
+      int a = gkyl_compare(fr[i]-fl[i], amdq[i]+apdq[i], 1e-9);
+      printf("[%d] equal? %d; df=%f, sum(A*dq)=%f; f %g, %g\n",
+          i, a, fr[i]-fl[i], amdq[i]+apdq[i], fl[i], fr[i]);
+    }
+
+    for (int i=0; i<9; ++i)
+      TEST_CHECK( gkyl_compare(fr[i]-fl[i], amdq[i]+apdq[i], 1e-9) );
+  }
+    
+  gkyl_wv_eqn_release(mhd);
+}
+
 TEST_LIST = {
   { "mhd_basic", test_mhd_basic },
   { "mhd_waves", test_mhd_waves },
+  { "glm_mhd_waves", test_glm_mhd_waves },
   { NULL, NULL },
 };

--- a/zero/gkyl_prim_mhd.h
+++ b/zero/gkyl_prim_mhd.h
@@ -33,3 +33,15 @@ double gkyl_mhd_max_abs_speed(int dir, double gas_gamma, const double q[8]);
  * @param flux On output, the flux in direction 'dir'
  */
 void gkyl_mhd_flux(int dir, double gas_gamma, const double q[8], double flux[8]);
+
+/**
+ * Compute flux in direction 'dir' for the GLM-MHD equations.
+ *
+ * @param dir Direction to compute flux
+ * @param gas_gamma Gas adiabatic constant
+ * @param ch The propagation speed of div(B) errors in the GLM method.
+ * @param Conserved variables
+ * @param flux On output, the flux in direction 'dir'
+ */
+void gkyl_glm_mhd_flux(int dir, double gas_gamma, double ch, const double q[8],
+                       double flux[8]);

--- a/zero/gkyl_wv_mhd.h
+++ b/zero/gkyl_wv_mhd.h
@@ -8,7 +8,7 @@
  * @param gas_gamma Gas adiabatic constant
  * @return Pointer to mhd equation object.
  */
-struct gkyl_wv_eqn* gkyl_wv_mhd_new(double gas_gamma);
+struct gkyl_wv_eqn* gkyl_wv_mhd_new(double gas_gamma, int has_eight_waves);
 
 /**
  * Get gas adiabatic constant.

--- a/zero/gkyl_wv_mhd.h
+++ b/zero/gkyl_wv_mhd.h
@@ -8,7 +8,8 @@
  * @param gas_gamma Gas adiabatic constant
  * @return Pointer to mhd equation object.
  */
-struct gkyl_wv_eqn* gkyl_wv_mhd_new(double gas_gamma, int has_eight_waves);
+struct gkyl_wv_eqn* gkyl_wv_mhd_new(
+    double gas_gamma, const char *divergence_constraint);
 
 /**
  * Get gas adiabatic constant.

--- a/zero/prim_mhd.c
+++ b/zero/prim_mhd.c
@@ -17,6 +17,7 @@ static const int dir_shuffle[][6] = {
 #define B1 (d[3])
 #define B2 (d[4])
 #define B3 (d[5])
+#define PSI_GLM (8)
 
 #define sq(x) ((x)*(x))
 
@@ -63,4 +64,16 @@ gkyl_mhd_flux(int dir, double gas_gamma, const double q[8], double flux[8])
   flux[B1] = 0;
   flux[B2] = u1*q[B2] - u2*q[B1];
   flux[B3] = u1*q[B3] - u3*q[B1];
+}
+
+void
+gkyl_glm_mhd_flux(int dir, double gas_gamma, double ch, const double q[9],
+                  double flux[9])
+{
+  int const *const d = dir_shuffle[dir];
+
+  gkyl_mhd_flux(dir, gas_gamma, q, flux);
+
+  flux[B1] = q[PSI_GLM];
+  flux[PSI_GLM] = ch*ch*q[B1];
 }

--- a/zero/wv_mhd.c
+++ b/zero/wv_mhd.c
@@ -114,8 +114,8 @@ wave_roe(const struct gkyl_wv_eqn *eqn, int dir, const double *dQ,
   //////////////////////////////////////////////////////////////////////////////
   // STEP 3: COMPUTE CHARACTERASTIC WAVE SPEEDS AND OTHER USEFUL QUANTITIES   //
   //////////////////////////////////////////////////////////////////////////////
-  // CG97 eq. 4.12; FIXME: dBx is included as needed by 8-wave scheme
-  double X = (sq(dQ[BX]) + sq(dQ[BY]) + sq(dQ[BZ])) / (2*sq(srrhol+srrhor));
+  // CG97 eq. 4.12
+  double X = (sq(dQ[BY]) + sq(dQ[BZ])) / (2*sq(srrhol+srrhor));
 
   // CG97 eq 4.17, wave speeds
   double ca2 = Bx*Bx/rho; // for alfven speed due to normal B field

--- a/zero/wv_mhd.c
+++ b/zero/wv_mhd.c
@@ -26,6 +26,7 @@ static const int dir_shuffle[][6] = {
 struct wv_mhd {
   struct gkyl_wv_eqn eqn; // base object
   double gas_gamma; // gas adiabatic constant
+  int has_eight_waves; // set 1 to add divB wave for powell's 8-wave scheme
 };
 
 static void
@@ -255,6 +256,9 @@ wave_roe(const struct gkyl_wv_eqn *eqn, int dir, const double *dQ,
   wv[MZ] = eta[3]*w;
   wv[ER] = eta[3]*(v2/2 + X*(gamma-2)/(gamma-1));
 
+  if (mhd->has_eight_waves)
+    wv[BX] = dQ[BX];
+
   /* printf("\n"); */
   /* printf("u=%f, a=%f, ca=%f, cs=%f, cf=%f\n", u, a, ca, cs, cf); */
   /* printf("alphaf=%f, alphas=%f, betay=%f, betaz=%f\n", */
@@ -298,7 +302,7 @@ max_speed(const struct gkyl_wv_eqn *eqn, int dir, const double *q)
 }
 
 struct gkyl_wv_eqn*
-gkyl_wv_mhd_new(double gas_gamma)
+gkyl_wv_mhd_new(double gas_gamma, int has_eight_waves)
 {
   struct wv_mhd *mhd = gkyl_malloc(sizeof(struct wv_mhd));
 
@@ -306,6 +310,7 @@ gkyl_wv_mhd_new(double gas_gamma)
   mhd->eqn.num_equations = 8;
   mhd->eqn.num_waves = 7;
   mhd->gas_gamma = gas_gamma;
+  mhd->has_eight_waves = has_eight_waves;
   mhd->eqn.waves_func = wave_roe;
   mhd->eqn.qfluct_func = qfluct_roe;
   mhd->eqn.max_speed_func = max_speed;


### PR DESCRIPTION
#### Summary
I might have to stop working on this for now so I'm saving the updates.

- Dedner's GLM scheme for div(B) cleaning. Only the hyperbolic part is implemented.
- 1d 7-wave test of Ryu & Jones (1995)
- 2d Orszag-Tang test using GLM-MHD.
  - Even without the damping term, GLM seems to give OK results but the run still dies due to negative pressure/density. In contrast, without any cleaning, the results seem incorrect after a while.

#### TODOs:
- Source term for the div(B) damping in GLM-MHD.
- For GLM, right now, the propagation speed is set to the fast magnetosonic speed. It could be `cfl * dx / dt`.

#### Problems and thoughts
The GLM div(B) waves are added on top of the ideal MHD roe solver. This does NOT yield a roe solver for the full 9-wave system that satisfies `fr-fl=amdq+apdq`. This is because the (Bx, psi) system is evolved separately, but the 1d ideal MHD Rieman solver relies on Bx to compute wave speeds to evolve other seven MHD quantities. It's a one-way reliance, and the 1d ideal MHD Riemann solver assumes Bx to be continuous. Could a clever average make the 1d ideal MHD Riemann solver work for discontinuous Bx?

Powell's original eight-wave scheme does not directly extend from the ideal system's eigenvectors. The latter, with out div(B) source terms, does not contain the 8th wave at all. Instead, it uses the flux Jacobian from the quasi-linear form equation for primitive variables. The eigenvectors are then transformed into the conservative variable space, and evaluated at ad hoc averages to construct a Roe solver. However, this does not guarantee the `fr-fl=amdq+apdq` condition. On the other hand, the additional source terms added afterward on momentum, energy, and B field make the entire solver non-conservative and less ideal for shock capturing.

Indeed, the most natural way would be a CT scheme with primary B field evolved at face centers. Then B_normal at the face of the Riemann solver is used to compute wave speeds, and B_tangential interpolated onto cell-centers are used to provide fluxes to evolve density, momentum, and total energy. However, CT would require substantially more work (data arrangement, E field calculation, etc.)