### PR TITLE
Add more boundary conditions to bc_basic for G0-G2 merge

### DIFF
--- a/apps/gkyl_vlasov.h
+++ b/apps/gkyl_vlasov.h
@@ -131,7 +131,7 @@ struct gkyl_vlasov_fluid_species {
   struct gkyl_vlasov_fluid_diffusion diffusion;
   
   // boundary conditions
-  enum gkyl_fluid_species_bc_type bcx[2], bcy[2], bcz[2];
+  enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
 };
 
 // Top-level app parameters

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -12,6 +12,7 @@
 #include <gkyl_array_ops.h>
 #include <gkyl_array_reduce.h>
 #include <gkyl_array_rio.h>
+#include <gkyl_bc_basic.h>
 #include <gkyl_dg_advection.h>
 #include <gkyl_dg_bin_ops.h>
 #include <gkyl_dg_diffusion.h>
@@ -234,10 +235,9 @@ struct vm_field {
 
   // boundary conditions on lower/upper edges in each direction  
   enum gkyl_field_bc_type lower_bc[3], upper_bc[3];
-  // Note: we need to store pointers to the struct as these may
-  // actually be on the GPUs. Seems ugly, but I am not sure how else
-  // to ensure the function and context lives on the GPU
-  struct gkyl_array_copy_func *wall_bc_func[3]; // for wall BCs
+  // Pointers to updaters that apply BC.
+  struct gkyl_bc_basic *bc_lo[3];
+  struct gkyl_bc_basic *bc_up[3];
 
   double* omegaCfl_ptr;
 };

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -268,12 +268,10 @@ struct vm_fluid_species {
   gkyl_hyper_dg *advect_slvr; // Fluid equation solver
   gkyl_hyper_dg *diff_slvr; // Fluid equation solver
 
-  // boundary conditions on lower/upper edges in each direction  
-  enum gkyl_fluid_species_bc_type lower_bc[3], upper_bc[3];
-  // Note: we need to store pointers to the struct as these may
-  // actually be on the GPUs. Seems ugly, but I am not sure how else
-  // to ensure the function and context lives on the GPU
-  struct gkyl_array_copy_func *absorb_bc_func[3]; // for absorbing BCs
+  enum gkyl_species_bc_type lower_bc[3], upper_bc[3];
+  // Pointers to updaters that apply BC.
+  struct gkyl_bc_basic *bc_lo[3];
+  struct gkyl_bc_basic *bc_up[3];
 
   // specified advection
   bool has_advect; // flag to indicate there is applied advection

--- a/apps/vm_field.c
+++ b/apps/vm_field.c
@@ -89,8 +89,8 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
     ghost[d] = 1;
   
   for (int d=0; d<app->cdim; ++d) {
-    // Lower BC updater.
-    enum gkyl_bc_basic_type bctype;
+    // Lower BC updater. Copy BCs by default.
+    enum gkyl_bc_basic_type bctype = GKYL_BC_COPY;
     if (f->lower_bc[d] == GKYL_FIELD_COPY)
       bctype = GKYL_BC_COPY;
     else if (f->lower_bc[d] == GKYL_FIELD_PEC_WALL)
@@ -98,7 +98,7 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
   
     f->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &app->local_ext, ghost, bctype,
                                     app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
-    // Upper BC updater.
+    // Upper BC updater. Copy BCs by default.
     if (f->upper_bc[d] == GKYL_FIELD_COPY)
       bctype = GKYL_BC_COPY;
     else if (f->upper_bc[d] == GKYL_FIELD_PEC_WALL)
@@ -255,12 +255,10 @@ vm_field_release(const gkyl_vlasov_app* app, struct vm_field *f)
   else {
     gkyl_free(f->omegaCfl_ptr);
   }
-
+  // Copy BCs are allocated by default. Need to free.
   for (int d=0; d<app->cdim; ++d) {
-    if (f->lower_bc[d]==GKYL_FIELD_COPY || f->lower_bc[d]==GKYL_FIELD_PEC_WALL)
-      gkyl_bc_basic_release(f->bc_lo[d]);
-    if (f->upper_bc[d]==GKYL_FIELD_COPY || f->upper_bc[d]==GKYL_FIELD_PEC_WALL)
-      gkyl_bc_basic_release(f->bc_up[d]);
+    gkyl_bc_basic_release(f->bc_lo[d]);
+    gkyl_bc_basic_release(f->bc_up[d]);
   }
 
   gkyl_free(f);

--- a/apps/vm_field.c
+++ b/apps/vm_field.c
@@ -6,6 +6,7 @@
 
 #include <gkyl_alloc.h>
 #include <gkyl_array_ops.h>
+#include <gkyl_bc_basic.h>
 #include <gkyl_dg_eqn.h>
 #include <gkyl_util.h>
 #include <gkyl_vlasov_priv.h>
@@ -82,9 +83,30 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
       f->upper_bc[dir] = bc[1];
     }
   }
-  for (int d=0; d<3; ++d)
-    f->wall_bc_func[d] = gkyl_maxwell_wall_bc_create(eqn, d,
-      app->basis_on_dev.confBasis);
+
+  int ghost[GKYL_MAX_DIM];
+  for (int d=0; d<app->cdim; ++d)
+    ghost[d] = 1;
+  
+  for (int d=0; d<app->cdim; ++d) {
+    // Lower BC updater.
+    enum gkyl_bc_basic_type bctype;
+    if (f->lower_bc[d] == GKYL_FIELD_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (f->lower_bc[d] == GKYL_FIELD_PEC_WALL)
+      bctype = GKYL_BC_MAXWELL_PEC;
+  
+    f->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &app->local_ext, ghost, bctype,
+                                    app->basis_on_dev.basis, app->cdim, app->use_gpu);
+    // Upper BC updater.
+    if (f->upper_bc[d] == GKYL_FIELD_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (f->upper_bc[d] == GKYL_FIELD_PEC_WALL)
+      bctype = GKYL_BC_MAXWELL_PEC;
+    
+    f->bc_up[d] = gkyl_bc_basic_new(d, GKYL_UPPER_EDGE, &app->local_ext, ghost, bctype,
+                                    app->basis_on_dev.basis, app->cdim, app->use_gpu);
+  }
 
   gkyl_dg_eqn_release(eqn);
 
@@ -156,44 +178,6 @@ vm_field_apply_periodic_bc(gkyl_vlasov_app *app, const struct vm_field *field,
   gkyl_array_copy_from_buffer(f, field->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
 }
 
-
-// Apply copy BCs on EM fields
-void
-vm_field_apply_copy_bc(gkyl_vlasov_app *app, const struct vm_field *field,
-  int dir, enum vm_domain_edge edge, struct gkyl_array *f)
-{
-  if (edge == VM_EDGE_LOWER) {
-    gkyl_array_copy_to_buffer(field->bc_buffer->data, f, app->skin_ghost.lower_skin[dir]);
-    gkyl_array_copy_from_buffer(f, field->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
-  }
-
-  if (edge == VM_EDGE_UPPER) {
-    gkyl_array_copy_to_buffer(field->bc_buffer->data, f, app->skin_ghost.upper_skin[dir]);
-    gkyl_array_copy_from_buffer(f, field->bc_buffer->data, app->skin_ghost.upper_ghost[dir]);
-  }
-}
-
-// Perfect electrical conductor
-void
-vm_field_apply_pec_bc(gkyl_vlasov_app *app, const struct vm_field *field,
-  int dir, enum vm_domain_edge edge, struct gkyl_array *f)
-{
-  
-  if (edge == VM_EDGE_LOWER) {
-    gkyl_array_copy_to_buffer_fn(field->bc_buffer->data, f, app->skin_ghost.lower_skin[dir],
-      field->wall_bc_func[dir]->on_dev
-    );
-    gkyl_array_copy_from_buffer(f, field->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
-  }
-
-  if (edge == VM_EDGE_UPPER) {
-    gkyl_array_copy_to_buffer_fn(field->bc_buffer->data, f, app->skin_ghost.upper_skin[dir],
-      field->wall_bc_func[dir]->on_dev
-    );
-    gkyl_array_copy_from_buffer(f, field->bc_buffer->data, app->skin_ghost.upper_ghost[dir]);
-  }  
-}
-
 // Determine which directions are periodic and which directions are copy,
 // and then apply boundary conditions for EM fields
 void
@@ -205,15 +189,13 @@ vm_field_apply_bc(gkyl_vlasov_app *app, const struct vm_field *field, struct gky
     vm_field_apply_periodic_bc(app, field, app->periodic_dirs[d], f);
     is_np_bc[app->periodic_dirs[d]] = 0;
   }
-  for (int d=0; d<cdim; ++d)
+  for (int d=0; d<cdim; ++d) {
     if (is_np_bc[d]) {
 
       switch (field->lower_bc[d]) {
         case GKYL_FIELD_COPY:
-          vm_field_apply_copy_bc(app, field, d, VM_EDGE_LOWER, f);
-          break;
         case GKYL_FIELD_PEC_WALL:
-          vm_field_apply_pec_bc(app, field, d, VM_EDGE_LOWER, f);
+          gkyl_bc_basic_advance(field->bc_lo[d], field->bc_buffer, f);
           break;
         default:
           break;
@@ -221,15 +203,14 @@ vm_field_apply_bc(gkyl_vlasov_app *app, const struct vm_field *field, struct gky
 
       switch (field->upper_bc[d]) {
         case GKYL_FIELD_COPY:
-          vm_field_apply_copy_bc(app, field, d, VM_EDGE_UPPER, f);
-          break;
         case GKYL_FIELD_PEC_WALL:
-          vm_field_apply_pec_bc(app, field, d, VM_EDGE_UPPER, f);
+          gkyl_bc_basic_advance(field->bc_up[d], field->bc_buffer, f);
           break;
         default:
-          break;          
-      }      
+          break;
+      }   
     }
+  }
 }
 
 void
@@ -275,8 +256,12 @@ vm_field_release(const gkyl_vlasov_app* app, struct vm_field *f)
     gkyl_free(f->omegaCfl_ptr);
   }
 
-  for (int d=0; d<3; ++d)
-    gkyl_maxwell_bc_release(f->wall_bc_func[d]);
+  for (int d=0; d<app->cdim; ++d) {
+    if (f->lower_bc[d]==GKYL_FIELD_COPY || f->lower_bc[d]==GKYL_FIELD_PEC_WALL)
+      gkyl_bc_basic_release(f->bc_lo[d]);
+    if (f->upper_bc[d]==GKYL_FIELD_COPY || f->upper_bc[d]==GKYL_FIELD_PEC_WALL)
+      gkyl_bc_basic_release(f->bc_up[d]);
+  }
 
   gkyl_free(f);
 }

--- a/apps/vm_field.c
+++ b/apps/vm_field.c
@@ -97,7 +97,7 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
       bctype = GKYL_BC_MAXWELL_PEC;
   
     f->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &app->local_ext, ghost, bctype,
-                                    app->basis_on_dev.basis, app->cdim, app->use_gpu);
+                                    app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
     // Upper BC updater.
     if (f->upper_bc[d] == GKYL_FIELD_COPY)
       bctype = GKYL_BC_COPY;
@@ -105,7 +105,7 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
       bctype = GKYL_BC_MAXWELL_PEC;
     
     f->bc_up[d] = gkyl_bc_basic_new(d, GKYL_UPPER_EDGE, &app->local_ext, ghost, bctype,
-                                    app->basis_on_dev.basis, app->cdim, app->use_gpu);
+                                    app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
   }
 
   gkyl_dg_eqn_release(eqn);

--- a/apps/vm_fluid_species.c
+++ b/apps/vm_fluid_species.c
@@ -145,8 +145,8 @@ vm_fluid_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm
     ghost[d] = 1;
   
   for (int d=0; d<app->cdim; ++d) {
-    // Lower BC updater.
-    enum gkyl_bc_basic_type bctype;
+    // Lower BC updater. Copy BCs by default.
+    enum gkyl_bc_basic_type bctype = GKYL_BC_COPY;
     if (f->lower_bc[d] == GKYL_SPECIES_COPY)
       bctype = GKYL_BC_COPY;
     else if (f->lower_bc[d] == GKYL_SPECIES_ABSORB)
@@ -154,7 +154,7 @@ vm_fluid_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm
   
     f->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &app->local_ext, ghost, bctype,
                                     app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
-    // Upper BC updater.
+    // Upper BC updater. Copy BCs by default.
     if (f->upper_bc[d] == GKYL_SPECIES_COPY)
       bctype = GKYL_BC_COPY;
     else if (f->upper_bc[d] == GKYL_SPECIES_ABSORB)
@@ -367,10 +367,9 @@ vm_fluid_species_release(const gkyl_vlasov_app* app, struct vm_fluid_species *f)
   else {
     gkyl_free(f->omegaCfl_ptr);
   }
+  // Copy BCs are allocated by default. Need to free.
   for (int d=0; d<app->cdim; ++d) {
-    if (f->lower_bc[d]==GKYL_SPECIES_ABSORB || f->lower_bc[d]==GKYL_SPECIES_COPY)
       gkyl_bc_basic_release(f->bc_lo[d]);
-    if (f->upper_bc[d]==GKYL_SPECIES_ABSORB || f->upper_bc[d]==GKYL_SPECIES_COPY)
       gkyl_bc_basic_release(f->bc_up[d]);
   }
 }

--- a/apps/vm_fluid_species.c
+++ b/apps/vm_fluid_species.c
@@ -127,7 +127,7 @@ vm_fluid_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm
 
   for (int dir=0; dir<app->cdim; ++dir) {
     if (is_np[dir]) {
-      const enum gkyl_fluid_species_bc_type *bc;
+      const enum gkyl_species_bc_type *bc;
       if (dir == 0)
         bc = f->info.bcx;
       else if (dir == 1)
@@ -139,9 +139,30 @@ vm_fluid_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm
       f->upper_bc[dir] = bc[1];
     }
   }
-  for (int d=0; d<3; ++d)
-    f->absorb_bc_func[d] = gkyl_advection_absorb_bc_create(f->advect_eqn, d,
-      app->basis_on_dev.confBasis);
+
+  int ghost[GKYL_MAX_DIM];
+  for (int d=0; d<app->cdim; ++d)
+    ghost[d] = 1;
+  
+  for (int d=0; d<app->cdim; ++d) {
+    // Lower BC updater.
+    enum gkyl_bc_basic_type bctype;
+    if (f->lower_bc[d] == GKYL_SPECIES_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (f->lower_bc[d] == GKYL_SPECIES_ABSORB)
+      bctype = GKYL_BC_ABSORB;
+  
+    f->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &app->local_ext, ghost, bctype,
+                                    app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
+    // Upper BC updater.
+    if (f->upper_bc[d] == GKYL_SPECIES_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (f->upper_bc[d] == GKYL_SPECIES_ABSORB)
+      bctype = GKYL_BC_ABSORB;
+    
+    f->bc_up[d] = gkyl_bc_basic_new(d, GKYL_UPPER_EDGE, &app->local_ext, ghost, bctype,
+                                    app->basis_on_dev.confBasis, app->cdim, app->use_gpu);
+  }  
 }
 
 void
@@ -259,44 +280,6 @@ vm_fluid_species_apply_periodic_bc(gkyl_vlasov_app *app, const struct vm_fluid_s
   gkyl_array_copy_from_buffer(f, fluid_species->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
 }
 
-
-// Apply copy BCs on fluid species
-void
-vm_fluid_species_apply_copy_bc(gkyl_vlasov_app *app, const struct vm_fluid_species *fluid_species,
-  int dir, enum vm_domain_edge edge, struct gkyl_array *f)
-{
-  if (edge == VM_EDGE_LOWER) {
-    gkyl_array_copy_to_buffer(fluid_species->bc_buffer->data, f, app->skin_ghost.lower_skin[dir]);
-    gkyl_array_copy_from_buffer(f, fluid_species->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
-  }
-
-  if (edge == VM_EDGE_UPPER) {
-    gkyl_array_copy_to_buffer(fluid_species->bc_buffer->data, f, app->skin_ghost.upper_skin[dir]);
-    gkyl_array_copy_from_buffer(f, fluid_species->bc_buffer->data, app->skin_ghost.upper_ghost[dir]);
-  }
-}
-
-// Apply absorbing BCs on fluid species
-void
-vm_fluid_species_apply_absorb_bc(gkyl_vlasov_app *app, const struct vm_fluid_species *fluid_species,
-  int dir, enum vm_domain_edge edge, struct gkyl_array *f)
-{
-  
-  if (edge == VM_EDGE_LOWER) {
-    gkyl_array_copy_to_buffer_fn(fluid_species->bc_buffer->data, f, app->skin_ghost.lower_skin[dir],
-      fluid_species->absorb_bc_func[dir]->on_dev
-    );
-    gkyl_array_copy_from_buffer(f, fluid_species->bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
-  }
-
-  if (edge == VM_EDGE_UPPER) {
-    gkyl_array_copy_to_buffer_fn(fluid_species->bc_buffer->data, f, app->skin_ghost.upper_skin[dir],
-      fluid_species->absorb_bc_func[dir]->on_dev
-    );
-    gkyl_array_copy_from_buffer(f, fluid_species->bc_buffer->data, app->skin_ghost.upper_ghost[dir]);
-  }  
-}
-
 // Determine which directions are periodic and which directions are copy,
 // and then apply boundary conditions for fluid species
 void
@@ -312,20 +295,30 @@ vm_fluid_species_apply_bc(gkyl_vlasov_app *app, const struct vm_fluid_species *f
     if (is_np_bc[d]) {
 
       switch (fluid_species->lower_bc[d]) {
-        case GKYL_FLUID_SPECIES_COPY:
-          vm_fluid_species_apply_copy_bc(app, fluid_species, d, VM_EDGE_LOWER, f);
+        case GKYL_SPECIES_COPY:
+        case GKYL_SPECIES_ABSORB:
+          gkyl_bc_basic_advance(fluid_species->bc_lo[d], fluid_species->bc_buffer, f);
           break;
-        case GKYL_FLUID_SPECIES_ABSORB:
-          vm_fluid_species_apply_absorb_bc(app, fluid_species, d, VM_EDGE_LOWER, f);
+        case GKYL_SPECIES_REFLECT:
+        case GKYL_SPECIES_NO_SLIP:
+        case GKYL_SPECIES_WEDGE:
+          assert(false);
+          break;
+        default:
           break;
       }
 
       switch (fluid_species->upper_bc[d]) {
-        case GKYL_FLUID_SPECIES_COPY:
-          vm_fluid_species_apply_copy_bc(app, fluid_species, d, VM_EDGE_UPPER, f);
+        case GKYL_SPECIES_COPY:
+        case GKYL_SPECIES_ABSORB:
+          gkyl_bc_basic_advance(fluid_species->bc_up[d], fluid_species->bc_buffer, f);
           break;
-        case GKYL_FLUID_SPECIES_ABSORB:
-          vm_fluid_species_apply_absorb_bc(app, fluid_species, d, VM_EDGE_UPPER, f);
+        case GKYL_SPECIES_REFLECT:
+        case GKYL_SPECIES_NO_SLIP:
+        case GKYL_SPECIES_WEDGE:
+          assert(false);
+          break;
+        default:
           break;
       }      
     }
@@ -374,7 +367,11 @@ vm_fluid_species_release(const gkyl_vlasov_app* app, struct vm_fluid_species *f)
   else {
     gkyl_free(f->omegaCfl_ptr);
   }
-  for (int d=0; d<3; ++d)
-    gkyl_advection_bc_release(f->absorb_bc_func[d]);
+  for (int d=0; d<app->cdim; ++d) {
+    if (f->lower_bc[d]==GKYL_SPECIES_ABSORB || f->lower_bc[d]==GKYL_SPECIES_COPY)
+      gkyl_bc_basic_release(f->bc_lo[d]);
+    if (f->upper_bc[d]==GKYL_SPECIES_ABSORB || f->upper_bc[d]==GKYL_SPECIES_COPY)
+      gkyl_bc_basic_release(f->bc_up[d]);
+  }
 }
 

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -326,8 +326,8 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
     }
   }
   for (int d=0; d<app->cdim; ++d) {
-    // Lower BC updater.
-    enum gkyl_bc_basic_type bctype;
+    // Lower BC updater. Copy BCs by default.
+    enum gkyl_bc_basic_type bctype = GKYL_BC_COPY;
     if (s->lower_bc[d] == GKYL_SPECIES_COPY)
       bctype = GKYL_BC_COPY;
     else if (s->lower_bc[d] == GKYL_SPECIES_REFLECT)
@@ -337,7 +337,7 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
   
     s->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &s->local_ext, ghost, bctype,
                                     app->basis_on_dev.basis, app->cdim, app->use_gpu);
-    // Upper BC updater.
+    // Upper BC updater. Copy BCs by default.
     if (s->upper_bc[d] == GKYL_SPECIES_COPY)
       bctype = GKYL_BC_COPY;
     else if (s->upper_bc[d] == GKYL_SPECIES_REFLECT)
@@ -633,12 +633,10 @@ vm_species_release(const gkyl_vlasov_app* app, const struct vm_species *s)
 
   if (s->calc_bflux)
     vm_species_bflux_release(app, &s->bflux);
-
+  // Copy BCs are allocated by default. Need to free.
   for (int d=0; d<app->cdim; ++d) {
-    if (s->lower_bc[d]==GKYL_SPECIES_REFLECT || s->lower_bc[d]==GKYL_SPECIES_ABSORB || s->lower_bc[d]==GKYL_SPECIES_COPY)
-      gkyl_bc_basic_release(s->bc_lo[d]);
-    if (s->upper_bc[d]==GKYL_SPECIES_REFLECT || s->upper_bc[d]==GKYL_SPECIES_ABSORB || s->upper_bc[d]==GKYL_SPECIES_COPY)
-      gkyl_bc_basic_release(s->bc_up[d]);
+    gkyl_bc_basic_release(s->bc_lo[d]);
+    gkyl_bc_basic_release(s->bc_up[d]);
   }
   
   if (app->use_gpu) {

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -6,12 +6,12 @@
 #include <gkyl_app.h>
 #include <gkyl_array.h>
 #include <gkyl_array_ops.h>
+#include <gkyl_bc_basic.h>
 #include <gkyl_dynvec.h>
 #include <gkyl_elem_type.h>
 #include <gkyl_eqn_type.h>
 #include <gkyl_proj_on_basis.h>
 #include <gkyl_vlasov_priv.h>
-#include <gkyl_bc_basic.h>
 #include <time.h>
 
 // Projection functions for p/(m*gamma) = v in special relativistic systems
@@ -328,19 +328,23 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
   for (int d=0; d<app->cdim; ++d) {
     // Lower BC updater.
     enum gkyl_bc_basic_type bctype;
-    if (s->lower_bc[d] == GKYL_SPECIES_REFLECT) {
+    if (s->lower_bc[d] == GKYL_SPECIES_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (s->lower_bc[d] == GKYL_SPECIES_REFLECT)
       bctype = GKYL_BC_REFLECT;
-    } else if (s->lower_bc[d] == GKYL_SPECIES_ABSORB) {
+    else if (s->lower_bc[d] == GKYL_SPECIES_ABSORB)
       bctype = GKYL_BC_ABSORB;
-    }
+  
     s->bc_lo[d] = gkyl_bc_basic_new(d, GKYL_LOWER_EDGE, &s->local_ext, ghost, bctype,
                                     app->basis_on_dev.basis, app->cdim, app->use_gpu);
     // Upper BC updater.
-    if (s->upper_bc[d] == GKYL_SPECIES_REFLECT) {
+    if (s->upper_bc[d] == GKYL_SPECIES_COPY)
+      bctype = GKYL_BC_COPY;
+    else if (s->upper_bc[d] == GKYL_SPECIES_REFLECT)
       bctype = GKYL_BC_REFLECT;
-    } else if (s->upper_bc[d] == GKYL_SPECIES_ABSORB) {
+    else if (s->upper_bc[d] == GKYL_SPECIES_ABSORB)
       bctype = GKYL_BC_ABSORB;
-    }
+    
     s->bc_up[d] = gkyl_bc_basic_new(d, GKYL_UPPER_EDGE, &s->local_ext, ghost, bctype,
                                     app->basis_on_dev.basis, app->cdim, app->use_gpu);
   }
@@ -500,13 +504,13 @@ vm_species_apply_bc(gkyl_vlasov_app *app, const struct vm_species *species, stru
 
       switch (species->lower_bc[d]) {
         case GKYL_SPECIES_COPY:
-          vm_species_apply_copy_bc(app, species, d, VM_EDGE_LOWER, f);
-          break;
         case GKYL_SPECIES_REFLECT:
-          gkyl_bc_basic_advance(species->bc_lo[d], species->bc_buffer, f);
-          break;
         case GKYL_SPECIES_ABSORB:
           gkyl_bc_basic_advance(species->bc_lo[d], species->bc_buffer, f);
+          break;
+        case GKYL_SPECIES_NO_SLIP:
+        case GKYL_SPECIES_WEDGE:
+          assert(false);
           break;
         default:
           break;
@@ -514,13 +518,13 @@ vm_species_apply_bc(gkyl_vlasov_app *app, const struct vm_species *species, stru
 
       switch (species->upper_bc[d]) {
         case GKYL_SPECIES_COPY:
-          vm_species_apply_copy_bc(app, species, d, VM_EDGE_UPPER, f);
-          break;
         case GKYL_SPECIES_REFLECT:
-          gkyl_bc_basic_advance(species->bc_up[d], species->bc_buffer, f);
-          break;
         case GKYL_SPECIES_ABSORB:
           gkyl_bc_basic_advance(species->bc_up[d], species->bc_buffer, f);
+          break;
+        case GKYL_SPECIES_NO_SLIP:
+        case GKYL_SPECIES_WEDGE:
+          assert(false);
           break;
         default:
           break;
@@ -631,9 +635,9 @@ vm_species_release(const gkyl_vlasov_app* app, const struct vm_species *s)
     vm_species_bflux_release(app, &s->bflux);
 
   for (int d=0; d<app->cdim; ++d) {
-    if (s->lower_bc[d]==GKYL_SPECIES_REFLECT || s->lower_bc[d]==GKYL_SPECIES_ABSORB)
+    if (s->lower_bc[d]==GKYL_SPECIES_REFLECT || s->lower_bc[d]==GKYL_SPECIES_ABSORB || s->lower_bc[d]==GKYL_SPECIES_COPY)
       gkyl_bc_basic_release(s->bc_lo[d]);
-    if (s->upper_bc[d]==GKYL_SPECIES_REFLECT || s->upper_bc[d]==GKYL_SPECIES_ABSORB)
+    if (s->upper_bc[d]==GKYL_SPECIES_REFLECT || s->upper_bc[d]==GKYL_SPECIES_ABSORB || s->upper_bc[d]==GKYL_SPECIES_COPY)
       gkyl_bc_basic_release(s->bc_up[d]);
   }
   

--- a/regression/rt_mirror_lorentzian_1x1v_p_perp.c
+++ b/regression/rt_mirror_lorentzian_1x1v_p_perp.c
@@ -230,7 +230,7 @@ main(int argc, char **argv)
 
     .advection = {.advect_with = "elc", .collision_id = GKYL_LBO_COLLISIONS},
 
-    .bcx = { GKYL_FLUID_SPECIES_ABSORB, GKYL_FLUID_SPECIES_ABSORB },
+    .bcx = { GKYL_SPECIES_ABSORB, GKYL_SPECIES_ABSORB },
   };  
   
   // electrons
@@ -277,7 +277,7 @@ main(int argc, char **argv)
 
     .advection = {.advect_with = "ion", .collision_id = GKYL_LBO_COLLISIONS},
 
-    .bcx = { GKYL_FLUID_SPECIES_ABSORB, GKYL_FLUID_SPECIES_ABSORB },
+    .bcx = { GKYL_SPECIES_ABSORB, GKYL_SPECIES_ABSORB },
   };  
   
   // ions

--- a/zero/bc_basic.c
+++ b/zero/bc_basic.c
@@ -20,6 +20,10 @@ gkyl_bc_basic_create_arr_copy_func(int dir, int cdim, enum gkyl_bc_basic_type bc
 
   struct gkyl_array_copy_func *fout = (struct gkyl_array_copy_func*) gkyl_malloc(sizeof(struct gkyl_array_copy_func));
   switch (bctype) {
+    case GKYL_BC_COPY:
+      fout->func = copy_bc;
+      break;
+      
     case GKYL_BC_ABSORB:
       fout->func = species_absorb_bc;
       break;
@@ -27,7 +31,11 @@ gkyl_bc_basic_create_arr_copy_func(int dir, int cdim, enum gkyl_bc_basic_type bc
     case GKYL_BC_REFLECT:
       fout->func = species_reflect_bc;
       break;
-
+    // Perfect electrical conductor
+    case GKYL_BC_MAXWELL_PEC:
+      fout->func = maxwell_pec_bc;
+      break;
+      
     default:
       assert(false);
       break;
@@ -72,7 +80,9 @@ gkyl_bc_basic_advance(const struct gkyl_bc_basic *up, struct gkyl_array *buff_ar
   // Apply BC in two steps:
   // 1) Copy skin to buffer while applying array_copy_func.
   switch (up->bctype) {
+    case GKYL_BC_COPY:
     case GKYL_BC_ABSORB:
+    case GKYL_BC_MAXWELL_PEC:
       gkyl_array_copy_to_buffer_fn(buff_arr->data, f_arr,
                                    up->skin_r, up->array_copy_func->on_dev);
       break;

--- a/zero/bc_basic_cu.cu
+++ b/zero/bc_basic_cu.cu
@@ -4,7 +4,7 @@ extern "C" {
 #include <gkyl_bc_basic.h>
 #include <gkyl_bc_basic_priv.h>
 #include <gkyl_alloc.h>
-// #include <gkyl_alloc_flags_priv.h>
+#include <gkyl_alloc_flags_priv.h>
 }
 
 __global__ static void
@@ -16,12 +16,20 @@ gkyl_bc_basic_create_set_cu_dev_ptrs(int dir, int cdim, enum gkyl_bc_basic_type 
   ctx->basis = basis;
 
   switch (bctype) {
+    case GKYL_BC_COPY:
+      fout->func = copy_bc;
+      break;
+
     case GKYL_BC_ABSORB:
       fout->func = species_absorb_bc;
       break;
 
     case GKYL_BC_REFLECT:
       fout->func = species_reflect_bc;
+      break;
+    // Perfect electrical conductor
+    case GKYL_BC_MAXWELL_PEC:
+      fout->func = maxwell_pec_bc;
       break;
 
     default:

--- a/zero/dg_maxwell.c
+++ b/zero/dg_maxwell.c
@@ -26,44 +26,6 @@ gkyl_maxwell_free(const struct gkyl_ref_count *ref)
   gkyl_free(maxwell);
 }
 
-struct gkyl_array_copy_func*
-gkyl_maxwell_wall_bc_create(const struct gkyl_dg_eqn *eqn, int dir, const struct gkyl_basis* cbasis)
-{
-#ifdef GKYL_HAVE_CUDA
-  if (gkyl_dg_eqn_is_cu_dev(eqn)) {
-    return gkyl_maxwell_wall_bc_create_cu(eqn->on_dev, dir, cbasis);
-  }
-#endif
-
-  struct dg_maxwell *maxwell = container_of(eqn, struct dg_maxwell, eqn);
-
-  struct dg_bc_ctx *ctx = (struct dg_bc_ctx*) gkyl_malloc(sizeof(struct dg_bc_ctx));
-  ctx->dir = dir;
-  ctx->basis = cbasis;
-
-  struct gkyl_array_copy_func *bc = (struct gkyl_array_copy_func*) gkyl_malloc(sizeof(struct gkyl_array_copy_func));
-  bc->func = maxwell->wall_bc;
-  bc->ctx = ctx;
-  bc->ctx_on_dev = bc->ctx;
-
-  bc->flags = 0;
-  GKYL_CLEAR_CU_ALLOC(bc->flags);
-  bc->on_dev = bc; // CPU eqn obj points to itself
-  return bc;
-}
-
-void
-gkyl_maxwell_bc_release(struct gkyl_array_copy_func* bc)
-{
-  if (gkyl_array_copy_func_is_cu_dev(bc)) {
-    gkyl_cu_free(bc->ctx_on_dev);
-    gkyl_cu_free(bc->on_dev);
-  }
-  gkyl_free(bc->ctx);
-  gkyl_free(bc);
-}
-
-
 struct gkyl_dg_eqn*
 gkyl_dg_maxwell_new(const struct gkyl_basis* cbasis,
   double lightSpeed, double elcErrorSpeedFactor, double mgnErrorSpeedFactor, bool use_gpu)
@@ -118,9 +80,6 @@ gkyl_dg_maxwell_new(const struct gkyl_basis* cbasis,
     maxwell->surf[1] = CK(surf_y_kernels, cdim, poly_order);
   if (cdim>2)
     maxwell->surf[2] = CK(surf_z_kernels, cdim, poly_order);
-
-  // setup pointer for wall BC function
-  maxwell->wall_bc = maxwell_wall_bc;
 
   // ensure non-NULL pointers 
   for (int i=0; i<cdim; ++i) assert(maxwell->surf[i]);

--- a/zero/dg_maxwell_cu.cu
+++ b/zero/dg_maxwell_cu.cu
@@ -11,46 +11,6 @@ extern "C" {
 
 #define CK(lst,cdim,poly_order) lst[cdim-1].kernels[poly_order]
 
-__global__ static void
-gkyl_maxwell_wall_bc_create_set_cu_dev_ptrs(const struct gkyl_dg_eqn *eqn, int dir,
-  const struct gkyl_basis* cbasis, struct dg_bc_ctx *ctx, struct gkyl_array_copy_func *bc)
-{
-  struct dg_maxwell *maxwell = container_of(eqn, struct dg_maxwell, eqn);
-
-  ctx->dir = dir;
-  ctx->basis = cbasis;
-
-  bc->func = maxwell->wall_bc;
-  bc->ctx = ctx;
-}
-
-struct gkyl_array_copy_func*
-gkyl_maxwell_wall_bc_create_cu(const struct gkyl_dg_eqn *eqn, int dir, const struct gkyl_basis* cbasis)
-{
-  // create host context and bc func structs
-  struct dg_bc_ctx *ctx = (struct dg_bc_ctx*) gkyl_malloc(sizeof(struct dg_bc_ctx));
-  struct gkyl_array_copy_func *bc = (struct gkyl_array_copy_func*) gkyl_malloc(sizeof(struct gkyl_array_copy_func));
-  bc->ctx = ctx;
-
-  bc->flags = 0;
-  GKYL_SET_CU_ALLOC(bc->flags);
-
-  // create device context and bc func structs
-  struct dg_bc_ctx *ctx_cu = (struct dg_bc_ctx*) gkyl_cu_malloc(sizeof(struct dg_bc_ctx));
-  struct gkyl_array_copy_func *bc_cu = (struct gkyl_array_copy_func*) gkyl_cu_malloc(sizeof(struct gkyl_array_copy_func));
-
-  gkyl_cu_memcpy(ctx_cu, ctx, sizeof(struct dg_bc_ctx), GKYL_CU_MEMCPY_H2D);
-  gkyl_cu_memcpy(bc_cu, bc, sizeof(struct gkyl_array_copy_func), GKYL_CU_MEMCPY_H2D);
-
-  bc->ctx_on_dev = ctx_cu;
-
-  gkyl_maxwell_wall_bc_create_set_cu_dev_ptrs<<<1,1>>>(eqn, dir, cbasis, ctx_cu, bc_cu);
-
-  // set parent on_dev pointer 
-  bc->on_dev = bc_cu;  
-  return bc;
-}
-
 __global__ void static
 dg_maxwell_set_cu_dev_ptrs(struct dg_maxwell* maxwell, enum gkyl_basis_type b_type, int cdim, int poly_order)
 {
@@ -88,9 +48,6 @@ dg_maxwell_set_cu_dev_ptrs(struct dg_maxwell* maxwell, enum gkyl_basis_type b_ty
     maxwell->surf[1] = CK(surf_y_kernels, cdim, poly_order);
   if (cdim>2)
     maxwell->surf[2] = CK(surf_z_kernels, cdim, poly_order);
-
-  // setup pointer for wall BC function
-  maxwell->wall_bc = maxwell_wall_bc;
 }
 
 struct gkyl_dg_eqn*

--- a/zero/gkyl_bc_basic.h
+++ b/zero/gkyl_bc_basic.h
@@ -5,7 +5,7 @@
 #include <gkyl_array.h>
 
 // BC types in this updater.
-enum gkyl_bc_basic_type { GKYL_BC_ABSORB, GKYL_BC_REFLECT };
+enum gkyl_bc_basic_type { GKYL_BC_COPY, GKYL_BC_ABSORB, GKYL_BC_REFLECT, GKYL_BC_MAXWELL_PEC };
 
 // Object type
 typedef struct gkyl_bc_basic gkyl_bc_basic;

--- a/zero/gkyl_bc_basic_priv.h
+++ b/zero/gkyl_bc_basic_priv.h
@@ -42,6 +42,15 @@ struct dg_bc_ctx {
 
 GKYL_CU_D
 static void
+copy_bc(size_t nc, double *out, const double *inp, void *ctx)
+{
+  struct dg_bc_ctx *mc = (struct dg_bc_ctx*) ctx;
+  int nbasis = mc->basis->num_basis;
+  for (int c=0; c<nbasis; ++c) out[c] = inp[c];
+}
+
+GKYL_CU_D
+static void
 species_absorb_bc(size_t nc, double *out, const double *inp, void *ctx)
 {
   struct dg_bc_ctx *mc = (struct dg_bc_ctx*) ctx;
@@ -60,3 +69,37 @@ species_reflect_bc(size_t nc, double *out, const double *inp, void *ctx)
   mc->basis->flip_odd_sign(dir+cdim, out, out);
 }
 
+enum { M_EX, M_EY, M_EZ, M_BX, M_BY, M_BZ }; // components of EM field
+GKYL_CU_D static const int m_flip_even[3][3] = { // zero tangent E and zero normal B
+  {M_BX, M_EY, M_EZ},
+  {M_BY, M_EX, M_EZ},
+  {M_BZ, M_EX, M_EY},
+};
+GKYL_CU_D static const int m_flip_odd[3][3] = { // zero gradient
+  { M_EX, M_BY, M_BZ },
+  { M_EY, M_BX, M_BZ },
+  { M_EZ, M_BX, M_BY },
+};
+
+// Perfect electrical conductor
+GKYL_CU_D
+static void
+maxwell_pec_bc(size_t nc, double *out, const double *inp, void *ctx)
+{
+  struct dg_bc_ctx *mc = (struct dg_bc_ctx*) ctx;
+  int dir = mc->dir;
+  int nbasis = mc->basis->num_basis;
+
+  const int *feven = m_flip_even[dir];
+  const int *fodd = m_flip_odd[dir];
+
+  for (int i=0; i<3; ++i) {
+    int eloc = nbasis*feven[i], oloc = nbasis*fodd[i];
+    mc->basis->flip_even_sign(dir, &inp[eloc], &out[eloc]);
+    mc->basis->flip_odd_sign(dir, &inp[oloc], &out[oloc]);
+  }
+  // correction potentials
+  int eloc = nbasis*6, oloc = nbasis*7;
+  mc->basis->flip_even_sign(dir, &inp[eloc], &out[eloc]);
+  mc->basis->flip_odd_sign(dir, &inp[oloc], &out[oloc]);
+}

--- a/zero/gkyl_dg_maxwell.h
+++ b/zero/gkyl_dg_maxwell.h
@@ -27,39 +27,3 @@ struct gkyl_dg_eqn* gkyl_dg_maxwell_new(const struct gkyl_basis* cbasis,
  */
 struct gkyl_dg_eqn* gkyl_dg_maxwell_cu_dev_new(const struct gkyl_basis* cbasis,
   double lightSpeed, double elcErrorSpeedFactor, double mgnErrorSpeedFactor);
-
-/**
- * Set up function to apply wall boundary conditions.
- * 
- * @param eqn Equation pointer.
- * @param dir Direction to apply wall boundary conditions.
- * @param cbasis basis
- * @return Pointer to array_copy_func which can be passed to array_copy_fn methods
- */
-
-struct gkyl_array_copy_func* gkyl_maxwell_wall_bc_create(const struct gkyl_dg_eqn *eqn, 
-  int dir, const struct gkyl_basis* cbasis);
-
-/**
- * Release wall boundary conditions function.
- * 
- * @param bc Pointer to array_copy_func.
- */
-
-void gkyl_maxwell_bc_release(struct gkyl_array_copy_func* bc);
-
-#ifdef GKYL_HAVE_CUDA
-
-/**
- * CUDA device function to set up function to apply wall boundary conditions.
- * 
- * @param eqn Equation pointer.
- * @param dir Direction to apply wall boundary conditions.
- * @param cbasis basis
- * @return Pointer to array_copy_func which can be passed to array_copy_fn methods
- */
-
-struct gkyl_array_copy_func* gkyl_maxwell_wall_bc_create_cu(const struct gkyl_dg_eqn *eqn, 
-  int dir, const struct gkyl_basis* cbasis);
-
-#endif

--- a/zero/gkyl_dg_maxwell_priv.h
+++ b/zero/gkyl_dg_maxwell_priv.h
@@ -7,26 +7,12 @@
 // private header for use in Maxwell DG equation object creation
 // functions
 
-enum { M_EX, M_EY, M_EZ, M_BX, M_BY, M_BZ }; // components of EM field
-GKYL_CU_D static const int m_flip_even[3][3] = { // zero tangent E and zero normal B
-  {M_BX, M_EY, M_EZ},
-  {M_BY, M_EX, M_EZ},
-  {M_BZ, M_EX, M_EY},
-};
-GKYL_CU_D static const int m_flip_odd[3][3] = { // zero gradient
-  { M_EX, M_BY, M_BZ },
-  { M_EY, M_BX, M_BZ },
-  { M_EZ, M_BX, M_BY },
-};
-
 // Types for various kernels
 typedef double (*maxwell_vol_t)(const gkyl_maxwell_inp *meq,
   const double *w, const double *dx, const double *q, double* GKYL_RESTRICT out);
 
 typedef void (*maxwell_surf_t)(const gkyl_maxwell_inp *meq, const double *w, const double *dx,
   const double *ql, const double *qc, const double *qr, double* GKYL_RESTRICT out);
-
-typedef void (*bc_funcf_t)(size_t nc, double *out, const double *inp, void *ctx);
 
 // for use in kernel tables
 typedef struct { maxwell_vol_t kernels[3]; } gkyl_dg_maxwell_vol_kern_list;
@@ -109,7 +95,6 @@ struct dg_maxwell {
   gkyl_maxwell_inp maxwell_data; // Parameters needed by kernels
   maxwell_vol_t vol; // pointer to volume kernel
   maxwell_surf_t surf[3]; // pointers to surface kernels
-  bc_funcf_t wall_bc; // wall BCs function
 };
 
 
@@ -153,26 +138,4 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
   const double* qInEdge, const double* qInSkin, double* GKYL_RESTRICT qRhsOut)
 {
   
-}
-
-GKYL_CU_D
-static void
-maxwell_wall_bc(size_t nc, double *out, const double *inp, void *ctx)
-{
-  struct dg_bc_ctx *mc = (struct dg_bc_ctx*) ctx;
-  int dir = mc->dir;
-  int nbasis = mc->basis->num_basis;
-
-  const int *feven = m_flip_even[dir];
-  const int *fodd = m_flip_odd[dir];
-
-  for (int i=0; i<3; ++i) {
-    int eloc = nbasis*feven[i], oloc = nbasis*fodd[i];
-    mc->basis->flip_even_sign(dir, &inp[eloc], &out[eloc]);
-    mc->basis->flip_odd_sign(dir, &inp[oloc], &out[oloc]);
-  }
-  // correction potentials
-  int eloc = nbasis*6, oloc = nbasis*7;
-  mc->basis->flip_even_sign(dir, &inp[eloc], &out[eloc]);
-  mc->basis->flip_odd_sign(dir, &inp[oloc], &out[oloc]);
 }


### PR DESCRIPTION
This branch puts copy BCs and Maxwell's equations perfect electrical conductor BC. Also cleans up the G0 app significantly now that all currently supported BCs (across Vlasov, fluids, and Maxwell's) are handled through bc_basic.