### PR TITLE
Implement _new basis methods for creating basis objects

### DIFF
--- a/unit/ctest_basis.c
+++ b/unit/ctest_basis.c
@@ -5,11 +5,8 @@
 #include <gkyl_util.h>
 
 void
-test_ser_1d()
+test_ser_1d_members(struct gkyl_basis basis1)
 {
-  struct gkyl_basis basis1;
-  gkyl_cart_modal_serendip(&basis1, 1, 1);
-
   TEST_CHECK( basis1.ndim == 1 );
   TEST_CHECK( basis1.poly_order == 1 );
   TEST_CHECK( basis1.num_basis == 2 );
@@ -48,11 +45,20 @@ test_ser_1d()
 }
 
 void
-test_ser_2d()
+test_ser_1d()
 {
-  struct gkyl_basis basis;
-  gkyl_cart_modal_serendip(&basis, 2, 2);
+  struct gkyl_basis basis1;
+  gkyl_cart_modal_serendip(&basis1, 1, 1);
+  test_ser_1d_members(basis1);
 
+  struct gkyl_basis *basis2 = gkyl_cart_modal_serendip_new(1, 1);
+  test_ser_1d_members(*basis2);
+  gkyl_free(basis2);
+}
+
+void
+test_ser_2d_members(struct gkyl_basis basis)
+{
   TEST_CHECK( basis.ndim == 2 );
   TEST_CHECK( basis.poly_order == 2 );
   TEST_CHECK( basis.num_basis == 8 );
@@ -146,11 +152,20 @@ test_ser_2d()
 }
 
 void
-test_ten_2d()
+test_ser_2d()
 {
-  struct gkyl_basis basis;
-  gkyl_cart_modal_tensor(&basis, 2, 2);
+  struct gkyl_basis basis1;
+  gkyl_cart_modal_serendip(&basis1, 2, 2);
+  test_ser_2d_members(basis1);
 
+  struct gkyl_basis *basis2 = gkyl_cart_modal_serendip_new(2, 2);
+  test_ser_2d_members(*basis2);
+  gkyl_free(basis2);
+}
+
+void
+test_ten_2d_members(struct gkyl_basis basis)
+{
   TEST_CHECK( basis.ndim == 2 );
   TEST_CHECK( basis.poly_order == 2 );
   TEST_CHECK( basis.num_basis == 9 );
@@ -187,11 +202,20 @@ test_ten_2d()
 }
 
 void
-test_hyb()
+test_ten_2d()
 {
-  struct gkyl_basis basis;
-  gkyl_cart_modal_hybrid(&basis, 1, 1);
+  struct gkyl_basis basis1;
+  gkyl_cart_modal_tensor(&basis1, 2, 2);
+  test_ten_2d_members(basis1);
 
+  struct gkyl_basis *basis2 = gkyl_cart_modal_tensor_new(2, 2);
+  test_ten_2d_members(*basis2);
+  gkyl_free(basis2);
+}
+
+void
+test_hyb_members(struct gkyl_basis basis)
+{
   TEST_CHECK( basis.ndim == 2 );
   TEST_CHECK( basis.poly_order == 1 );
   TEST_CHECK( basis.num_basis == 6 );
@@ -227,11 +251,20 @@ test_hyb()
 }
 
 void
-test_gkhyb()
+test_hyb()
 {
-  struct gkyl_basis basis;
-  gkyl_cart_modal_gkhybrid(&basis, 1, 2);
+  struct gkyl_basis basis1;
+  gkyl_cart_modal_hybrid(&basis1, 1, 1);
+  test_hyb_members(basis1);
 
+  struct gkyl_basis *basis2 = gkyl_cart_modal_hybrid_new(1, 1);
+  test_hyb_members(*basis2);
+  gkyl_free(basis2);
+}
+
+void
+test_gkhyb_members(struct gkyl_basis basis)
+{
   TEST_CHECK( basis.ndim == 3 );
   TEST_CHECK( basis.poly_order == 1 );
   TEST_CHECK( basis.num_basis == 12 );
@@ -278,23 +311,42 @@ test_gkhyb()
 
 }
 
+void
+test_gkhyb()
+{
+  struct gkyl_basis basis1;
+  gkyl_cart_modal_gkhybrid(&basis1, 1, 2);
+  test_gkhyb_members(basis1);
+
+  struct gkyl_basis *basis2 = gkyl_cart_modal_gkhybrid_new(1, 2);
+  test_gkhyb_members(*basis2);
+  gkyl_free(basis2);
+}
+
 #ifdef GKYL_HAVE_CUDA
 
 int dev_cu_ser_2d(struct gkyl_basis *basis);
 
 void
-test_cu_ser_2d()
+test_cu_ser_2d_members(struct gkyl_basis *basis)
 {
-  struct gkyl_basis *basis = gkyl_cu_malloc(sizeof(struct gkyl_basis));
-  gkyl_cart_modal_serendip_cu_dev(basis, 2, 2);
-
   int nfail = dev_cu_ser_2d(basis);
 
   TEST_CHECK(nfail == 0);
-
-  gkyl_cu_free(basis);
 }
 
+void
+test_cu_ser_2d()
+{
+  struct gkyl_basis *basis1 = gkyl_cu_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_serendip_cu_dev(basis1, 2, 2);
+  test_cu_ser_2d_members(basis1);
+  gkyl_cu_free(basis1);
+
+  struct gkyl_basis *basis2 = gkyl_cart_modal_serendip_cu_dev_new(2, 2);
+  test_cu_ser_2d_members(basis2);
+  gkyl_cu_free(basis2);
+}
 #endif
 
 TEST_LIST = {

--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -430,7 +430,7 @@ test_1x2v(int poly_order, bool use_gpu)
   vtsq = mkarr(confBasis.num_basis, confLocal_ext.volume);
   struct gkyl_array *udrift_cu, *vtsq_cu;
   if (use_gpu) { // create device copies
-    udrift_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, confBasis.num_basis, confLocal_ext.volume);
+    udrift_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, vdim*confBasis.num_basis, confLocal_ext.volume);
     vtsq_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, confBasis.num_basis, confLocal_ext.volume);
   }
 

--- a/zero/cart_modal_gkhybrid.c
+++ b/zero/cart_modal_gkhybrid.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <string.h>
 #include <gkyl_util.h>
+#include <gkyl_alloc.h>
 
 #include "cart_modal_gkhybrid_priv.h"
 
@@ -27,9 +28,23 @@ gkyl_cart_modal_gkhybrid(struct gkyl_basis *basis, int cdim, int vdim)
   basis->nodal_to_modal = n2m_list[ndim].n2m[1];
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_gkhybrid_new(int cdim, int vdim)
+{
+  struct gkyl_basis *basis = gkyl_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_gkhybrid(basis, cdim, vdim);
+  return basis;
+}
+
 #ifndef GKYL_HAVE_CUDA
 void
 gkyl_cart_modal_gkhybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim)
+{
+  assert(false);
+}
+
+struct gkyl_basis *
+gkyl_cart_modal_gkhybrid_cu_dev_new(int cdim, int vdim)
 {
   assert(false);
 }

--- a/zero/cart_modal_gkhybrid_cu.cu
+++ b/zero/cart_modal_gkhybrid_cu.cu
@@ -52,3 +52,10 @@ gkyl_cart_modal_gkhybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim)
   gkyl_cart_modal_gkhybrid_cu_dev_kern<<<1,1>>>(basis, cdim, vdim);
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_gkhybrid_cu_dev_new(int cdim, int vdim)
+{
+  struct gkyl_basis *basis = (struct gkyl_basis *) gkyl_cu_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_gkhybrid_cu_dev(basis, cdim, vdim);
+  return basis;
+}

--- a/zero/cart_modal_hybrid.c
+++ b/zero/cart_modal_hybrid.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <string.h>
 #include <gkyl_util.h>
+#include <gkyl_alloc.h>
 
 #include "cart_modal_hybrid_priv.h"
 
@@ -27,9 +28,23 @@ gkyl_cart_modal_hybrid(struct gkyl_basis *basis, int cdim, int vdim)
   basis->nodal_to_modal = n2m_list[cdim].n2m[vdim];
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_hybrid_new(int cdim, int vdim)
+{
+  struct gkyl_basis *basis = gkyl_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_hybrid(basis, cdim, vdim);
+  return basis;
+}
+
 #ifndef GKYL_HAVE_CUDA
 void
 gkyl_cart_modal_hybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim)
+{
+  assert(false);
+}
+
+struct gkyl_basis *
+gkyl_cart_modal_hybrid_cu_dev_new(int cdim, int vdim)
 {
   assert(false);
 }

--- a/zero/cart_modal_hybrid_cu.cu
+++ b/zero/cart_modal_hybrid_cu.cu
@@ -51,3 +51,10 @@ gkyl_cart_modal_hybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim)
   gkyl_cart_modal_hybrid_cu_dev_kern<<<1,1>>>(basis, cdim, vdim);
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_hybrid_cu_dev_new(int cdim, int vdim)
+{
+  struct gkyl_basis *basis = (struct gkyl_basis *) gkyl_cu_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_hybrid_cu_dev(basis, cdim, vdim);
+  return basis;
+}

--- a/zero/cart_modal_serendip.c
+++ b/zero/cart_modal_serendip.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <string.h>
 #include <gkyl_util.h>
+#include <gkyl_alloc.h>
 
 #include "cart_modal_serendip_priv.h"
 
@@ -26,9 +27,23 @@ gkyl_cart_modal_serendip(struct gkyl_basis *basis, int ndim, int poly_order)
   basis->nodal_to_modal = n2m_list[ndim].n2m[poly_order];
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_serendip_new(int ndim, int poly_order)
+{
+  struct gkyl_basis *basis = gkyl_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_serendip(basis, ndim, poly_order);
+  return basis;
+}
+
 #ifndef GKYL_HAVE_CUDA
 void
 gkyl_cart_modal_serendip_cu_dev(struct gkyl_basis *basis, int ndim, int poly_order)
+{
+  assert(false);
+}
+
+struct gkyl_basis *
+gkyl_cart_modal_serendip_cu_dev_new(int ndim, int poly_order)
 {
   assert(false);
 }

--- a/zero/cart_modal_serendip_cu.cu
+++ b/zero/cart_modal_serendip_cu.cu
@@ -49,3 +49,10 @@ gkyl_cart_modal_serendip_cu_dev(struct gkyl_basis *basis, int ndim, int poly_ord
   gkyl_cart_modal_serendip_cu_dev_kern<<<1,1>>>(basis, ndim, poly_order);
 }
 
+struct gkyl_basis *
+gkyl_cart_modal_serendip_cu_dev_new(int ndim, int poly_order)
+{
+  struct gkyl_basis *basis = (struct gkyl_basis *) gkyl_cu_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_serendip_cu_dev(basis, ndim, poly_order);
+  return basis;
+}

--- a/zero/cart_modal_tensor.c
+++ b/zero/cart_modal_tensor.c
@@ -4,6 +4,7 @@
 
 #include <gkyl_basis.h>
 #include <gkyl_util.h>
+#include <gkyl_alloc.h>
 #include <gkyl_basis_ser_kernels.h>
 #include <gkyl_basis_tensor_kernels.h>
 
@@ -105,3 +106,25 @@ gkyl_cart_modal_tensor(struct gkyl_basis *basis, int ndim, int poly_order)
   basis->node_list = nl_list[ndim].nl[poly_order];
   basis->nodal_to_modal = n2m_list[ndim].n2m[poly_order];
 }
+
+struct gkyl_basis *
+gkyl_cart_modal_tensor_new(int ndim, int poly_order)
+{
+  struct gkyl_basis *basis = gkyl_malloc(sizeof(struct gkyl_basis));
+  gkyl_cart_modal_tensor(basis, ndim, poly_order);
+  return basis;
+}
+
+#ifndef GKYL_HAVE_CUDA
+void
+gkyl_cart_modal_tensor_cu_dev(struct gkyl_basis *basis, int ndim, int poly_order)
+{
+  assert(false);
+}
+
+struct gkyl_basis *
+gkyl_cart_modal_tensor_cu_dev_new(int ndim, int poly_order)
+{
+  assert(false);
+}
+#endif

--- a/zero/gkyl_basis.h
+++ b/zero/gkyl_basis.h
@@ -88,12 +88,11 @@ struct gkyl_basis {
 };
 
 /**
- * Create new modal serendipity basis function object.
+ * Assign object members in modal serendipity basis object.
  *
  * @param basis Basis object to initialize
  * @param ndim Dimension of reference element.
  * @param poly_order Polynomial order.
- * @return Pointer to new basis function.
  */
 void gkyl_cart_modal_serendip(struct gkyl_basis *basis, int ndim,
   int poly_order);
@@ -101,12 +100,21 @@ void gkyl_cart_modal_serendip_cu_dev(struct gkyl_basis *basis, int ndim,
   int poly_order);
 
 /**
- * Create new modal tensor-product basis function object.
+ * Create new modal serendipity basis function object.
+ *
+ * @param ndim Dimension of reference element.
+ * @param poly_order Polynomial order.
+ * @return new basis struct.
+ */
+struct gkyl_basis * gkyl_cart_modal_serendip_new(int ndim, int poly_order);
+struct gkyl_basis * gkyl_cart_modal_serendip_cu_dev_new(int ndim, int poly_order);
+
+/**
+ * Assign object members in modal tensor-product basis object.
  *
  * @param basis Basis object to initialize
  * @param ndim Dimension of reference element.
  * @param poly_order Polynomial order.
- * @return Pointer to new basis function.
  */
 void gkyl_cart_modal_tensor(struct gkyl_basis *basis, int ndim,
   int poly_order);
@@ -114,26 +122,57 @@ void gkyl_cart_modal_tensor_cu_dev(struct gkyl_basis *basis, int ndim,
   int poly_order);
 
 /**
- * Create new hybrid basis. These are p=1 in configuration space
+ * Create new modal tensor-product basis function object.
+ *
+ * @param ndim Dimension of reference element.
+ * @param poly_order Polynomial order.
+ * @return new basis struct.
+ */
+struct gkyl_basis * gkyl_cart_modal_tensor_new(int ndim, int poly_order);
+struct gkyl_basis * gkyl_cart_modal_tensor_cu_dev_new(int ndim, int poly_order);
+
+/**
+ * Assign object members in hybrid basis. These are p=1 in configuration space
  * and p=2 in velocity space.
  *
  * @param basis Basis object to initialize
  * @param cdim dimension of configuration space.
  * @param vdim dimension of velocity space.
- * @return Pointer to new basis function.
  */
 void gkyl_cart_modal_hybrid(struct gkyl_basis *basis, int cdim, int vdim);
 void gkyl_cart_modal_hybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim);
 
 /**
- * Create new hybrid basis for use in gyrokinetics p=1
+ * Create new hybrid basis. These are p=1 in configuration space
+ * and p=2 in velocity space.
+ *
+ * @param cdim dimension of configuration space.
+ * @param vdim dimension of velocity space.
+ * @return new basis struct.
+ */
+struct gkyl_basis * gkyl_cart_modal_hybrid_new(int cdim, int vdim);
+struct gkyl_basis * gkyl_cart_modal_hybrid_cu_dev_new(int cdim, int vdim);
+
+/**
+ * Assign object members in hybrid basis for use in gyrokinetics p=1
  * simulations. These basis have the v_par^2 monomial and its tensor
  * product with other monomials included. 
  *
  * @param basis Basis object to initialize
  * @param cdim dimension of configuration space.
  * @param vdim dimension of velocity space.
- * @return Pointer to new basis function.
  */
 void gkyl_cart_modal_gkhybrid(struct gkyl_basis *basis, int cdim, int vdim);
 void gkyl_cart_modal_gkhybrid_cu_dev(struct gkyl_basis *basis, int cdim, int vdim);
+
+/**
+ * Create new hybrid basis for use in gyrokinetics p=1
+ * simulations. These basis have the v_par^2 monomial and its tensor
+ * product with other monomials included. 
+ *
+ * @param cdim dimension of configuration space.
+ * @param vdim dimension of velocity space.
+ * @return new basis struct.
+ */
+struct gkyl_basis * gkyl_cart_modal_gkhybrid_new(int cdim, int vdim);
+struct gkyl_basis * gkyl_cart_modal_gkhybrid_cu_dev_new(int cdim, int vdim);

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -120,9 +120,9 @@ gkyl_proj_maxwellian_on_basis_prim_mom_cu_ker(int num_quad, const struct gkyl_re
   int tot_conf_quad = conf_basis_at_ords->size;
   int tot_phase_quad = phase_basis_at_ords->size;
 
-  // double den[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+  // double m0_o[tot_conf_quad], udrift_o[tot_conf_quad][vdim], vtsq_o[tot_conf_quad];
   // MF 2022/08/09: hard-coded to 3x, vdim=3, p=2 for now.
-  double m0[27], udrift_o[27][3], vtsq_o[27];
+  double m0_o[27], udrift_o[27][3], vtsq_o[27];
 
   double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM];
   int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
@@ -212,7 +212,7 @@ gkyl_proj_maxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *u
   struct gkyl_array *fmax)
 {
   int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
-  gkyl_proj_maxwellian_on_basis_lab_mom_cu_ker<<<nblocks, nthreads>>>
+  gkyl_proj_maxwellian_on_basis_prim_mom_cu_ker<<<nblocks, nthreads>>>
     (up->num_quad, up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
      up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
      m0->on_dev, udrift->on_dev, vtsq->on_dev, fmax->on_dev);


### PR DESCRIPTION
Add _new methods to the basis objects to allocate and assign basis objects. See commit message.

This means that basis objects will have to be freed with gkyl_free or gkyl_cu_free. I didn't add a release method for basis because the release is simply gkyl_free/gkyl_cu_free. But thinking about g2, maybe a release method is necessary so that g2 doesn't have to choose between gkyl_free or gkyl_cu_free, (g0 would make that choice based on where the basis is allocated).

Basis unit test pass on CPU and GPU, and rt_sheath_1v test looks identical before and after this change.

Also: I caught an error in proj_maxwellian_on_basis prim_mom methods which I fixed in this branch.