### PR TITLE
Minor cleanup of mhd solver to prepare for the mhd source solver

### DIFF
--- a/regression/rt_mhd_brio_wu.c
+++ b/regression/rt_mhd_brio_wu.c
@@ -56,7 +56,11 @@ main(int argc, char **argv)
   struct mhd_ctx ctx = mhd_ctx(); // context for init functions
 
   // equation object
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, GKYL_MHD_DIVB_NONE);
+  const struct wv_mhd_inp inp = {
+    .gas_gamma = ctx.gas_gamma,
+    .divergence_constraint = GKYL_MHD_DIVB_NONE,
+  };
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(&inp);
 
   struct gkyl_moment_species fluid = {
     .name = "mhd",

--- a/regression/rt_mhd_ot.c
+++ b/regression/rt_mhd_ot.c
@@ -36,7 +36,7 @@ evalMhdInit(double t, const double* GKYL_RESTRICT xn,
   double vy = sin(2*M_PI*x);
   double vz = 0;
   double B0 = 1/sqrt(4*M_PI);
-  double Bx = -B0*sin(4*M_PI*x);
+  double Bx = -B0*sin(2*M_PI*x);
   double By = B0*sin(4*M_PI*y);
   double Bz = 0;
   double v[8] = {rho, vx, vy, vz, p, Bx, By, Bz};

--- a/regression/rt_mhd_ot.c
+++ b/regression/rt_mhd_ot.c
@@ -73,7 +73,12 @@ main(int argc, char **argv)
   struct mhd_ctx ctx = mhd_ctx(); // context for init functions
 
   // equation object
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, GKYL_MHD_DIVB_GLM);
+  const struct wv_mhd_inp inp = {
+    .gas_gamma = ctx.gas_gamma,
+    .divergence_constraint = GKYL_MHD_DIVB_GLM,
+    .glm_ch = 0,
+  };
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(&inp);
 
   struct gkyl_moment_species fluid = {
     .name = "mhd",

--- a/regression/rt_mhd_rj2.c
+++ b/regression/rt_mhd_rj2.c
@@ -61,7 +61,11 @@ main(int argc, char **argv)
   struct mhd_ctx ctx = mhd_ctx(); // context for init functions
 
   // equation object
-  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(ctx.gas_gamma, GKYL_MHD_DIVB_NONE);
+  const struct wv_mhd_inp inp = {
+    .gas_gamma = ctx.gas_gamma,
+    .divergence_constraint = GKYL_MHD_DIVB_NONE,
+  };
+  struct gkyl_wv_eqn *mhd = gkyl_wv_mhd_new(&inp);
 
   struct gkyl_moment_species fluid = {
     .name = "mhd",

--- a/zero/gkyl_wv_mhd.h
+++ b/zero/gkyl_wv_mhd.h
@@ -9,6 +9,12 @@ enum gkyl_wv_mhd_div_constraint {
   GKYL_MHD_DIVB_GLM
 };
 
+struct wv_mhd_inp {
+  double gas_gamma; // gas adiabatic constant
+  enum gkyl_wv_mhd_div_constraint divergence_constraint; // divB correction
+  double glm_ch; // factor to use in GLM scheme
+};
+
 /**
  * Create a new ideal MHD equation object.
  *
@@ -16,7 +22,7 @@ enum gkyl_wv_mhd_div_constraint {
  * @param divb Divergence constraint method
  * @return Pointer to mhd equation object.
  */
-struct gkyl_wv_eqn* gkyl_wv_mhd_new(double gas_gamma, enum gkyl_wv_mhd_div_constraint divb);
+struct gkyl_wv_eqn* gkyl_wv_mhd_new(const struct wv_mhd_inp *inp);
 
 /**
  * Get gas adiabatic constant.


### PR DESCRIPTION
- fixed typo in OT initial condition; taken from https://www.astro.princeton.edu/~jstone/Athena/tests/orszag-tang/pagesource.html
- encapsulate initialization parameters

TODO:
- Dedner's GLM: implement and test different choices of ch. Following are used for now
  ```c
    if (mhd->glm_ch > 0)
      ch = mhd->glm_ch;
    else
      // candidates:
      // 1. Dedner (2002) sec 4: cfl * min(dx, dy, dz) / dt
      // 2. Derigs (2018) eq 3.30: max_speed_global - max_global(|u|, |v|, |w|)
      // 3. local version of 2; needs to store ch for the source step
      ch = max_speed;
```