### PR TITLE
Geom_3d

### DIFF
--- a/regression/rt_landau_damping.c
+++ b/regression/rt_landau_damping.c
@@ -17,7 +17,7 @@ struct langmuir_ctx {
 
 static inline double sq(double x) { return x*x; }
 
-inline double
+static inline double
 maxwellian(double n, double v, double u, double vth)
 {
   double v2 = (v - u)*(v - u);

--- a/regression/rt_neut_lbo_sod_shock.c
+++ b/regression/rt_neut_lbo_sod_shock.c
@@ -15,7 +15,7 @@ struct free_stream_ctx {
 
 static inline double sq(double x) { return x*x; }
 
-inline double
+static inline double
 maxwellian(double n, double v, double u, double vth)
 {
   double v2 = (v - u)*(v - u);

--- a/regression/rt_neut_lbo_sod_shock_2v.c
+++ b/regression/rt_neut_lbo_sod_shock_2v.c
@@ -15,7 +15,7 @@ struct free_stream_ctx {
 
 static inline double sq(double x) { return x*x; }
 
-inline double
+static inline double
 maxwellian(double n, double vx, double vy, double u, double vth)
 {
   double v2 = (vx - u)*(vx - u) + vy*vy;

--- a/regression/rt_neut_lbo_sod_shock_3v.c
+++ b/regression/rt_neut_lbo_sod_shock_3v.c
@@ -15,7 +15,7 @@ struct free_stream_ctx {
 
 static inline double sq(double x) { return x*x; }
 
-inline double
+static inline double
 maxwellian(double n, double vx, double vy, double vz, double u, double vth)
 {
   double v2 = (vx - u)*(vx - u) + vy*vy + vz*vz;

--- a/regression/rt_neut_lbo_wall.c
+++ b/regression/rt_neut_lbo_wall.c
@@ -15,7 +15,7 @@ struct free_stream_ctx {
 
 static inline double sq(double x) { return x*x; }
 
-inline double
+static inline double
 maxwellian(double n, double v, double u, double vth)
 {
   double v2 = (v - u)*(v - u);

--- a/regression/rt_weibel_3d.c
+++ b/regression/rt_weibel_3d.c
@@ -18,7 +18,7 @@ struct weibel_ctx {
   double perturb;
 };
 
-inline double
+static inline double
 maxwellian2D(double n, double vx, double vy, double ux, double uy, double vth)
 {
   double v2 = (vx-ux)*(vx-ux) + (vy-uy)*(vy-uy);

--- a/regression/rt_weibel_4d.c
+++ b/regression/rt_weibel_4d.c
@@ -20,7 +20,7 @@ struct weibel_ctx {
   bool use_gpu;
 };
 
-inline double
+static inline double
 maxwellian2D(double n, double vx, double vy, double ux, double uy, double vth)
 {
   double v2 = (vx-ux)*(vx-ux) + (vy-uy)*(vy-uy);

--- a/regression/rt_weibel_lbo_4d.c
+++ b/regression/rt_weibel_lbo_4d.c
@@ -20,7 +20,7 @@ struct weibel_ctx {
   bool use_gpu;
 };
 
-inline double
+static inline double
 maxwellian2D(double n, double vx, double vy, double ux, double uy, double vth)
 {
   double v2 = (vx-ux)*(vx-ux) + (vy-uy)*(vy-uy);

--- a/unit/ctest_prim_vlasov.c
+++ b/unit/ctest_prim_vlasov.c
@@ -16,14 +16,14 @@
 #include <gkyl_prim_lbo_type.h>
 #include <gkyl_prim_lbo_vlasov.h>
 
-inline double
+static inline double
 maxwellian1D(double n, double vx, double ux, double vth)
 {
   double v2 = (vx-ux)*(vx-ux);
   return n/sqrt(2*M_PI*vth*vth)*exp(-v2/(2*vth*vth));
 }
 
-inline double
+static inline double
 maxwellian2D(double n, double vx, double vy, double ux, double uy, double vth)
 {
   double v2 = (vx-ux)*(vx-ux) + (vy-uy)*(vy-uy);

--- a/unit/ctest_wave_geom.c
+++ b/unit/ctest_wave_geom.c
@@ -226,10 +226,87 @@ test_wv_geom_2d_2()
   gkyl_wave_geom_release(wg);
 }
 
+void
+test_wv_geom_3d_1()
+{
+  int ndim = 3;
+  double lower[] = {0.0, 0.0, 0.0}, upper[] = {1.0, 1.0, 1.0};
+  int cells[] = {2, 2, 2};
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // create range
+  int nghost[GKYL_MAX_DIM] = { 0 };
+  struct gkyl_range range, ext_range;
+  gkyl_create_grid_ranges(&grid, nghost, &ext_range, &range);
+
+  struct gkyl_wave_geom *wg = gkyl_wave_geom_new(&grid, &range, nomapc2p, &ndim);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  
+  while (gkyl_range_iter_next(&iter)) {
+    const struct gkyl_wave_cell_geom *cg = gkyl_wave_geom_get(wg, iter.idx);
+
+    TEST_CHECK( gkyl_compare_double( cg->kappa, 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->lenr[0], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->lenr[1], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->lenr[2], 1.0, 1e-15) );
+
+    // normal to lower-x face is ex
+    TEST_CHECK( gkyl_compare_double( cg->norm[0][0], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[0][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[0][2], 0.0, 1e-15) );
+
+    // tangent1 to lower-x face is ey
+    TEST_CHECK( gkyl_compare_double( cg->tau1[0][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[0][1], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[0][2], 0.0, 1e-15) );
+
+    // tangent2 to lower-x face is ez
+    TEST_CHECK( gkyl_compare_double( cg->tau2[0][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[0][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[0][2], 1.0, 1e-15) );
+
+    // normal to lower-y face is ey
+    TEST_CHECK( gkyl_compare_double( cg->norm[1][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[1][1], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[1][2], 0.0, 1e-15) );
+
+    // tangent1 to lower-y face is ez
+    TEST_CHECK( gkyl_compare_double( cg->tau1[1][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[1][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[1][2], 1.0, 1e-15) );
+
+    // tangent2 to lower-y face is ex
+    TEST_CHECK( gkyl_compare_double( cg->tau2[1][0], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[1][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[1][2], 0.0, 1e-15) );
+
+    // normal to lower-z face is ez
+    TEST_CHECK( gkyl_compare_double( cg->norm[2][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[2][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->norm[2][2], 1.0, 1e-15) );
+
+    // tangent1 to lower-z face is ex
+    TEST_CHECK( gkyl_compare_double( cg->tau1[2][0], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[2][1], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau1[2][2], 0.0, 1e-15) );
+
+    // tangent2 to lower-z face is ey
+    TEST_CHECK( gkyl_compare_double( cg->tau2[2][0], 0.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[2][1], 1.0, 1e-15) );
+    TEST_CHECK( gkyl_compare_double( cg->tau2[2][2], 0.0, 1e-15) );
+  }
+
+  gkyl_wave_geom_release(wg);
+}
+
 TEST_LIST = {
   { "wv_geom_1d_1", test_wv_geom_1d_1 },
   { "wv_geom_1d_2", test_wv_geom_1d_2 },
   { "wv_geom_2d_1", test_wv_geom_2d_1 },
   { "wv_geom_2d_2", test_wv_geom_2d_2 },
+  { "wv_geom_3d_1", test_wv_geom_3d_1 },
   { NULL, NULL },
 };

--- a/unit/ctest_wave_geom_helpers.c
+++ b/unit/ctest_wave_geom_helpers.c
@@ -1,0 +1,181 @@
+#include <math.h>
+#include <acutest.h>
+#include <../zero/wave_geom.c>
+
+static void
+test_tri()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(1, 1, 2);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(-2, 4, 3);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(-2, -2, 4);
+
+  double area = triangle_area(p1, p2, p3);
+
+  TEST_CHECK( gkyl_compare_double( area, 10.173494974687902, 1e-15) );
+}
+
+static void
+test_planar_quad_1()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(0, 0, 0);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(1, 2, 3);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(5, 7, 9);
+  struct gkyl_vec3 p4 = gkyl_vec3_new(4, 5, 6);
+
+  struct gkyl_vec3 norm;
+
+  double area = planar_quad_area_norm(
+      p1, p2, p3, p4, &norm);
+
+  TEST_CHECK( gkyl_compare_double( area, 3*sqrt(6), 1e-15) );
+
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(norm), 1, 1e-15) );
+
+  struct gkyl_vec3 v12 = gkyl_vec3_sub(p2, p1);
+  struct gkyl_vec3 v23 = gkyl_vec3_sub(p3, p2);
+  struct gkyl_vec3 v34 = gkyl_vec3_sub(p4, p3);
+  struct gkyl_vec3 v41 = gkyl_vec3_sub(p1, p2);
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v12), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v23), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v34), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v41), 0, 1e-15) );
+}
+
+static void
+test_quad_1()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(0, 0, 0);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(1, 2, 3);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(5, 7, 9);
+  struct gkyl_vec3 p4 = gkyl_vec3_new(4, 5, 6);
+
+  struct gkyl_vec3 norm, tau1, tau2;
+
+  double area = quad_area_norm_tang(p1, p2, p3, p4, &norm, &tau1, &tau2);
+
+  TEST_CHECK( gkyl_compare_double( area, 3*sqrt(6), 1e-15) );
+
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(norm), 1, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(tau1), 1, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(tau2), 1, 1e-15) );
+
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, tau1), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, tau2), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(tau1, tau2), 0, 1e-15) );
+
+  struct gkyl_vec3 cross = gkyl_vec3_cross(tau1, tau2);
+  TEST_CHECK( gkyl_compare_double( cross.x[0], norm.x[0], 1e-15) );
+  TEST_CHECK( gkyl_compare_double( cross.x[1], norm.x[1], 1e-15) );
+  TEST_CHECK( gkyl_compare_double( cross.x[2], norm.x[2], 1e-15) );
+
+  struct gkyl_vec3 v12 = gkyl_vec3_sub(p2, p1);
+  struct gkyl_vec3 v23 = gkyl_vec3_sub(p3, p2);
+  struct gkyl_vec3 v34 = gkyl_vec3_sub(p4, p3);
+  struct gkyl_vec3 v41 = gkyl_vec3_sub(p1, p2);
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v12), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v23), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v34), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, v41), 0, 1e-15) );
+}
+
+static void
+test_quad_2()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(9., 3., 4.);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(9., 8., 7.);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(5., 2., 4.);
+  struct gkyl_vec3 p4 = gkyl_vec3_new(7., 9., 9.);
+
+  struct gkyl_vec3 norm, tau1, tau2;
+
+  double area = quad_area_norm_tang(p1, p2, p3, p4, &norm, &tau1, &tau2);
+
+  TEST_CHECK( gkyl_compare_double( area, 5.099019513592786, 1e-15) );
+
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(norm), 1, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(tau1), 1, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_len(tau2), 1, 1e-15) );
+
+  TEST_CHECK( gkyl_compare_double( norm.x[0], -0.196116, 1e-5) );
+  TEST_CHECK( gkyl_compare_double( norm.x[1],  0.784465, 1e-5) );
+  TEST_CHECK( gkyl_compare_double( norm.x[2], -0.588348, 1e-5) );
+
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, tau1), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(norm, tau2), 0, 1e-15) );
+  TEST_CHECK( gkyl_compare_double( gkyl_vec3_dot(tau1, tau2), 0, 1e-15) );
+
+  struct gkyl_vec3 cross = gkyl_vec3_cross(tau1, tau2);
+  TEST_CHECK( gkyl_compare_double( cross.x[0], norm.x[0], 1e-15) );
+  TEST_CHECK( gkyl_compare_double( cross.x[1], norm.x[1], 1e-15) );
+  TEST_CHECK( gkyl_compare_double( cross.x[2], norm.x[2], 1e-15) );
+}
+
+static void
+test_vol_tetra_1()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(0, 0, 0);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(1, 0, 0);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(1, 1, 0);
+  struct gkyl_vec3 p4 = gkyl_vec3_new(1, 1, 1);
+  double vol = vol_tetra(p1, p2, p3, p4);
+  TEST_CHECK( gkyl_compare_double( vol, 1./6., 1e-15) );
+}
+
+static void
+test_vol_tetra_2()
+{
+  struct gkyl_vec3 p1 = gkyl_vec3_new(0.37, 0.07, 0.29);
+  struct gkyl_vec3 p2 = gkyl_vec3_new(1.03, 0.08, 0.05);
+  struct gkyl_vec3 p3 = gkyl_vec3_new(1.1 , 1.2 , 0.32);
+  struct gkyl_vec3 p4 = gkyl_vec3_new(1.17, 1.18, 1.31);
+  double vol = vol_tetra(p1, p2, p3, p4);
+  TEST_CHECK( gkyl_compare_double( vol, 0.12567, 1e-15) );
+}
+
+static void
+test_vol_hexa_1()
+{
+  struct gkyl_vec3 verts[8] = {
+    {0, 0, 0},
+    {1, 0, 0},
+    {1, 1, 0},
+    {0, 1, 0},
+    {0, 0, 1},
+    {1, 0, 1},
+    {1, 1, 1},
+    {0, 1, 1},
+  };
+  
+  double vol = vol_hexa(verts);
+  TEST_CHECK( gkyl_compare_double( vol, 1, 1e-15) );
+}
+
+static void
+test_vol_hexa_2()
+{
+  struct gkyl_vec3 verts[8] = {
+    {0.37, 0.07, 0.21},
+    {1.16, 0.2 , 0.29},
+    {1.33, 1.18, 0.23},
+    {0.01, 1.21, 0.28},
+    {0.38, 0.36, 1.02},
+    {1.19, 0.11, 1.01},
+    {1.04, 1.23, 1.14},
+    {0.22, 1.2 , 1.18},
+  };
+  
+  double vol = vol_hexa(verts);
+  TEST_CHECK( gkyl_compare_double( vol, 0.746420666666667, 1e-15) );
+}
+
+TEST_LIST = {
+  { "triangle", test_tri },
+  { "parallelogram_as_planar_quad", test_planar_quad_1 },
+  { "parallelogram_as_quad", test_quad_1 },
+  { "quad", test_quad_2 },
+  { "vol_tetra_1", test_vol_tetra_1 },
+  { "vol_tetra_2", test_vol_tetra_2 },
+  { "vol_hexa_1", test_vol_hexa_1 },
+  { "vol_hexa_2", test_vol_hexa_2 },
+  { NULL, NULL },
+};

--- a/zero/wave_geom.c
+++ b/zero/wave_geom.c
@@ -100,9 +100,208 @@ calc_geom_2d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx, stru
   }
 }
 
-static void
-calc_geom_3d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx, struct gkyl_wave_cell_geom *geo)
+static double
+vol_tetra(const struct gkyl_vec3 p1,
+          const struct gkyl_vec3 p2,
+          const struct gkyl_vec3 p3,
+          const struct gkyl_vec3 p4)
 {
+  struct gkyl_vec3 a = gkyl_vec3_sub(p1, p4);
+  struct gkyl_vec3 b = gkyl_vec3_sub(p2, p4);
+  struct gkyl_vec3 c = gkyl_vec3_sub(p3, p4);
+  double vol = gkyl_vec3_dot(a, gkyl_vec3_cross(b, c)) / 6.;
+  return vol > 0? vol : -vol;
+}
+
+/* The order of vertices is assumed to be (l: lower, u: upper):
+[0], lll: (i,   j,   k  ) or (i-0.5, j-0.5, k-0.5)
+[1], ull: (i+1, j,   k  ) or (i+0.5, j-0.5, k-0.5)
+[2], uul: (i+1, j+1, k  ) or (i+0.5, j+0.5, k-0.5)
+[3], lul: (i,   j+1, k  ) or (i-0.5, j+0.5, k-0.5)
+[4], llu: (i,   j,   k+1) or (i-0.5, j-0.5, k+0.5)
+[5], ulu: (i+1, j,   k+1) or (i+0.5, j-0.5, k+0.5)
+[6], uuu: (i+1, j+1, k+1) or (i+0.5, j+0.5, k+0.5)
+[7], luu: (i,   j+1, k+1) or (i-0.5, j+0.5, k+0.5)
+
+       y
+3----------2
+|\     ^   |\
+| \    |   | \
+|  \   |   |  \
+|   7------+---6
+|   |  *-- |-- | -> x
+0---+---\--1   |
+ \  |    \  \  |
+  \ |     \  \ |
+   \|      x  \|
+    4----------5
+*/
+static double
+vol_hexa(const struct gkyl_vec3 *verts)
+{
+  // split the hexahedron into five tetrahedrons and add up their volumes
+  // FIXME does this handle bad hexahedrons?
+  double vol = 0;
+  vol += vol_tetra(verts[1], verts[5], verts[4], verts[6]);
+  vol += vol_tetra(verts[7], verts[4], verts[6], verts[3]);
+  vol += vol_tetra(verts[4], verts[0], verts[1], verts[3]);
+  vol += vol_tetra(verts[6], verts[1], verts[3], verts[4]);
+  vol += vol_tetra(verts[1], verts[2], verts[6], verts[3]);
+
+  return vol;
+}
+
+static inline double
+triangle_area(const struct gkyl_vec3 p1,
+              const struct gkyl_vec3 p2,
+              const struct gkyl_vec3 p3)
+{
+  return 0.5*gkyl_vec3_len(
+      gkyl_vec3_cross(gkyl_vec3_sub(p1, p2), gkyl_vec3_sub(p2, p3)));
+}
+
+// Points are in anti-clockwise order, i.e., p1-p3 and p2-p4 are diagonals.
+static double
+planar_quad_area_norm(const struct gkyl_vec3 p1,
+                        const struct gkyl_vec3 p2,
+                        const struct gkyl_vec3 p3,
+                        const struct gkyl_vec3 p4,
+                        struct gkyl_vec3 *norm)
+{
+  struct gkyl_vec3 v13 = gkyl_vec3_sub(p3, p1);
+  struct gkyl_vec3 v24 = gkyl_vec3_sub(p4, p2);
+
+  double area = 0.5 * gkyl_vec3_len(gkyl_vec3_cross(v13, v24));
+
+  if (norm) {
+    struct gkyl_vec3 norm_ = gkyl_vec3_norm(gkyl_vec3_cross(v13, v24));
+
+    for (int d=0; d<3; ++d)
+    {
+      norm->x[d] = norm_.x[d];
+    }
+  }
+
+  return area;
+}
+
+// ca * a + cb * b
+static inline struct gkyl_vec3
+gkyl_vec3_add_coeff(
+  const double ca, struct gkyl_vec3 a, const double cb, struct gkyl_vec3 b)
+{
+  return (struct gkyl_vec3) { .x = {
+    ca*a.x[0] + cb*b.x[0],
+    ca*a.x[1] + cb*b.x[1],
+    ca*a.x[2] + cb*b.x[2] } };
+}
+
+static double
+quad_area_norm_tang(const struct gkyl_vec3 p1,
+                    const struct gkyl_vec3 p2,
+                    const struct gkyl_vec3 p3,
+                    const struct gkyl_vec3 p4,
+                    struct gkyl_vec3 *norm,
+                    struct gkyl_vec3 *tau1,
+                    struct gkyl_vec3 *tau2)
+{
+  // find Varignon parallelogram and use its normal as the quad's normal
+  struct gkyl_vec3 pp1 = gkyl_vec3_add_coeff(0.5, p1, 0.5, p2);
+  struct gkyl_vec3 pp2 = gkyl_vec3_add_coeff(0.5, p2, 0.5, p3);
+  struct gkyl_vec3 pp3 = gkyl_vec3_add_coeff(0.5, p3, 0.5, p4);
+  struct gkyl_vec3 pp4 = gkyl_vec3_add_coeff(0.5, p4, 0.5, p1);
+  double area = planar_quad_area_norm(pp1, pp2, pp3, pp4, norm);
+
+  // tau1 is v(p1->p2) projected on the normal plane, (tau1, tau2, norm)
+  // completes a high-hand system
+  struct gkyl_vec3 p12 = gkyl_vec3_sub(p2, p1);
+  double d = gkyl_vec3_dot(p12, *norm);
+  struct gkyl_vec3 t1 = gkyl_vec3_norm(gkyl_vec3_add_coeff(1, p12, -d, *norm));
+  struct gkyl_vec3 t2 = gkyl_vec3_cross(*norm, t1);
+  for (int d=0; d<3; ++d)
+  {
+    tau1->x[d] = t1.x[d];
+    tau2->x[d] = t2.x[d];
+  }
+
+#if 1
+  // project corner points onto the normal plane and use the projected planar
+  // quad's area as the original quad's area
+  d = gkyl_vec3_dot(*norm, p1);
+  struct gkyl_vec3 proj1 = gkyl_vec3_add_coeff(1, p1, -d, *norm);
+  d = gkyl_vec3_dot(*norm, p2);
+  struct gkyl_vec3 proj2 = gkyl_vec3_add_coeff(1, p2, -d, *norm);
+  d = gkyl_vec3_dot(*norm, p3);
+  struct gkyl_vec3 proj3 = gkyl_vec3_add_coeff(1, p3, -d, *norm);
+  d = gkyl_vec3_dot(*norm, p4);
+  struct gkyl_vec3 proj4 = gkyl_vec3_add_coeff(1, p4, -d, *norm);
+  
+  area = planar_quad_area_norm(proj1, proj2, proj3, proj4, norm);
+#else
+  // accumulate triangle areas
+  area += triangle_area(p1, pp1, pp4);
+  area += triangle_area(p2, pp2, pp1);
+  area += triangle_area(p3, pp3, pp2);
+  area += triangle_area(p4, pp4, pp3);
+#endif
+
+  return area;
+}
+
+static void
+calc_geom_3d(const double *dx, const double *xc, evalf_t mapc2p, void *ctx,
+             struct gkyl_wave_cell_geom *geo)
+{
+  // get all vertices of the hexahedron; see vol_hexa for their order
+  struct gkyl_vec3 verts_c[8] = {
+    gkyl_vec3_new(xc[0]-0.5*dx[0], xc[1]-0.5*dx[1], xc[2]-0.5*dx[2]),
+    gkyl_vec3_new(xc[0]+0.5*dx[0], xc[1]-0.5*dx[1], xc[2]-0.5*dx[2]),
+    gkyl_vec3_new(xc[0]+0.5*dx[0], xc[1]+0.5*dx[1], xc[2]-0.5*dx[2]),
+    gkyl_vec3_new(xc[0]-0.5*dx[0], xc[1]+0.5*dx[1], xc[2]-0.5*dx[2]),
+    gkyl_vec3_new(xc[0]-0.5*dx[0], xc[1]-0.5*dx[1], xc[2]+0.5*dx[2]),
+    gkyl_vec3_new(xc[0]+0.5*dx[0], xc[1]-0.5*dx[1], xc[2]+0.5*dx[2]),
+    gkyl_vec3_new(xc[0]+0.5*dx[0], xc[1]+0.5*dx[1], xc[2]+0.5*dx[2]),
+    gkyl_vec3_new(xc[0]-0.5*dx[0], xc[1]+0.5*dx[1], xc[2]+0.5*dx[2])
+  };
+
+  struct gkyl_vec3 verts[8];
+  for (int i=0; i<8; ++i)
+    mapc2p(0.0, verts_c[i].x, verts[i].x, ctx);
+
+  // compute cell volume and kappa
+  double vol = vol_hexa(verts);
+  double cell_vol_c = dx[0] * dx[1] * dx[2];
+  geo->kappa = vol / cell_vol_c;
+
+  // for each of the thee lower quad faces 'owned' by the present cell, compute
+  // area, norm, tan1, tan2, and lenr
+  int pt_idx[3][4] = { // indices of verices of each face in verts; see vol_hexa
+    // lower-x face, lll, lul, luu, llu; v(p1->p2)=ey
+    {0, 3, 7, 4},
+    // lower-y face, lll, llu, ulu, ull; v(p1->p2)=ez
+    {0, 4, 5, 1},
+    // lower-z face, lll, ull, uul, lul; v(p1->p2)=ex
+    {0, 1, 2, 3}
+  };
+  for (int face_idx = 0; face_idx < 3; ++face_idx)
+  {
+    int ip1 = pt_idx[face_idx][0];
+    int ip2 = pt_idx[face_idx][1];
+    int ip3 = pt_idx[face_idx][2];
+    int ip4 = pt_idx[face_idx][3];
+
+    struct gkyl_vec3 norm, tau1, tau2;
+    double area= quad_area_norm_tang(
+        verts[ip1], verts[ip2], verts[ip3], verts[ip4], &norm, &tau1, &tau2);
+    double cell_area_c = cell_vol_c / dx[face_idx];
+    geo->lenr[face_idx] = area / cell_area_c;
+    for (int d=0; d<3; ++d)
+    {
+      geo->norm[face_idx][d] = norm.x[d];
+      geo->tau1[face_idx][d] = tau1.x[d];
+      geo->tau2[face_idx][d] = tau2.x[d];
+    }
+  }
 }
 
 struct gkyl_wave_geom*


### PR DESCRIPTION
# Consolidating `calc_geom_3d`

### Important facts
- The tangent vector definitions are not consistent with those used in `calc_geom_2d`.
  - Presently, in `calc_geom_2d`, for the bottom edge, `norm`, `tau2`, tau2` point to `+y`, `+x`, `-z`.
  - In this PR,  `calc_geom_3d` is designed so  that for the lower-y face has `norm`, `tau2`, `tau2` point to `+y`, `+z`, `+x`. This way, the three lower faces in x, y, and z can be handled in the same way but just with a shuffle.
  -  I'm not sure if this is consistent with `wave_prop` in dimensional splitting (needs to check the rotation direction, etc.). This could be easily controlled, though, by shuffling the order of vertices used to define these faces.
- The hexahedron volume calculation only handles "good" cells. It divides the hexahedron into five tetrahedrons.
- The cell face quad norm and area calculation uses the [varignon](https://math.stackexchange.com/a/2919201) projection. But other options are possible if we encounter performance/accuracy issues. Tests of present implementation is consistent with the area and norm computed by vtk internal algorithms for non-planar quads.

#### Division of the hexahedron
In the following image, the upper left panel is the original hexahedron, the rest are constituting tetrahedrons.
<img src="https://user-images.githubusercontent.com/1000547/159135147-861412fc-5885-43ae-b7ad-adaa62b45c92.png" alt="drawing" width="300"/>

### Unit tests
I still don't have a nontrivial unit test for `calc_geom_3d`, but its components are tested in `ctest_wave_geom_helpers.c`. Also, a trivial test of a cube is included in `ctest_wave_geom.c`.