### PR TITLE
Array shiftc0

### DIFF
--- a/unit/ctest_array.c
+++ b/unit/ctest_array.c
@@ -1490,7 +1490,7 @@ void test_cu_array_shiftc0()
   // copy host arrays to device
   gkyl_array_copy(a1_cu, a1);
 
-  gkyl_array_shift(a1_cu, s);
+  gkyl_array_shiftc0(a1_cu, s);
 
   // copy from device and check if things are ok
   gkyl_array_copy(a1, a1_cu);

--- a/unit/ctest_array.c
+++ b/unit/ctest_array.c
@@ -318,6 +318,27 @@ void test_array_scale_by_cell()
   gkyl_array_release(s);
 }
 
+void test_array_shiftc0()
+{
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 3, 10);
+
+  double s = -0.5;
+  double *a1_d = a1->data;
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (size_t k=0; k<a1->ncomp; ++k) a1_d[i*a1->ncomp+k] = i*2.0+k;
+  }
+
+  gkyl_array_shiftc0(a1, s);
+
+  TEST_CHECK( gkyl_compare(a1_d[0], 0*1.0+0-0.5, 1e-14) );
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (size_t k=1; k<a1->ncomp; ++k) 
+      TEST_CHECK( gkyl_compare(a1_d[i*a1->ncomp+k], i*2.0+k, 1e-14) );
+  }
+
+  gkyl_array_release(a1);
+}
+
 void test_array_opcombine()
 {
   struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 1, 10);  
@@ -1452,6 +1473,37 @@ void test_cu_array_scale_by_cell()
   gkyl_array_release(s_cu);
 }
 
+void test_cu_array_shiftc0()
+{
+  double s = -0.5;
+
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 3, 10);
+  // make device copies
+  struct gkyl_array *a1_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 3, 10);
+
+  // initialize data
+  double *a1_d  = a1->data;
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (size_t k=0; k<a1->ncomp; ++k) a1_d[i*a1->ncomp+k] = i*2.0+k;
+  }
+
+  // copy host arrays to device
+  gkyl_array_copy(a1_cu, a1);
+
+  gkyl_array_shift(a1_cu, s);
+
+  // copy from device and check if things are ok
+  gkyl_array_copy(a1, a1_cu);
+  TEST_CHECK( gkyl_compare(a1_d[0], 0*1.0+0-0.5, 1e-14) );
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (size_t k=1; k<a1->ncomp; ++k)
+      TEST_CHECK( gkyl_compare(a1_d[i*a1->ncomp+k], i*2.0+k, 1e-14) );
+  }
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a1_cu);
+}
+
 void test_cu_array_copy_buffer()
 {
   int shape[] = {10, 20};
@@ -1705,6 +1757,7 @@ TEST_LIST = {
   { "array_set_range", test_array_set_range },
   { "array_scale", test_array_scale },
   { "array_scale_by_cell", test_array_scale_by_cell },
+  { "array_shiftc0", test_array_shiftc0 },
   { "array_opcombine", test_array_opcombine },
   { "array_ops_comp", test_array_ops_comp },
   { "array_copy_buffer", test_array_copy_buffer },
@@ -1733,6 +1786,7 @@ TEST_LIST = {
   { "cu_array_set_range", test_cu_array_set_range },
   { "cu_array_scale", test_cu_array_scale },
   { "cu_array_scale_by_cell", test_cu_array_scale_by_cell },
+  { "cu_array_shiftc0", test_cu_array_shiftc0 },
   { "cu_array_copy_buffer", test_cu_array_copy_buffer },
   { "cu_array_copy_buffer_fn", test_cu_array_copy_buffer_fn },
   { "cu_array_flip_copy_buffer_fn", test_cu_array_flip_copy_buffer_fn },

--- a/zero/array_ops.c
+++ b/zero/array_ops.c
@@ -96,6 +96,20 @@ gkyl_array_scale_by_cell(struct gkyl_array* out, const struct gkyl_array* a)
   return out;
 }
 
+struct gkyl_array*
+gkyl_array_shiftc0(struct gkyl_array* out, double a)
+{
+  assert(out->type == GKYL_DOUBLE);
+#ifdef GKYL_HAVE_CUDA
+  if (gkyl_array_is_cu_dev(out)) { gkyl_array_shiftc0_cu(out, a); return out; }
+#endif
+
+  double *out_d = out->data;
+  for (size_t i=0; i<out->size; ++i)
+    out_d[i*out->ncomp] = a+out_d[i*out->ncomp];
+  return out;
+}
+
 void 
 gkyl_array_reduce(double *out, const struct gkyl_array *arr, enum gkyl_array_op op)
 {

--- a/zero/array_ops_cu.cu
+++ b/zero/array_ops_cu.cu
@@ -70,6 +70,14 @@ gkyl_array_scale_by_cell_cu_kernel(struct gkyl_array* out, const struct gkyl_arr
     out_d[linc] = a_d[linc/out->ncomp]*out_d[linc];
 } 
 
+__global__ void
+gkyl_array_shiftc0_cu_kernel(struct gkyl_array* out, double a)
+{
+  double *out_d = (double*) out->data;
+  for (unsigned long linc = START_ID; linc < NSIZE(out); linc += blockDim.x*gridDim.x)
+    out_d[linc*out->ncomp] = a+out_d[linc*out->ncomp];
+} 
+
 // Host-side wrappers for array operations
 void
 gkyl_array_clear_cu(struct gkyl_array* out, double val)
@@ -99,6 +107,12 @@ void
 gkyl_array_scale_by_cell_cu(struct gkyl_array* out, const struct gkyl_array* a)
 {
   gkyl_array_scale_by_cell_cu_kernel<<<out->nblocks, out->nthreads>>>(out->on_dev, a->on_dev);
+}
+
+void
+gkyl_array_shiftc0_cu(struct gkyl_array* out, double a)
+{
+  gkyl_array_shiftc0_cu_kernel<<<out->nblocks, out->nthreads>>>(out->on_dev, a);
 }
 
 // Range-based methods

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -85,6 +85,15 @@ struct gkyl_array* gkyl_array_scale(struct gkyl_array *out, double a);
 struct gkyl_array* gkyl_array_scale_by_cell(struct gkyl_array *out, const struct gkyl_array *a);
 
 /**
+ * Shift the zeroth coefficient in every cell, out_0 = a+out_0. Returns out.
+ *
+ * @param out Output array.
+ * @param a Factor to shift 0th coefficient by.
+ * @return out array.
+ */
+struct gkyl_array* gkyl_array_shiftc0(struct gkyl_array *out, double a);
+
+/**
  * Clear out = val. Returns out.
  *
  * @param out Output array

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -246,6 +246,8 @@ void gkyl_array_scale_cu(struct gkyl_array* out, double a);
 
 void gkyl_array_scale_by_cell_cu(struct gkyl_array* out, const struct gkyl_array* a);
 
+void gkyl_array_shiftc0_cu(struct gkyl_array* out, double a);
+
 /**
  * Host-side wrappers for range-based array operations
  */


### PR DESCRIPTION
method to shift the 0th component of an array by a constant.

This is intended for shifting DG fields by some constant. The user needs to make sure the normalization of the constant is computed correctly.

unit tests pass on CPU & GPU