### PR TITLE
VM Source Cleanup

### DIFF
--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -120,11 +120,16 @@ struct vm_boundary_fluxes {
 struct vm_source {
   struct vm_species_moment moms; // source moments
 
+  bool calc_bflux; // flag for calculating boundary fluxes
+  struct vm_boundary_fluxes bflux; // boundary flux object
+
   struct gkyl_array *source; // applied source
   struct gkyl_array *source_host; // host copy for use in IO and projecting
   gkyl_proj_on_basis *source_proj; // projector for source
 
   struct vm_species *source_species; // species to use for the source
+  int source_species_idx; // index of source species
+  
   double scale_factor; // factor to scale source function
   double source_length; // length used to scale the source function
   double *scale_ptr;
@@ -186,9 +191,6 @@ struct vm_species {
   enum gkyl_source_id source_id; // type of source
   struct vm_source src; // applied source
   
-  bool calc_bflux; // flag to indicate if boundary fluxes should be calculated
-  struct vm_boundary_fluxes bflux; // boundary flux object
-
   bool has_mirror_force; // flag to indicate Vlasov includes mirror force from external magnetic field
   struct gkyl_array *gradB; // gradient of magnetic field
   struct gkyl_array *magB; // magnitude of magnetic field (J = 1/B)
@@ -583,7 +585,7 @@ void vm_species_source_init(struct gkyl_vlasov_app *app, struct vm_species *s, s
  * @param rhs On output, the RHS from LBO
  */
 void vm_species_source_rhs(gkyl_vlasov_app *app, const struct vm_species *species,
-  struct vm_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs);
+  struct vm_source *src, const struct gkyl_array *fin[], struct gkyl_array *rhs[]);
 
 /**
  * Release species source object.

--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -122,6 +122,12 @@ gkyl_vlasov_app_new(struct gkyl_vm *vm)
       && app->species[i].lbo.num_cross_collisions) {
       vm_species_lbo_cross_init(app, &app->species[i], &app->species[i].lbo);
     }
+
+  // initialize each species source terms: this has to be done here
+  // as they may initialize a bflux updater for their source species
+  for (int i=0; i<ns; ++i)
+    if (app->species[i].source_id)
+      vm_species_source_init(app, &app->species[i], &app->species[i].src);
   
   // initialize each fluid species
   for (int i=0; i<nsf; ++i)
@@ -521,6 +527,14 @@ forward_euler(gkyl_vlasov_app* app, double tcurr, double dt,
   for (int i=0; i<app->num_fluid_species; ++i) {
     double dt1 = vm_fluid_species_rhs(app, &app->fluid_species[i], fluidin[i], fluidout[i]);
     dtmin = fmin(dtmin, dt1);
+  }
+  // compute source term
+  // done here as the RHS update for all species should be complete before
+  // bflux calculation of the source species
+  for (int i=0; i<app->num_species; ++i) {
+    if (app->species[i].source_id) {
+      vm_species_source_rhs(app, &app->species[i], &app->species[i].src, fin, fout);
+    }
   }
   // compute RHS of Maxwell equations
   if (app->has_field) {

--- a/apps/vm_species_source.c
+++ b/apps/vm_species_source.c
@@ -71,8 +71,11 @@ void
 vm_species_source_release(const struct gkyl_vlasov_app *app, const struct vm_source *src)
 {
   gkyl_array_release(src->source);
-  if (app->use_gpu)
+  if (app->use_gpu) {
     gkyl_array_release(src->source_host);
-
+    gkyl_cu_free(src->scale_ptr);
+  } else {
+    gkyl_free(src->scale_ptr);
+  }
   gkyl_proj_on_basis_release(src->source_proj);
 }

--- a/apps/vm_species_source.c
+++ b/apps/vm_species_source.c
@@ -4,18 +4,21 @@
 void 
 vm_species_source_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm_source *src)
 {
+  src->calc_bflux = false;
   if (s->source_id == GKYL_BFLUX_SOURCE) {
+    src->calc_bflux = true;
     assert(s->info.source.source_length);
     assert(s->info.source.source_species);
     src->source_length = s->info.source.source_length;
     src->source_species = vm_find_species(app, s->info.source.source_species);
-    src->source_species->calc_bflux = true; // ensure that boundary fluxes will be calculated
+    src->source_species_idx = vm_find_species_idx(app, s->info.source.source_species);
+    vm_species_bflux_init(app, src->source_species, &src->bflux); // boundary flux updater
     if (app->use_gpu)
       src->scale_ptr = gkyl_cu_malloc(sizeof(double));
     else
       src->scale_ptr = gkyl_malloc(sizeof(double));
   }
-  
+
   // we need to ensure source has same shape as distribution function
   src->source = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
   src->scale_factor = 1.0;
@@ -39,23 +42,24 @@ vm_species_source_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct
 // computes rhs of the boundary flux
 void
 vm_species_source_rhs(gkyl_vlasov_app *app, const struct vm_species *species,
-  struct vm_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs)
+  struct vm_source *src, const struct gkyl_array *fin[], struct gkyl_array *rhs[])
 {
-  double red_mom[app->vdim+2];
+  int species_idx;
+  species_idx = vm_find_species_idx(app, species->info.name);
   // use boundary fluxes to scale source profile
   if (species->source_id == GKYL_BFLUX_SOURCE) {
     src->scale_factor = 0;
     double z[app->confBasis.num_basis];
     double red_mom[1];
-    
+
     for (int d=0; d<app->cdim; ++d) {
-      gkyl_array_reduce(src->scale_ptr, src->source_species->bflux.integ_moms[2*d].marr, GKYL_SUM);
+      gkyl_array_reduce(src->scale_ptr, src->bflux.integ_moms[2*d].marr, GKYL_SUM);
       if (app->use_gpu)
         gkyl_cu_memcpy(red_mom, src->scale_ptr, sizeof(double), GKYL_CU_MEMCPY_D2H);
       else
         red_mom[0] = src->scale_ptr[0];
       src->scale_factor += red_mom[0];
-      gkyl_array_reduce(src->scale_ptr, src->source_species->bflux.integ_moms[2*d+1].marr, GKYL_SUM);
+      gkyl_array_reduce(src->scale_ptr, src->bflux.integ_moms[2*d+1].marr, GKYL_SUM);
       if (app->use_gpu)
         gkyl_cu_memcpy(red_mom, src->scale_ptr, sizeof(double), GKYL_CU_MEMCPY_D2H);
       else
@@ -64,7 +68,14 @@ vm_species_source_rhs(gkyl_vlasov_app *app, const struct vm_species *species,
     }
     src->scale_factor = src->scale_factor/src->source_length;
   }
-  gkyl_array_accumulate(rhs, src->scale_factor, src->source);
+
+  gkyl_array_accumulate(rhs[species_idx], src->scale_factor, src->source);
+
+  // bflux calculation needs to be after source. The source uses bflux from the previous stage.
+  if (src->calc_bflux)
+    vm_species_bflux_rhs(app, src->source_species, &src->bflux, fin[src->source_species_idx],
+      rhs[src->source_species_idx]);
+
 }
 
 void
@@ -78,4 +89,6 @@ vm_species_source_release(const struct gkyl_vlasov_app *app, const struct vm_sou
     gkyl_free(src->scale_ptr);
   }
   gkyl_proj_on_basis_release(src->source_proj);
+  if (src->calc_bflux)
+    vm_species_bflux_release(app, &src->bflux);
 }

--- a/apps/vm_species_source.c
+++ b/apps/vm_species_source.c
@@ -14,9 +14,9 @@ vm_species_source_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct
     src->source_species_idx = vm_find_species_idx(app, s->info.source.source_species);
     vm_species_bflux_init(app, src->source_species, &src->bflux); // boundary flux updater
     if (app->use_gpu)
-      src->scale_ptr = gkyl_cu_malloc(sizeof(double));
+      src->scale_ptr = gkyl_cu_malloc((2 + app->vdim)*sizeof(double));
     else
-      src->scale_ptr = gkyl_malloc(sizeof(double));
+      src->scale_ptr = gkyl_malloc((2 + app->vdim)*sizeof(double));
   }
 
   // we need to ensure source has same shape as distribution function


### PR DESCRIPTION
- Fixed a number of memory issues with the source/boundary flux implementation.
- Previously the source set a flag for the source species telling it to do the boundary flux as part of its RHS update. In addition to causing issues where flags are being set for uninitialized species, it is preferable to not have species sub-objects setting flags for a separate species.
- To clean up this process, the source update was moved outside the species RHS function, and the boundary flux calculation for the source species is handled entirely inside the source object that points to it.