### PR TITLE
GPU implementation of MOB

### DIFF
--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -73,7 +73,7 @@ void eval_M2_2v(double t, const double *xn, double* restrict fout, void *ctx)
 }
 
 void
-test_1x1v(int poly_order)
+test_1x1v(int poly_order, bool use_gpu)
 {
   double lower[] = {0.1, -6.0}, upper[] = {1.0, 6.0};
   int cells[] = {2, 32};
@@ -129,9 +129,9 @@ test_1x1v(int poly_order)
 
   // projection updater to compute Maxwellian
   gkyl_proj_maxwellian_on_basis *proj_max = gkyl_proj_maxwellian_on_basis_new(&grid,
-    &confBasis, &basis, poly_order+1);
+    &confBasis, &basis, poly_order+1, use_gpu);
 
-  gkyl_proj_maxwellian_on_basis_lab_mom(proj_max, local, confLocal, m0, m1i, m2, distf);
+  gkyl_proj_maxwellian_on_basis_lab_mom(proj_max, &local, &confLocal, m0, m1i, m2, distf);
 
   // values to compare  at index (1, 17) [remember, lower-left index is (1,1)]
   double p1_vals[] = {  7.5585421616306459e-01, -2.1688605007995894e-17,  2.5560131294504802e-02,
@@ -176,13 +176,8 @@ test_1x1v(int poly_order)
   gkyl_proj_on_basis_release(proj_m2);
 }
 
-void test_1x1v_p0() { test_1x1v(0); }
-void test_1x1v_p1() { test_1x1v(1); }
-void test_1x1v_p2() { test_1x1v(2); }
-void test_1x1v_p3() { test_1x1v(3); }
-
 void
-test_1x2v(int poly_order)
+test_1x2v(int poly_order, bool use_gpu)
 {
   double lower[] = {0.1, -6.0, -6.0}, upper[] = {1.0, 6.0, 6.0};
   int cells[] = {2, 16, 16};
@@ -238,9 +233,9 @@ test_1x2v(int poly_order)
 
   // projection updater to compute Maxwellian
   gkyl_proj_maxwellian_on_basis *proj_max = gkyl_proj_maxwellian_on_basis_new(&grid,
-    &confBasis, &basis, poly_order+1);
+    &confBasis, &basis, poly_order+1, use_gpu);
 
-  gkyl_proj_maxwellian_on_basis_lab_mom(proj_max, local, confLocal, m0, m1i, m2, distf);
+  gkyl_proj_maxwellian_on_basis_lab_mom(proj_max, &local, &confLocal, m0, m1i, m2, distf);
 
   // values to compare  at index (1, 9, 9) [remember, lower-left index is (1,1,1)]
   double p1_vals[] = {  4.2319425948079414e-01,  1.2894963939286889e-17,  1.1450235276582092e-02,
@@ -295,10 +290,15 @@ test_1x2v(int poly_order)
   gkyl_proj_on_basis_release(proj_m2);
 }
 
-void test_1x2v_p0() { test_1x2v(0); }
-void test_1x2v_p1() { test_1x2v(1); }
-void test_1x2v_p2() { test_1x2v(2); }
-void test_1x2v_p3() { test_1x2v(3); }
+void test_1x1v_p0() { test_1x1v(0, false); }
+void test_1x1v_p1() { test_1x1v(1, false); }
+void test_1x1v_p2() { test_1x1v(2, false); }
+void test_1x1v_p3() { test_1x1v(3, false); }
+
+void test_1x2v_p0() { test_1x2v(0, false); }
+void test_1x2v_p1() { test_1x2v(1, false); }
+void test_1x2v_p2() { test_1x2v(2, false); }
+void test_1x2v_p3() { test_1x2v(3, false); }
 
 TEST_LIST = {
   { "test_1x1v_p0", test_1x1v_p0 },

--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -310,7 +310,7 @@ test_1x2v(int poly_order, bool use_gpu)
   
   if (poly_order == 1) {
     for (int i=0; i<basis.num_basis; ++i)
-      TEST_CHECK( gkyl_compare_double(p1_vals[i], fv[i], 1e-12) );    
+      TEST_CHECK( gkyl_compare_double(p1_vals[i], fv[i], 1e-12) );
   }
 
   if (poly_order == 2) {
@@ -322,10 +322,11 @@ test_1x2v(int poly_order, bool use_gpu)
     for (int i=0; i<basis.num_basis; ++i)
       TEST_CHECK( gkyl_compare_double(p3_vals[i], fv[i], 1e-10) );
   }
-  // write distribution function to file
-  char fname[1024];
-  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x2v_p%d.gkyl", poly_order);
-  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
+
+//  // write distribution function to file
+//  char fname[1024];
+//  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x2v_p%d.gkyl", poly_order);
+//  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
 
   // release memory for moment data object
   gkyl_array_release(m0); gkyl_array_release(m1i); gkyl_array_release(m2);
@@ -380,8 +381,8 @@ TEST_LIST = {
   
   { "test_1x2v_p0_gpu", test_1x2v_p0_gpu },  
   { "test_1x2v_p1_gpu", test_1x2v_p1_gpu },
-//  { "test_1x2v_p2_gpu", test_1x2v_p2_gpu },
-//  { "test_1x2v_p3_gpu", test_1x2v_p3_gpu },
+  { "test_1x2v_p2_gpu", test_1x2v_p2_gpu },
+  { "test_1x2v_p3_gpu", test_1x2v_p3_gpu },
 #endif
   { NULL, NULL },
 };

--- a/zero/gkyl_proj_maxwellian_on_basis.h
+++ b/zero/gkyl_proj_maxwellian_on_basis.h
@@ -16,12 +16,13 @@ typedef struct gkyl_proj_maxwellian_on_basis gkyl_proj_maxwellian_on_basis;
  * @param conf_basis Conf-space basis functions
  * @param phase_basis Phase-space basis functions
  * @param num_quad Number of quadrature nodes
+ * @param use_gpu boolean indicating whether to use the GPU.
  * @return New updater pointer.
  */
 gkyl_proj_maxwellian_on_basis* gkyl_proj_maxwellian_on_basis_new(
   const struct gkyl_rect_grid *grid,
   const struct gkyl_basis *conf_basis, const struct gkyl_basis *phase_basis,
-  int num_quad);
+  int num_quad, bool use_gpu);
 
 /**
  * Compute projection of Maxwellian on basis. This method takes
@@ -37,7 +38,7 @@ gkyl_proj_maxwellian_on_basis* gkyl_proj_maxwellian_on_basis_new(
  * @param fmax Output Maxwellian
  */
 void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *pob,
-  const struct gkyl_range phase_range, const struct gkyl_range conf_range,
+  const struct gkyl_range *phase_range, const struct gkyl_range *conf_range,
   const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,  
   struct gkyl_array *fmax);
 

--- a/zero/gkyl_proj_maxwellian_on_basis.h
+++ b/zero/gkyl_proj_maxwellian_on_basis.h
@@ -29,7 +29,7 @@ gkyl_proj_maxwellian_on_basis* gkyl_proj_maxwellian_on_basis_new(
  * lab-frame moments to compute the projection of Maxwellian on basis
  * functions.
  *
- * @param pob Project on basis updater to run
+ * @param mob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
  * @param M0 Number density moment
@@ -37,7 +37,7 @@ gkyl_proj_maxwellian_on_basis* gkyl_proj_maxwellian_on_basis_new(
  * @param M2 Energy in lab-frame
  * @param fmax Output Maxwellian
  */
-void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *pob,
+void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *mob,
   const struct gkyl_range *phase_range, const struct gkyl_range *conf_range,
   const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,  
   struct gkyl_array *fmax);
@@ -50,14 +50,14 @@ void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *
  * @param pob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
- * @param n Number density moment
- * @param vel Velocity vector
- * @param vth2 Square of thermal velocity (vth2 = T/m)
+ * @param m0 Number density moment
+ * @param udrift Velocity vector
+ * @param vtsq Square of thermal velocity (vtsq = T/m)
  * @param fmax Output Maxwellian
  */
-void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *pob,
-  const struct gkyl_range phase_range, const struct gkyl_range conf_range,
-  const struct gkyl_array *n, const struct gkyl_array *vel, const struct gkyl_array *vth2,  
+void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *mob,
+  const struct gkyl_range *phase_range, const struct gkyl_range *conf_range,
+  const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,  
   struct gkyl_array *fmax);
 
 /**
@@ -65,4 +65,4 @@ void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis 
  *
  * @param pob Updater to delete.
  */
-void gkyl_proj_maxwellian_on_basis_release(gkyl_proj_maxwellian_on_basis* pob);
+void gkyl_proj_maxwellian_on_basis_release(gkyl_proj_maxwellian_on_basis* mob);

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -51,3 +51,9 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
   const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,
   struct gkyl_array *fmax);
+
+void
+gkyl_proj_maxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,
+  struct gkyl_array *fmax);

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -1,5 +1,6 @@
 #include <gkyl_proj_maxwellian_on_basis.h>
 
+GKYL_CU_DH
 static inline void
 comp_to_phys(int ndim, const double *eta,
   const double * GKYL_RESTRICT dx, const double * GKYL_RESTRICT xc,
@@ -44,3 +45,8 @@ struct gkyl_proj_maxwellian_on_basis {
                                   // ordinates in a cell.
 };
 
+void
+gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,
+  struct gkyl_array *fmax);

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -1,0 +1,46 @@
+#include <gkyl_proj_maxwellian_on_basis.h>
+
+static inline void
+comp_to_phys(int ndim, const double *eta,
+  const double * GKYL_RESTRICT dx, const double * GKYL_RESTRICT xc,
+  double* GKYL_RESTRICT xout)
+{
+  for (int d=0; d<ndim; ++d) xout[d] = 0.5*dx[d]*eta[d]+xc[d];
+}
+
+static inline void
+copy_idx_arrays(int cdim, int pdim, const int *cidx, const int *vidx, int *out)
+{
+  for (int i=0; i<cdim; ++i)
+    out[i] = cidx[i];
+  for (int i=cdim; i<pdim; ++i)
+    out[i] = vidx[i-cdim];
+}
+
+struct gkyl_proj_maxwellian_on_basis {
+  struct gkyl_rect_grid grid;
+  int num_quad; // number of quadrature points to use in each direction
+  int cdim; // Configuration-space dimension
+  int pdim; // Phase-space dimension
+
+  int num_conf_basis; // number of conf-space basis functions
+  int num_phase_basis; // number of phase-space basis functions
+
+  bool use_gpu;
+
+  // for quadrature in phase-space
+  int tot_quad; // total number of quadrature points
+  struct gkyl_array *ordinates; // ordinates for quadrature
+  struct gkyl_array *weights; // weights for quadrature
+  struct gkyl_array *basis_at_ords; // basis functions at ordinates
+
+  // for quadrature in conf space
+  int tot_conf_quad; // total number of quadrature points
+  struct gkyl_array *conf_ordinates; // conf-space ordinates for quadrature
+  struct gkyl_array *conf_weights; // weights for conf-space quadrature  
+  struct gkyl_array *conf_basis_at_ords; // conf-space basis functions at ordinates
+
+  struct gkyl_array *fun_at_ords; // function (Maxwellian) evaluated at
+                                  // ordinates in a cell.
+};
+

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -43,6 +43,7 @@ struct gkyl_proj_maxwellian_on_basis {
 
   struct gkyl_array *fun_at_ords; // function (Maxwellian) evaluated at
                                   // ordinates in a cell.
+  int *p2c_qidx;  // Mapping between conf-space and phase-space ordinates.
 };
 
 void

--- a/zero/proj_maxwellian_on_basis.c
+++ b/zero/proj_maxwellian_on_basis.c
@@ -8,6 +8,7 @@
 #include <gkyl_proj_maxwellian_on_basis.h>
 #include <gkyl_proj_maxwellian_on_basis_priv.h>
 #include <gkyl_range.h>
+#include <assert.h>
 
 // Sets ordinates, weights and basis functions at ords. Returns total
 // number of quadrature nodes
@@ -101,6 +102,9 @@ gkyl_proj_maxwellian_on_basis_new(
   up->num_conf_basis = conf_basis->num_basis;
   up->num_phase_basis = phase_basis->num_basis;
   up->use_gpu = use_gpu;
+
+  // MF 2022/08/09: device kernel has arrays hard-coded to 3x, vdim=3, p=2 for now.
+  if (use_gpu) assert((up->cdim<3 && conf_basis->poly_order<4) || (up->cdim==3 && conf_basis->poly_order<3));
 
   // initialize data needed for phase-space quadrature 
   up->tot_quad = init_quad_values(phase_basis, num_quad,

--- a/zero/proj_maxwellian_on_basis.c
+++ b/zero/proj_maxwellian_on_basis.c
@@ -282,7 +282,7 @@ gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up,
 
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu)
-    return gkyl_proj_maxwellian_on_basis_prim_mom_cu(up, phase_rng, conf_rng, M0, udrift, vtsq, fmax);
+    return gkyl_proj_maxwellian_on_basis_prim_mom_cu(up, phase_rng, conf_rng, m0, udrift, vtsq, fmax);
 #endif
 
   int cdim = up->cdim, pdim = up->pdim;

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -3,6 +3,8 @@
 extern "C" {
 #include <gkyl_proj_maxwellian_on_basis.h>
 #include <gkyl_proj_maxwellian_on_basis_priv.h>
+#include <gkyl_const.h>
+#include <gkyl_range.h>
 }
 
 __global__ static void
@@ -12,9 +14,9 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rec
   const struct gkyl_array* GKYL_RESTRICT phase_basis_at_ords, 
   const struct gkyl_array* GKYL_RESTRICT phase_ordinates, 
   const struct gkyl_array* GKYL_RESTRICT phase_weights, 
-  const struct gkyl_array* GKYL_RESTRICT fun_at_ords, 
-  const struct gkyl_array* GKYL_RESTRICT M0, struct gkyl_array* GKYL_RESTRICT M1i
-  const struct gkyl_array* GKYL_RESTRICT M2, const gkyl_mom_calc* fmax)
+  struct gkyl_array* GKYL_RESTRICT fun_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT M0, const struct gkyl_array* GKYL_RESTRICT M1i,
+  const struct gkyl_array* GKYL_RESTRICT M2, struct gkyl_array* fmax)
 {
   int pdim = phase_r.ndim, cdim = conf_r.ndim;
   int vdim = pdim-cdim;
@@ -24,7 +26,9 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rec
   int tot_conf_quad = conf_basis_at_ords->size;
   int tot_phase_quad = phase_basis_at_ords->size;
 
-  double num[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+  // double den[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+  // MF 2022/08/09: hard-coded to 3x, vdim=3, p=2 for now.
+  double den[27], vel[27][3], vtsq[27];
 
   // create range to loop over config-space and phase-space quadrature points
   int qshape[GKYL_MAX_DIM];
@@ -47,34 +51,33 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rec
     for (unsigned int k = 0; k < conf_r.ndim; k++) cidx[k] = pidx[k];
     long lincC = gkyl_range_idx(&conf_r, cidx);
 
-    const double *M0_d = gkyl_array_cfetch(M0, lincC);
-    const double *M1i_d = gkyl_array_cfetch(M1i, lincC);
-    const double *M2_d = gkyl_array_cfetch(M2, lincC);
+    const double *M0_d = (const double *) gkyl_array_cfetch(M0, lincC);
+    const double *M1i_d = (const double *) gkyl_array_cfetch(M1i, lincC);
+    const double *M2_d = (const double *) gkyl_array_cfetch(M2, lincC);
 
     // compute primitive moments at quadrature nodes
     for (int n=0; n<tot_conf_quad; ++n) {
-      const double *b_ord = gkyl_array_cfetch(conf_basis_at_ords, n);
+      const double *b_ord = (const double *) gkyl_array_cfetch(conf_basis_at_ords, n);
 
       // number density
-      num[n] = 0.0;
-      for (int k=0; k<num_conf_basis; ++k) num[n] += M0_d[k]*b_ord[k];
+      den[n] = 0.0;
+      for (int k=0; k<num_conf_basis; ++k) den[n] += M0_d[k]*b_ord[k];
 
       // drift velocity vector
       for (int d=0; d<vdim; ++d) {
         double M1i_n = 0.0;
         for (int k=0; k<num_conf_basis; ++k)
           M1i_n += M1i_d[num_conf_basis*d+k]*b_ord[k];
-        vel[n][d] = M1i_n/num[n];
+        vel[n][d] = M1i_n/den[n];
       }
 
       // thermal speed squared
       double M2_n = 0.0;
       for (int k=0; k<num_conf_basis; ++k)
         M2_n += M2_d[k]*b_ord[k];
-
       double vsq = 0.0; // velocity^2
       for (int d=0; d<vdim; ++d) vsq += vel[n][d]*vel[n][d];
-      vtsq[n] = (M2_n - num[n]*vsq)/(num[n]*vdim);
+      vtsq[n] = (M2_n - den[n]*vsq)/(den[n]*vdim);
     }
 
     gkyl_rect_grid_cell_center(grid, pidx, xc);
@@ -85,32 +88,35 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rec
     while (gkyl_range_iter_next(&qiter)) {
 
       long cqidx = gkyl_range_idx(&conf_qrange, qiter.idx);
-      double nvtsq_q = num[cqidx]/pow(2*GKYL_PI*vtsq[cqidx], vdim/2.0);
+      double nvtsq_q = den[cqidx]/pow(2*GKYL_PI*vtsq[cqidx], vdim/2.0);
 
       long pqidx = gkyl_range_idx(&phase_qrange, qiter.idx);
 
-      comp_to_phys(pdim, gkyl_array_cfetch(phase_ordinates, pqidx),
-        up->grid.dx, xc, xmu);
+      comp_to_phys(pdim, (const double *) gkyl_array_cfetch(phase_ordinates, pqidx),
+        grid->dx, xc, xmu);
 
       double efact = 0.0;
       for (int d=0; d<vdim; ++d)
         efact += (vel[cqidx][d]-xmu[cdim+d])*(vel[cqidx][d]-xmu[cdim+d]);
 
-      double *fq = gkyl_array_fetch(fun_at_ords, pqidx);
+      double *fq = (double *) gkyl_array_fetch(fun_at_ords, pqidx);
       fq[0] = nvtsq_q*exp(-efact/(2*vtsq[cqidx]));
     }
 
     // compute expansion coefficients of Maxwellian on basis
     // The following is modeled after proj_on_basis in the private header.
     long lidx = gkyl_range_idx(&phase_r, pidx);
-    double *fm = gkyl_array_fetch(fmax, lidx);
+    double *fm = (double *) gkyl_array_fetch(fmax, lidx);
   
     for (int k=0; k<num_phase_basis; ++k) fm[k] = 0.0;
+    const double *phase_w = (const double *) phase_weights->data;
+    const double *fun_o = (const double *) fun_at_ords->data;
+    const double *phaseb_o = (const double *) phase_basis_at_ords->data;
   
     for (int imu=0; imu<tot_phase_quad; ++imu) {
-      double tmp = phase_weights->data[imu]*fun_at_ords->data[imu];
+      double tmp = phase_w[imu]*fun_o[imu];
       for (int k=0; k<num_phase_basis; ++k)
-        fm[k] += tmp*phase_basis_at_ords->data[k+num_phase_basis*imu];
+        fm[k] += tmp*phaseb_o[k+num_phase_basis*imu];
     }
 
   }
@@ -124,7 +130,7 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up
 {
 
   int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
-  gkyl_proj_maxwellian_on_basis_advance_cu_ker<<<nblocks, nthreads>>>
+  gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker<<<nblocks, nthreads>>>
     (up->num_quad, &up->grid, *phase_r, *conf_r, up->conf_basis_at_ords, up->basis_at_ords, up->ordinates, 
      up->weights, up->fun_at_ords, M0->on_dev, M1i->on_dev, M2->on_dev, fmax->on_dev);
 }

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -1,0 +1,130 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_proj_maxwellian_on_basis.h>
+#include <gkyl_proj_maxwellian_on_basis_priv.h>
+}
+
+__global__ static void
+gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rect_grid *grid,
+  const struct gkyl_range phase_r, const struct gkyl_range conf_r,
+  const struct gkyl_array* GKYL_RESTRICT conf_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_ordinates, 
+  const struct gkyl_array* GKYL_RESTRICT phase_weights, 
+  const struct gkyl_array* GKYL_RESTRICT fun_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT M0, struct gkyl_array* GKYL_RESTRICT M1i
+  const struct gkyl_array* GKYL_RESTRICT M2, const gkyl_mom_calc* fmax)
+{
+  int pdim = phase_r.ndim, cdim = conf_r.ndim;
+  int vdim = pdim-cdim;
+
+  int num_conf_basis = conf_basis_at_ords->ncomp;
+  int num_phase_basis = fmax->ncomp;
+  int tot_conf_quad = conf_basis_at_ords->size;
+  int tot_phase_quad = phase_basis_at_ords->size;
+
+  double num[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+
+  // create range to loop over config-space and phase-space quadrature points
+  int qshape[GKYL_MAX_DIM];
+  for (int i=0; i<cdim; ++i) qshape[i] = num_quad;
+  struct gkyl_range conf_qrange;
+  gkyl_range_init_from_shape(&conf_qrange, cdim, qshape);
+
+  for (int i=0; i<pdim; ++i) qshape[i] = num_quad;
+  struct gkyl_range phase_qrange;
+  gkyl_range_init_from_shape(&phase_qrange, pdim, qshape);
+
+  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM];
+  int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < phase_r.volume; tid += blockDim.x*gridDim.x) {
+    gkyl_sub_range_inv_idx(&phase_r, tid, pidx);
+
+    // get conf-space linear index.
+    for (unsigned int k = 0; k < conf_r.ndim; k++) cidx[k] = pidx[k];
+    long lincC = gkyl_range_idx(&conf_r, cidx);
+
+    const double *M0_d = gkyl_array_cfetch(M0, lincC);
+    const double *M1i_d = gkyl_array_cfetch(M1i, lincC);
+    const double *M2_d = gkyl_array_cfetch(M2, lincC);
+
+    // compute primitive moments at quadrature nodes
+    for (int n=0; n<tot_conf_quad; ++n) {
+      const double *b_ord = gkyl_array_cfetch(conf_basis_at_ords, n);
+
+      // number density
+      num[n] = 0.0;
+      for (int k=0; k<num_conf_basis; ++k) num[n] += M0_d[k]*b_ord[k];
+
+      // drift velocity vector
+      for (int d=0; d<vdim; ++d) {
+        double M1i_n = 0.0;
+        for (int k=0; k<num_conf_basis; ++k)
+          M1i_n += M1i_d[num_conf_basis*d+k]*b_ord[k];
+        vel[n][d] = M1i_n/num[n];
+      }
+
+      // thermal speed squared
+      double M2_n = 0.0;
+      for (int k=0; k<num_conf_basis; ++k)
+        M2_n += M2_d[k]*b_ord[k];
+
+      double vsq = 0.0; // velocity^2
+      for (int d=0; d<vdim; ++d) vsq += vel[n][d]*vel[n][d];
+      vtsq[n] = (M2_n - num[n]*vsq)/(num[n]*vdim);
+    }
+
+    gkyl_rect_grid_cell_center(grid, pidx, xc);
+
+    // compute Maxwellian at phase-space quadrature nodes
+    struct gkyl_range_iter qiter;
+    gkyl_range_iter_init(&qiter, &phase_qrange);
+    while (gkyl_range_iter_next(&qiter)) {
+
+      long cqidx = gkyl_range_idx(&conf_qrange, qiter.idx);
+      double nvtsq_q = num[cqidx]/pow(2*GKYL_PI*vtsq[cqidx], vdim/2.0);
+
+      long pqidx = gkyl_range_idx(&phase_qrange, qiter.idx);
+
+      comp_to_phys(pdim, gkyl_array_cfetch(phase_ordinates, pqidx),
+        up->grid.dx, xc, xmu);
+
+      double efact = 0.0;
+      for (int d=0; d<vdim; ++d)
+        efact += (vel[cqidx][d]-xmu[cdim+d])*(vel[cqidx][d]-xmu[cdim+d]);
+
+      double *fq = gkyl_array_fetch(fun_at_ords, pqidx);
+      fq[0] = nvtsq_q*exp(-efact/(2*vtsq[cqidx]));
+    }
+
+    // compute expansion coefficients of Maxwellian on basis
+    // The following is modeled after proj_on_basis in the private header.
+    long lidx = gkyl_range_idx(&phase_r, pidx);
+    double *fm = gkyl_array_fetch(fmax, lidx);
+  
+    for (int k=0; k<num_phase_basis; ++k) fm[k] = 0.0;
+  
+    for (int imu=0; imu<tot_phase_quad; ++imu) {
+      double tmp = phase_weights->data[imu]*fun_at_ords->data[imu];
+      for (int k=0; k<num_phase_basis; ++k)
+        fm[k] += tmp*phase_basis_at_ords->data[k+num_phase_basis*imu];
+    }
+
+  }
+}
+
+void
+gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,
+  struct gkyl_array *fmax)
+{
+
+  int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
+  gkyl_proj_maxwellian_on_basis_advance_cu_ker<<<nblocks, nthreads>>>
+    (up->num_quad, &up->grid, *phase_r, *conf_r, up->conf_basis_at_ords, up->basis_at_ords, up->ordinates, 
+     up->weights, up->fun_at_ords, M0->on_dev, M1i->on_dev, M2->on_dev, fmax->on_dev);
+}

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -102,6 +102,96 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker(int num_quad, const struct gkyl_rec
   }
 }
 
+__global__ static void
+gkyl_proj_maxwellian_on_basis_prim_mom_cu_ker(int num_quad, const struct gkyl_rect_grid grid,
+  const struct gkyl_range phase_r, const struct gkyl_range conf_r,
+  const struct gkyl_array* GKYL_RESTRICT conf_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_ordinates, 
+  const struct gkyl_array* GKYL_RESTRICT phase_weights, const int *p2c_qidx,
+  const struct gkyl_array* GKYL_RESTRICT m0, const struct gkyl_array* GKYL_RESTRICT udrift,
+  const struct gkyl_array* GKYL_RESTRICT vtsq, struct gkyl_array* GKYL_RESTRICT fmax)
+{
+  int pdim = phase_r.ndim, cdim = conf_r.ndim;
+  int vdim = pdim-cdim;
+
+  int num_conf_basis = conf_basis_at_ords->ncomp;
+  int num_phase_basis = fmax->ncomp;
+  int tot_conf_quad = conf_basis_at_ords->size;
+  int tot_phase_quad = phase_basis_at_ords->size;
+
+  // double den[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+  // MF 2022/08/09: hard-coded to 3x, vdim=3, p=2 for now.
+  double m0[27], udrift_o[27][3], vtsq_o[27];
+
+  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM];
+  int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < phase_r.volume; tid += blockDim.x*gridDim.x) {
+    gkyl_sub_range_inv_idx(&phase_r, tid, pidx);
+
+    // get conf-space linear index.
+    for (unsigned int k = 0; k < conf_r.ndim; k++) cidx[k] = pidx[k];
+    long lincC = gkyl_range_idx(&conf_r, cidx);
+
+    const double *m0_d = (const double *) gkyl_array_cfetch(m0, lincC);
+    const double *udrift_d = (const double *) gkyl_array_cfetch(udrift, lincC);
+    const double *vtsq_d = (const double *) gkyl_array_cfetch(vtsq, lincC);
+
+    // compute primitive moments at quadrature nodes
+    for (int n=0; n<tot_conf_quad; ++n) {
+      const double *b_ord = (const double *) gkyl_array_cfetch(conf_basis_at_ords, n);
+
+      // number density
+      m0_o[n] = 0.0;
+      for (int d=0; d<vdim; ++d) udrift_o[n][d] = 0.0;
+      vtsq_o[n] = 0.0;
+      for (int k=0; k<num_conf_basis; ++k) {
+        m0_o[n] += m0_d[k]*b_ord[k];
+
+        for (int d=0; d<vdim; ++d)
+          udrift_o[n][d] += udrift_d[num_conf_basis*d+k]*b_ord[k];
+
+        vtsq_o[n] += vtsq_d[k]*b_ord[k];
+      }
+    }
+
+    gkyl_rect_grid_cell_center(&grid, pidx, xc);
+
+    long lidx = gkyl_range_idx(&phase_r, pidx);
+    double *fm = (double *) gkyl_array_fetch(fmax, lidx);
+
+    for (int k=0; k<num_phase_basis; ++k) fm[k] = 0.0;
+
+    // compute expansion coefficients of Maxwellian on basis
+    // The following is modeled after proj_on_basis in the private header.
+    const double *phase_w = (const double *) phase_weights->data;
+    const double *phaseb_o = (const double *) phase_basis_at_ords->data;
+  
+    // compute Maxwellian at phase-space quadrature nodes
+    for (int n=0; n<tot_phase_quad; ++n) {
+
+      int cqidx = p2c_qidx[n];
+      double nvtsq_o = m0_o[cqidx]/pow(2.0*GKYL_PI*vtsq_o[cqidx], vdim/2.0);
+
+      comp_to_phys(pdim, (const double *) gkyl_array_cfetch(phase_ordinates, n),
+        grid.dx, xc, &xmu[0]);
+
+      double efact = 0.0;
+      for (int d=0; d<vdim; ++d)
+        efact += pow(xmu[cdim+d]-udrift_o[cqidx][d],2);
+
+      double fmax_o = nvtsq_o*exp(-efact/(2.0*vtsq_o[cqidx]));
+
+      double tmp = phase_w[n]*fmax_o;
+      for (int k=0; k<num_phase_basis; ++k)
+        fm[k] += tmp*phaseb_o[k+num_phase_basis*n];
+    }
+
+  }
+}
+
 void
 gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
@@ -113,4 +203,17 @@ gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up
     (up->num_quad, up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
      up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
      M0->on_dev, M1i->on_dev, M2->on_dev, fmax->on_dev);
+}
+
+void
+gkyl_proj_maxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,
+  struct gkyl_array *fmax)
+{
+  int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
+  gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker<<<nblocks, nthreads>>>
+    (up->num_quad, up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
+     up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
+     m0->on_dev, udrift->on_dev, vtsq->on_dev, fmax->on_dev);
 }


### PR DESCRIPTION
GPU implementation of proj_maxwellian_on_basis.

This also implements the methods in this updater to project a maxwellian using the primitive moments m0, u and vtsq, which is more convenient for neutral models.

Note: unit tests pass on CPU and GPU. But when you run it with valgrind it seems to run to completion without errors but it crashes with a ```Test interrupted by SIGILL.``` message.