### PR TITLE
Clean up of mom_calc_bcorr and fix memory leaks

### DIFF
--- a/zero/gkyl_mom_calc_bcorr.h
+++ b/zero/gkyl_mom_calc_bcorr.h
@@ -19,10 +19,10 @@ typedef struct gkyl_mom_calc_bcorr gkyl_mom_calc_bcorr;
  * @param momt Moment type object for boundary correction
  */
 gkyl_mom_calc_bcorr* gkyl_mom_calc_bcorr_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_mom_type *momt, const char *space);
+  const struct gkyl_mom_type *momt);
 
 gkyl_mom_calc_bcorr* gkyl_mom_calc_bcorr_cu_dev_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_mom_type *momt, const char *space);
+  const struct gkyl_mom_type *momt);
 
 /**
  * Compute boundary correction moments.

--- a/zero/mom_calc_bcorr.c
+++ b/zero/mom_calc_bcorr.c
@@ -111,10 +111,11 @@ gkyl_mom_calc_bcorr_release(gkyl_mom_calc_bcorr* up)
 
 // "derived" class constructors
 gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary)
+gkyl_mom_calc_bcorr_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis,
+  const struct gkyl_basis* pbasis, const double* vBoundary)
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
-  bcorr_type = gkyl_mom_bcorr_lbo_vlasov_new(cbasis, pbasis, vBoundary);
+  bcorr_type = gkyl_mom_bcorr_lbo_vlasov_new(cbasis, pbasis, vBoundary);  
   struct gkyl_mom_calc_bcorr* calc = gkyl_mom_calc_bcorr_new(grid, bcorr_type);
   // Since calc now has pointer to specific type, decrease reference counter of type
   // so that eventual gkyl_mom_calc_bcorr_release method on calculator deallocates specific type data
@@ -123,7 +124,8 @@ gkyl_mom_calc_bcorr_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const stru
 }
 
 gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
+gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis,
+  const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
   bcorr_type = gkyl_mom_bcorr_lbo_gyrokinetic_new(cbasis, pbasis, vBoundary, mass);
@@ -135,7 +137,8 @@ gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(const struct gkyl_rect_grid *grid, const
 }
 
 gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_vlasov_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary)
+gkyl_mom_calc_bcorr_lbo_vlasov_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis,
+  const struct gkyl_basis* pbasis, const double* vBoundary)
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
   bcorr_type = gkyl_mom_bcorr_lbo_vlasov_cu_dev_new(cbasis, pbasis, vBoundary);
@@ -147,7 +150,8 @@ gkyl_mom_calc_bcorr_lbo_vlasov_cu_dev_new(const struct gkyl_rect_grid *grid, con
 }
 
 gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_gyrokinetic_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
+gkyl_mom_calc_bcorr_lbo_gyrokinetic_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis,
+  const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
   bcorr_type = gkyl_mom_bcorr_lbo_gyrokinetic_cu_dev_new(cbasis, pbasis, vBoundary, mass);

--- a/zero/mom_calc_bcorr.c
+++ b/zero/mom_calc_bcorr.c
@@ -12,93 +12,87 @@
 #include <gkyl_mom_bcorr_lbo_gyrokinetic.h>
 #include <gkyl_util.h>
 
+static inline void
+copy_idx_arrays(int cdim, int pdim, const int *cidx, const int *vidx, int *out)
+{
+  for (int i=0; i<cdim; ++i)
+    out[i] = cidx[i];
+  for (int i=cdim; i<pdim; ++i)
+    out[i] = vidx[i-cdim];
+}
+
 void
 gkyl_mom_calc_bcorr_advance(gkyl_mom_calc_bcorr *bcorr,
   const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
   const struct gkyl_array *GKYL_RESTRICT fIn, struct gkyl_array *GKYL_RESTRICT out)
 {
   double xc[GKYL_MAX_DIM];
-  struct gkyl_range edge_rng;
-  struct gkyl_range_iter conf_iter, edge_iter;
+  struct gkyl_range vel_rng;
+  struct gkyl_range_iter conf_iter, vel_iter;
   
-  int pidx[GKYL_MAX_DIM], eiter_idx[GKYL_MAX_DIM], rem_dir[GKYL_MAX_DIM] = { 0 };
-  int elower_idx[GKYL_MAX_DIM], eupper_idx[GKYL_MAX_DIM] = { 0 };
-  int conf_idx[GKYL_MAX_CDIM];
-  int dim_rng;
+  int pidx[GKYL_MAX_DIM], viter_idx[GKYL_MAX_DIM], rem_dir[GKYL_MAX_DIM] = { 0 };
   enum gkyl_vel_edge edge;
-
-  for (int dim=0; dim<phase_rng->ndim; ++dim) {
-    elower_idx[dim] = phase_rng->lower[dim];
-    eupper_idx[dim] = phase_rng->upper[dim];
-  }
-
-  gkyl_array_clear_range(out, 0.0, *conf_rng);
   
-  // iterate over either velocity space or configuration space
-  dim_rng = phase_rng->ndim - conf_rng->ndim;
-  if (bcorr->space == 0) {
-    dim_rng = conf_rng->ndim;
-  }
+  for (int d=0; d<conf_rng->ndim; ++d) rem_dir[d] = 1;
+  gkyl_array_clear_range(out, 0.0, *conf_rng);
 
-  for (int d=0; d<dim_rng; ++d) {
-    edge = d + GKYL_MAX_CDIM;
-    elower_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
-    gkyl_sub_range_init(&edge_rng, phase_rng, elower_idx, eupper_idx);
-    gkyl_range_iter_no_split_init(&edge_iter, &edge_rng);
-
-    while (gkyl_range_iter_next(&edge_iter)) {
-      gkyl_rect_grid_cell_center(&bcorr->grid, edge_iter.idx, xc);
-
-      for (int i=0; i<conf_rng->ndim; ++i) {
-        conf_idx[i] = edge_iter.idx[i];
-      }
-      long fidx = gkyl_range_idx(&edge_rng, edge_iter.idx);
-      long midx = gkyl_range_idx(conf_rng, conf_idx);
-      
-      gkyl_mom_type_calc(bcorr->momt, xc, bcorr->grid.dx, pidx,
-        gkyl_array_cfetch(fIn, fidx), gkyl_array_fetch(out, midx), &edge
-      );
-    }
-
-    edge = d;
-    elower_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    gkyl_sub_range_init(&edge_rng, phase_rng, elower_idx, eupper_idx);
-    gkyl_range_iter_no_split_init(&edge_iter, &edge_rng);
-
-    while (gkyl_range_iter_next(&edge_iter)) {
-      gkyl_rect_grid_cell_center(&bcorr->grid, edge_iter.idx, xc);
-
-      for (int i=0; i<conf_rng->ndim; ++i) {
-        conf_idx[i] = edge_iter.idx[i];
-      }
-      
-      long fidx = gkyl_range_idx(&edge_rng, edge_iter.idx);
-      long midx = gkyl_range_idx(conf_rng, conf_idx);
-       
-      gkyl_mom_type_calc(bcorr->momt, xc, bcorr->grid.dx, pidx,
-        gkyl_array_cfetch(fIn, fidx), gkyl_array_fetch(out, midx), &edge
-      );
-    }
+  // outer loop is over configuration space cells; for each
+  // config-space cell inner loop walks over the edges of velocity
+  // space
+  gkyl_range_iter_init(&conf_iter, conf_rng);
+  while (gkyl_range_iter_next(&conf_iter)) {
+    long midx = gkyl_range_idx(conf_rng, conf_iter.idx);
     
-    elower_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
+    for (int d=0; d<conf_rng->ndim; ++d)
+      viter_idx[d] = conf_iter.idx[d];
+    
+    for (int d=0; d<phase_rng->ndim - conf_rng->ndim; ++d) {
+      rem_dir[conf_rng->ndim + d] = 1;
+      
+      // loop over upper edge of velocity space
+      edge = d + GKYL_MAX_CDIM;
+      viter_idx[conf_rng->ndim + d] = phase_rng->upper[conf_rng->ndim + d];
+      gkyl_range_deflate(&vel_rng, phase_rng, rem_dir, viter_idx);
+      gkyl_range_iter_no_split_init(&vel_iter, &vel_rng);
+      
+      while (gkyl_range_iter_next(&vel_iter)) {
+        copy_idx_arrays(conf_rng->ndim, phase_rng->ndim, conf_iter.idx, vel_iter.idx, pidx);
+        gkyl_rect_grid_cell_center(&bcorr->grid, pidx, xc);
+      
+        long fidx = gkyl_range_idx(&vel_rng, vel_iter.idx);
+        gkyl_mom_type_calc(bcorr->momt, xc, bcorr->grid.dx, pidx,
+          gkyl_array_cfetch(fIn, fidx), gkyl_array_fetch(out, midx), &edge
+        );
+      }
+      
+      // loop over lower edge of velocity space
+      edge = d;
+      viter_idx[conf_rng->ndim + d] = phase_rng->lower[conf_rng->ndim + d];
+      gkyl_range_deflate(&vel_rng, phase_rng, rem_dir, viter_idx);
+      gkyl_range_iter_no_split_init(&vel_iter, &vel_rng);
+      
+      while (gkyl_range_iter_next(&vel_iter)) {
+        copy_idx_arrays(conf_rng->ndim, phase_rng->ndim, conf_iter.idx, vel_iter.idx, pidx);
+  
+        gkyl_rect_grid_cell_center(&bcorr->grid, pidx, xc);
+      
+        long fidx = gkyl_range_idx(&vel_rng, vel_iter.idx);
+        gkyl_mom_type_calc(bcorr->momt, xc, bcorr->grid.dx, pidx,
+          gkyl_array_cfetch(fIn, fidx), gkyl_array_fetch(out, midx), &edge
+        );
+      }
+      rem_dir[conf_rng->ndim + d] = 0;
+      viter_idx[conf_rng->ndim + d] = 0;
+    }
   }
 }
 
 gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_new(const struct gkyl_rect_grid *grid, const struct gkyl_mom_type *momt, const char *space)
+gkyl_mom_calc_bcorr_new(const struct gkyl_rect_grid *grid, const struct gkyl_mom_type *momt)
 {
   gkyl_mom_calc_bcorr *up = gkyl_malloc(sizeof(gkyl_mom_calc_bcorr));
   up->grid = *grid;
   up->momt = gkyl_mom_type_acquire(momt);
-  if (strcmp(space, "conf") == 0) {
-    up->space = 0;
-  } else {
-    up->space = momt->cdim;
-  }
-  
   up->flags = 0;
   GKYL_CLEAR_CU_ALLOC(up->flags);
   up->on_dev = up;
@@ -121,7 +115,11 @@ gkyl_mom_calc_bcorr_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const stru
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
   bcorr_type = gkyl_mom_bcorr_lbo_vlasov_new(cbasis, pbasis, vBoundary);
-  return gkyl_mom_calc_bcorr_new(grid, bcorr_type, "phase");
+  struct gkyl_mom_calc_bcorr* calc = gkyl_mom_calc_bcorr_new(grid, bcorr_type);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_mom_calc_bcorr_release method on calculator deallocates specific type data
+  gkyl_mom_type_release(bcorr_type);
+  return calc;
 }
 
 gkyl_mom_calc_bcorr*
@@ -129,33 +127,49 @@ gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(const struct gkyl_rect_grid *grid, const
 {
   struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
   bcorr_type = gkyl_mom_bcorr_lbo_gyrokinetic_new(cbasis, pbasis, vBoundary, mass);
-  return gkyl_mom_calc_bcorr_new(grid, bcorr_type, "phase");
-}
-
-#ifndef GKYL_HAVE_CUDA
-
-void
-gkyl_mom_calc_bcorr_advance_cu(gkyl_mom_calc_bcorr *bcorr,
-  const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
-  const struct gkyl_array *GKYL_RESTRICT fIn, struct gkyl_array *GKYL_RESTRICT out)
-{
-  assert(false);
-}
-
-gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_mom_type *momt, const char *space)
-{
-  assert(false);
+  struct gkyl_mom_calc_bcorr* calc = gkyl_mom_calc_bcorr_new(grid, bcorr_type);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_mom_calc_bcorr_release method on calculator deallocates specific type data
+  gkyl_mom_type_release(bcorr_type);
+  return calc;
 }
 
 gkyl_mom_calc_bcorr*
 gkyl_mom_calc_bcorr_lbo_vlasov_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary)
 {
-  assert(false);
+  struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
+  bcorr_type = gkyl_mom_bcorr_lbo_vlasov_cu_dev_new(cbasis, pbasis, vBoundary);
+  struct gkyl_mom_calc_bcorr* calc = gkyl_mom_calc_bcorr_cu_dev_new(grid, bcorr_type);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_mom_calc_bcorr_release method on calculator deallocates specific type data
+  gkyl_mom_type_release(bcorr_type);
+  return calc;
 }
 
 gkyl_mom_calc_bcorr*
 gkyl_mom_calc_bcorr_lbo_gyrokinetic_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
+{
+  struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
+  bcorr_type = gkyl_mom_bcorr_lbo_gyrokinetic_cu_dev_new(cbasis, pbasis, vBoundary, mass);
+  struct gkyl_mom_calc_bcorr* calc = gkyl_mom_calc_bcorr_cu_dev_new(grid, bcorr_type);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_mom_calc_bcorr_release method on calculator deallocates specific type data
+  gkyl_mom_type_release(bcorr_type);
+  return calc;
+}
+
+#ifndef GKYL_HAVE_CUDA
+
+gkyl_mom_calc_bcorr*
+gkyl_mom_calc_bcorr_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_mom_type *momt)
+{
+  assert(false);
+}
+
+void
+gkyl_mom_calc_bcorr_advance_cu(gkyl_mom_calc_bcorr *bcorr,
+  const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
+  const struct gkyl_array *GKYL_RESTRICT fIn, struct gkyl_array *GKYL_RESTRICT out)
 {
   assert(false);
 }

--- a/zero/mom_calc_bcorr_cu.cu
+++ b/zero/mom_calc_bcorr_cu.cu
@@ -7,8 +7,6 @@ extern "C" {
 #include <gkyl_array_ops.h>
 #include <gkyl_mom_calc_bcorr.h>
 #include <gkyl_mom_calc_bcorr_priv.h>
-#include <gkyl_mom_bcorr_lbo_vlasov.h>
-#include <gkyl_mom_bcorr_lbo_gyrokinetic.h>
 #include <gkyl_mom_type.h>
 #include <gkyl_range.h>
 #include <gkyl_rect_grid.h>
@@ -17,18 +15,18 @@ extern "C" {
 
 __global__ static void
 gkyl_mom_calc_bcorr_advance_cu_ker(const gkyl_mom_calc_bcorr* bcorr,
-  const struct gkyl_range conf_rng, struct gkyl_range edge_rng,
+  const struct gkyl_range conf_rng, struct gkyl_range vel_rng,
   enum gkyl_vel_edge edge, const struct gkyl_array* fin, struct gkyl_array* out)
 {
   double xc[GKYL_MAX_DIM];
   int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
 
   for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
-      tid < edge_rng.volume; tid += blockDim.x*gridDim.x) {
-    gkyl_sub_range_inv_idx(&edge_rng, tid, pidx);
+      tid < vel_rng.volume; tid += blockDim.x*gridDim.x) {
+    gkyl_sub_range_inv_idx(&vel_rng, tid, pidx);
     gkyl_rect_grid_cell_center(&bcorr->grid, pidx, xc);
 
-    long lincP = gkyl_range_idx(&edge_rng, pidx);
+    long lincP = gkyl_range_idx(&vel_rng, pidx);
     const double* fptr = (const double*) gkyl_array_cfetch(fin, lincP);
     double momLocal[96]; // hard-coded to max confBasis.num_basis (3x p=3 Ser) for now.
     for (unsigned int k=0; k<96; ++k)
@@ -44,7 +42,7 @@ gkyl_mom_calc_bcorr_advance_cu_ker(const gkyl_mom_calc_bcorr* bcorr,
 
     double* mptr = (double*) gkyl_array_fetch(out, lincC);
     for (unsigned int k = 0; k < out->ncomp; ++k) {
-       if (tid < edge_rng.volume)
+       if (tid < vel_rng.volume)
          atomicAdd(&mptr[k], momLocal[k]);
     }
   }
@@ -55,65 +53,54 @@ gkyl_mom_calc_bcorr_advance_cu(gkyl_mom_calc_bcorr *bcorr,
   const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
   const struct gkyl_array *GKYL_RESTRICT fin, struct gkyl_array *GKYL_RESTRICT out)
 {
-  struct gkyl_range edge_rng;
+  struct gkyl_range vel_rng;
   int nblocks, nthreads;
-  int dim_rng;
-  int elower_idx[GKYL_MAX_DIM], eupper_idx[GKYL_MAX_DIM] = { 0 };
+  int vlower_idx[GKYL_MAX_DIM], vupper_idx[GKYL_MAX_DIM] = { 0 };
   for (int dim=0; dim<phase_rng->ndim; ++dim) {
-    elower_idx[dim] = phase_rng->lower[dim];
-    eupper_idx[dim] = phase_rng->upper[dim];
+    vlower_idx[dim] = phase_rng->lower[dim];
+    vupper_idx[dim] = phase_rng->upper[dim];
   }
   enum gkyl_vel_edge edge;
   
   gkyl_array_clear_range(out, 0.0, *conf_rng);
-
-  dim_rng = phase_rng->ndim - conf_rng->ndim;
-  if (bcorr->space == 0) {
-    dim_rng = conf_rng->ndim;
-  }
   
-  for(int d=0; d<dim_rng; ++d) {
+  for(int d=0; d<phase_rng->ndim - conf_rng->ndim; ++d) {
     
     edge = gkyl_vel_edge(d + GKYL_MAX_CDIM);
-    elower_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
-    gkyl_sub_range_init(&edge_rng, phase_rng, elower_idx, eupper_idx);
-    nblocks = edge_rng.nblocks;
-    nthreads = edge_rng.nthreads;
+    vlower_idx[conf_rng->ndim + d] = phase_rng->upper[conf_rng->ndim + d];
+    vupper_idx[conf_rng->ndim + d] = phase_rng->upper[conf_rng->ndim + d];
+    gkyl_sub_range_init(&vel_rng, phase_rng, vlower_idx, vupper_idx);
+    nblocks = vel_rng.nblocks;
+    nthreads = vel_rng.nthreads;
 
     gkyl_mom_calc_bcorr_advance_cu_ker<<<nblocks, nthreads>>>(bcorr->on_dev,
-      *conf_rng, edge_rng, edge, fin->on_dev, out->on_dev);
+      *conf_rng, vel_rng, edge, fin->on_dev, out->on_dev);
 
     edge = gkyl_vel_edge(d);
-    elower_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    gkyl_sub_range_init(&edge_rng, phase_rng, elower_idx, eupper_idx);
-    nblocks = edge_rng.nblocks;
-    nthreads = edge_rng.nthreads;
+    vlower_idx[conf_rng->ndim + d] = phase_rng->lower[conf_rng->ndim + d];
+    vupper_idx[conf_rng->ndim + d] = phase_rng->lower[conf_rng->ndim + d];
+    gkyl_sub_range_init(&vel_rng, phase_rng, vlower_idx, vupper_idx);
+    nblocks = vel_rng.nblocks;
+    nthreads = vel_rng.nthreads;
 
     gkyl_mom_calc_bcorr_advance_cu_ker<<<nblocks, nthreads>>>(bcorr->on_dev,
-      *conf_rng, edge_rng, edge, fin->on_dev, out->on_dev);
+      *conf_rng, vel_rng, edge, fin->on_dev, out->on_dev);
 
     // Reset indices for loop over each velocity dimension
-    elower_idx[bcorr->space + d] = phase_rng->lower[bcorr->space + d];
-    eupper_idx[bcorr->space + d] = phase_rng->upper[bcorr->space + d];
+    vlower_idx[conf_rng->ndim + d] = phase_rng->lower[conf_rng->ndim + d];
+    vupper_idx[conf_rng->ndim + d] = phase_rng->upper[conf_rng->ndim + d];
   }
 }
 
 gkyl_mom_calc_bcorr*
 gkyl_mom_calc_bcorr_cu_dev_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_mom_type *momt, const char *space)
+  const struct gkyl_mom_type *momt)
 {
   gkyl_mom_calc_bcorr *up = (gkyl_mom_calc_bcorr*) gkyl_malloc(sizeof(gkyl_mom_calc_bcorr));
   up->grid = *grid;
   
   struct gkyl_mom_type *mt = gkyl_mom_type_acquire(momt);
   up->momt = mt->on_dev;
-  if (strcmp(space, "conf") == 0) {
-    up->space = 0;
-  } else {
-    up->space = momt->cdim;
-  }
 
   up->flags = 0;
   GKYL_SET_CU_ALLOC(up->flags);
@@ -125,20 +112,4 @@ gkyl_mom_calc_bcorr_cu_dev_new(const struct gkyl_rect_grid *grid,
   up->on_dev = up_cu;
   
   return up;
-}
-
-gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_vlasov_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary)
-{
-  struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
-  bcorr_type = gkyl_mom_bcorr_lbo_vlasov_cu_dev_new(cbasis, pbasis, vBoundary);
-  return gkyl_mom_calc_bcorr_cu_dev_new(grid, bcorr_type, "phase");
-}
-
-gkyl_mom_calc_bcorr*
-gkyl_mom_calc_bcorr_lbo_gyrokinetic_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, const double* vBoundary, double mass)
-{
-  struct gkyl_mom_type *bcorr_type; // LBO boundary corrections moment type
-  bcorr_type = gkyl_mom_bcorr_lbo_gyrokinetic_cu_dev_new(cbasis, pbasis, vBoundary, mass);
-  return gkyl_mom_calc_bcorr_cu_dev_new(grid, bcorr_type, "phase");
 }

--- a/zero/prim_lbo_calc.c
+++ b/zero/prim_lbo_calc.c
@@ -1,5 +1,5 @@
 #include <gkyl_alloc.h>
-//#include <gkyl_alloc_flags_priv.h>
+#include <gkyl_alloc_flags_priv.h>
 #include <gkyl_array_ops.h>
 #include <gkyl_prim_lbo_calc.h>
 #include <gkyl_prim_lbo_calc_priv.h>
@@ -110,7 +110,11 @@ gkyl_prim_lbo_vlasov_calc_new(const struct gkyl_rect_grid *grid, const struct gk
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_vlasov_new(cbasis, pbasis);
-  return gkyl_prim_lbo_calc_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 gkyl_prim_lbo_calc*
@@ -118,7 +122,11 @@ gkyl_prim_lbo_vlasov_with_fluid_calc_new(const struct gkyl_rect_grid *grid, cons
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_vlasov_with_fluid_new(cbasis, pbasis, conf_rng);
-  return gkyl_prim_lbo_calc_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 gkyl_prim_lbo_calc*
@@ -126,7 +134,11 @@ gkyl_prim_lbo_gyrokinetic_calc_new(const struct gkyl_rect_grid *grid, const stru
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_gyrokinetic_new(cbasis, pbasis);
-  return gkyl_prim_lbo_calc_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 gkyl_prim_lbo_calc*
@@ -134,7 +146,11 @@ gkyl_prim_lbo_vlasov_calc_cu_dev_new(const struct gkyl_rect_grid *grid, const st
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_vlasov_cu_dev_new(cbasis, pbasis);
-  return gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 gkyl_prim_lbo_calc*
@@ -142,7 +158,11 @@ gkyl_prim_lbo_vlasov_with_fluid_calc_cu_dev_new(const struct gkyl_rect_grid *gri
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_vlasov_with_fluid_cu_dev_new(cbasis, pbasis, conf_rng);
-  return gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 gkyl_prim_lbo_calc*
@@ -150,7 +170,11 @@ gkyl_prim_lbo_gyrokinetic_calc_cu_dev_new(const struct gkyl_rect_grid *grid, con
 {
   struct gkyl_prim_lbo_type *prim; // LBO primitive moments type
   prim = gkyl_prim_lbo_gyrokinetic_cu_dev_new(cbasis, pbasis);
-  return gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  struct gkyl_prim_lbo_calc *calc = gkyl_prim_lbo_calc_cu_dev_new(grid, prim);
+  // Since calc now has pointer to specific type, decrease reference counter of type
+  // so that eventual gkyl_prim_lbo_calc_release method on calculator deallocates specific type data
+  gkyl_prim_lbo_type_release(prim);
+  return calc;
 }
 
 #ifndef GKYL_HAVE_CUDA


### PR DESCRIPTION
This branch returns mom_calc_bcorr to its originally functionality of looping over edges in velocity space since ghost_surf_calc handles the more general case of computing fluxes at edges of the domain. 

Equally important: the derived constructor classes had memory leaks because they were creating types (mom_type or prim_lbo_type) and then creating the calculators which call acquire methods on these types.

As such, since we do not need the specific types subsequently after the calculator construction has acquired a pointer to these types, we call the release methods on these specific types. This decreases the reference count from 2 -> 1 (it goes from 1 -> 2 when the calculator calls the acquire) so that when the release method is called on the calculator at the end of the simulation, the reference count goes from 1 -> 0 and the specific mom_type or prim_lbo_type is free-ed.