### PR TITLE
Offset array methods

### DIFF
--- a/unit/ctest_array.c
+++ b/unit/ctest_array.c
@@ -186,6 +186,94 @@ void test_array_accumulate_range()
   gkyl_array_release(a2);
 }
 
+void test_array_accumulate_offset()
+{
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, 10);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, 10);
+
+  double *a1_d  = a1->data, *a2_d = a2->data;
+
+  // test a1 = 0.1*a2[a1->ncomp]
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+
+  for (unsigned i=0; i<a2->size; ++i)
+    for (unsigned j=0; j<a2->ncomp/a1->ncomp; ++j)
+      for (unsigned k=0; k<a1->ncomp; ++k)
+        a2_d[i*a2->ncomp+j*a1->ncomp+k] = i*0.1+k;
+
+  gkyl_array_accumulate_offset(a1, 0.5, a2, 1*a1->ncomp);
+
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      TEST_CHECK( gkyl_compare(a1_d[i*a1->ncomp+j], i*1.0+j+0.5*(i*0.1+j), 1e-14) );
+
+  // test a2[a1->ncomp] = 0.1*a1
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+
+  gkyl_array_accumulate_offset(a2, 0.5, a1, 1*a1->ncomp);
+
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (unsigned j=0; j<a1->ncomp; ++j) {
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+0*a1->ncomp+j], i*0.1+j, 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+1*a1->ncomp+j], i*0.1+j+0.5*(i*1.0+j), 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+2*a1->ncomp+j], i*0.1+j, 1e-14) );
+    }
+  }
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+}
+
+void test_array_accumulate_offset_range()
+{
+  int shape[] = {10, 20};
+  struct gkyl_range range;
+  gkyl_range_init_from_shape(&range, 2, shape);
+  
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, range.volume);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, range.volume);
+
+  // test a1 = a1+0.5*a2[a1->ncomp]
+  gkyl_array_clear(a1, 0.5);
+  gkyl_array_clear(a2, 1.5);
+
+  gkyl_array_accumulate_offset_range(a1, 0.5, a2, 1*a1->ncomp, range);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a1d = gkyl_array_fetch(a1, loc);
+    for (int i=0; i<a1->ncomp; ++i)
+      TEST_CHECK( a1d[i] == 0.5+0.5*1.5 );
+  }
+
+  // test a2[a1->ncomp] = a2[a1->ncomp]+0.5*a1
+  gkyl_array_clear(a1, 0.5);
+  gkyl_array_clear(a2, 1.5);
+
+  gkyl_array_accumulate_offset_range(a2, 0.5, a1, 1*a1->ncomp, range);
+
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a2d = gkyl_array_fetch(a2, loc);
+    for (int i=0; i<a1->ncomp; ++i) {
+      TEST_CHECK( a2d[i+0*a1->ncomp] == 1.5 );
+      TEST_CHECK( a2d[i+1*a1->ncomp] == 1.5+0.5*0.5 );
+      TEST_CHECK( a2d[i+2*a1->ncomp] == 1.5 );
+    }
+  }  
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+}
+
 void test_array_combine()
 {
   struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 1, 10);
@@ -306,12 +394,13 @@ void test_array_set_offset()
 
   gkyl_array_set_offset(a2, 2., a1, 1*a1->ncomp);
 
-  for (unsigned i=0; i<a1->size; ++i)
+  for (unsigned i=0; i<a1->size; ++i) {
     for (unsigned j=0; j<a1->ncomp; ++j) {
       TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+0*a1->ncomp+j], i*0.1+j, 1e-14) );
       TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+1*a1->ncomp+j], 2.*(i*0.2+2*j), 1e-14) );
       TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+2*a1->ncomp+j], i*0.1+j, 1e-14) );
     }
+  }
 
   gkyl_array_release(a1);
   gkyl_array_release(a2);
@@ -338,26 +427,25 @@ void test_array_set_offset_range()
     long loc = gkyl_range_idx(&range, iter.idx);
     double *a1d = gkyl_array_fetch(a1, loc);
     for (int i=0; i<a1->ncomp; ++i)
-//      printf("%g | %g\n", a1d[i] ,0.1*1.5 );
       TEST_CHECK( a1d[i] == 0.1*1.5 );
   }
 
-//  // test a2[a1->ncomp] = 0.1*a1
-//  gkyl_array_clear(a1, 0.5);
-//  gkyl_array_clear(a2, 1.5);
-//
-//  gkyl_array_set_offset_range(a2, 0.1, a1, 1*a1->ncomp, range);
-//
-//  gkyl_range_iter_init(&iter, &range);
-//  while (gkyl_range_iter_next(&iter)) {
-//    long loc = gkyl_range_idx(&range, iter.idx);
-//    double *a2d = gkyl_array_fetch(a2, loc);
-//    for (int i=0; i<a1->ncomp; ++i) {
-//      TEST_CHECK( a2d[i+0*a1->ncomp] == 0.5 );
-//      TEST_CHECK( a2d[i+1*a1->ncomp] == 0.1*0.5 );
-//      TEST_CHECK( a2d[i+2*a1->ncomp] == 0.5 );
-//    }
-//  }  
+  // test a2[a1->ncomp] = 0.1*a1
+  gkyl_array_clear(a1, 0.5);
+  gkyl_array_clear(a2, 1.5);
+
+  gkyl_array_set_offset_range(a2, 0.1, a1, 1*a1->ncomp, range);
+
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a2d = gkyl_array_fetch(a2, loc);
+    for (int i=0; i<a1->ncomp; ++i) {
+      TEST_CHECK( a2d[i+0*a1->ncomp] == 1.5 );
+      TEST_CHECK( a2d[i+1*a1->ncomp] == 0.1*0.5 );
+      TEST_CHECK( a2d[i+2*a1->ncomp] == 1.5 );
+    }
+  }  
 
   gkyl_array_release(a1);
   gkyl_array_release(a2);
@@ -1839,6 +1927,8 @@ TEST_LIST = {
   { "array_clear_range", test_array_clear_range },
   { "array_accumulate", test_array_accumulate },
   { "array_accumulate_range", test_array_accumulate_range },
+  { "array_accumulate_offset", test_array_accumulate_offset },
+  { "array_accumulate_offset_range", test_array_accumulate_offset_range },
   { "array_combine", test_array_combine },
   { "array_set", test_array_set },
   { "array_set_range", test_array_set_range },

--- a/unit/ctest_array.c
+++ b/unit/ctest_array.c
@@ -1397,6 +1397,125 @@ void test_cu_array_accumulate_range()
   gkyl_array_release(a2_cu);
 }
 
+void test_cu_array_accumulate_offset()
+{
+  // create host arrays 
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, 10);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, a1->size);
+  // make device copies
+  struct gkyl_array *a1_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a1->ncomp, a1->size);
+  struct gkyl_array *a2_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a2->ncomp, a2->size);
+
+  // initialize data
+  double *a1_d  = a1->data, *a2_d = a2->data;
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+
+  for (unsigned i=0; i<a2->size; ++i)
+    for (unsigned j=0; j<a2->ncomp/a1->ncomp; ++j)
+      for (unsigned k=0; k<a1->ncomp; ++k)
+        a2_d[i*a2->ncomp+j*a1->ncomp+k] = i*0.1+k;
+
+  // copy initialized arrays to device
+  gkyl_array_copy(a1_cu, a1);
+  gkyl_array_copy(a2_cu, a2);
+
+  // test a1 = 0.1*a2[a1->ncomp]
+  gkyl_array_accumulate_offset(a1_cu, 0.5, a2_cu, 1*a1->ncomp);
+
+  gkyl_array_copy(a1, a1_cu);
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      TEST_CHECK( gkyl_compare(a1_d[i*a1->ncomp+j], i*1.0+j+0.5*(i*0.1+j), 1e-14) );
+
+  // test a2[a1->ncomp] = 0.1*a1
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+  gkyl_array_copy(a1_cu, a1);
+
+  gkyl_array_accumulate_offset(a2_cu, 0.5, a1_cu, 1*a1->ncomp);
+
+  gkyl_array_copy(a2, a2_cu);
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (unsigned j=0; j<a1->ncomp; ++j) {
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+0*a1->ncomp+j], i*0.1+j, 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+1*a1->ncomp+j], i*0.1+j+0.5*(i*1.0+j), 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+2*a1->ncomp+j], i*0.1+j, 1e-14) );
+    }
+  }
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+  gkyl_array_release(a1_cu);
+  gkyl_array_release(a2_cu);
+}
+
+void test_cu_array_accumulate_offset_range()
+{
+  int shape[] = {20, 10};
+  struct gkyl_range range;
+  gkyl_range_init_from_shape(&range, 2, shape);
+  
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, range.volume);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, range.volume);
+
+  // make device copies of arrays
+  struct gkyl_array *a1_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a1->ncomp, range.volume);
+  struct gkyl_array *a2_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a2->ncomp, range.volume);
+
+  // initialize data
+  double *a1_d  = a1->data, *a2_d = a2->data;
+  for (unsigned i=0; i<a1->size; ++i) {
+    for(unsigned c=0; c<a1->ncomp; ++c) 
+      a1_d[i*a1->ncomp+c] = i*1.0 + .01*c;
+    for(unsigned j=0; j<a2->ncomp/a1->ncomp; ++j)
+      for(unsigned c=0; c<a1->ncomp; ++c) 
+        a2_d[i*a2->ncomp+j*a1->ncomp+c] = i*0.1 + .01*c;
+  }
+
+  // copy initialized arrays to device
+  gkyl_array_copy(a1_cu, a1);
+  gkyl_array_copy(a2_cu, a2);
+
+  // a1 = a1 + 0.5*a2[1*a1->ncomp]
+  gkyl_array_accumulate_offset_range(a1_cu, 0.5, a2_cu, 1*a1->ncomp, range);
+
+  gkyl_array_copy(a1, a1_cu);
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a1d = gkyl_array_fetch(a1, loc);
+    for (int c=0; c<a1->ncomp; ++c)
+      TEST_CHECK( gkyl_compare( a1d[c], loc*1.0+.01*c + 0.5*(loc*0.1+0.01*c), 1e-14 ) );
+  }
+
+  // test a2[1*a1->ncomp] = a2[1*a1->ncomp] + 0.5*a1
+  gkyl_array_clear(a1_cu, 0.5);
+  gkyl_array_clear(a2_cu, 1.5);
+
+  gkyl_array_accumulate_offset_range(a2_cu, 0.5, a1_cu, 1*a1->ncomp, range);
+
+  gkyl_array_copy(a2, a2_cu);
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a2d = gkyl_array_fetch(a2, loc);
+    for (int i=0; i<a1->ncomp; ++i) {
+      TEST_CHECK( a2d[i+0*a1->ncomp] == 1.5 );
+      TEST_CHECK( a2d[i+1*a1->ncomp] == 1.5+0.5*0.5 );
+      TEST_CHECK( a2d[i+2*a1->ncomp] == 1.5 );
+    }
+  }  
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+  gkyl_array_release(a1_cu);
+  gkyl_array_release(a2_cu);
+}
+
 void test_cu_array_accumulate_range_4d()
 {
   int lower[] = { 1, 1, 1, 1 };
@@ -1575,6 +1694,118 @@ void test_cu_array_set_range()
     double *a2d = gkyl_array_fetch(a2, loc);
     for (int i=0; i<3; ++i)
       TEST_CHECK( a2d[i] == 0.5*0.5 );
+  }  
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+  gkyl_array_release(a1_cu);
+  gkyl_array_release(a2_cu);
+}
+
+void test_cu_array_set_offset()
+{
+  // create host arrays 
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, 10);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, a1->size);
+  // make device copies
+  struct gkyl_array *a1_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a1->ncomp, a1->size);
+  struct gkyl_array *a2_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a2->ncomp, a2->size);
+
+  // initialize data
+  double *a1_d  = a1->data, *a2_d = a2->data;
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+
+  for (unsigned i=0; i<a2->size; ++i)
+    for (unsigned j=0; j<a2->ncomp/a1->ncomp; ++j)
+      for (unsigned k=0; k<a1->ncomp; ++k)
+        a2_d[i*a2->ncomp+j*a1->ncomp+k] = i*0.1+k;
+
+  // copy initialized arrays to device
+  gkyl_array_copy(a1_cu, a1);
+  gkyl_array_copy(a2_cu, a2);
+
+  // test a1 = 0.5*a2[a1->ncomp]
+  gkyl_array_set_offset(a1_cu, 0.5, a2_cu, 1*a1->ncomp);
+
+  gkyl_array_copy(a1, a1_cu);
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      TEST_CHECK( gkyl_compare(a1_d[i*a1->ncomp+j], 0.5*(i*0.1+j), 1e-14) );
+
+  // test a2[a1->ncomp] = 0.1*a1
+  for (unsigned i=0; i<a1->size; ++i)
+    for (unsigned j=0; j<a1->ncomp; ++j)
+      a1_d[i*a1->ncomp+j] = i*1.0+j;
+  gkyl_array_copy(a1_cu, a1);
+
+  gkyl_array_set_offset(a2_cu, 0.5, a1_cu, 1*a1->ncomp);
+
+  gkyl_array_copy(a2, a2_cu);
+  for (unsigned i=0; i<a1->size; ++i) {
+    for (unsigned j=0; j<a1->ncomp; ++j) {
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+0*a1->ncomp+j], i*0.1+j, 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+1*a1->ncomp+j], 0.5*(i*1.0+j), 1e-14) );
+      TEST_CHECK( gkyl_compare(a2_d[i*a2->ncomp+2*a1->ncomp+j], i*0.1+j, 1e-14) );
+    }
+  }
+
+  gkyl_array_release(a1);
+  gkyl_array_release(a2);
+  gkyl_array_release(a1_cu);
+  gkyl_array_release(a2_cu);
+}
+
+void test_cu_array_set_offset_range()
+{
+  int shape[] = {10, 20};
+  struct gkyl_range range;
+  gkyl_range_init_from_shape(&range, 2, shape);
+  
+  struct gkyl_array *a1 = gkyl_array_new(GKYL_DOUBLE, 2, range.volume);
+  struct gkyl_array *a2 = gkyl_array_new(GKYL_DOUBLE, 3*a1->ncomp, range.volume);
+
+  // make device copies of arrays
+  struct gkyl_array *a1_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a1->ncomp, range.volume);
+  struct gkyl_array *a2_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, a2->ncomp, range.volume);
+
+  // copy host arrays to device
+  gkyl_array_copy(a1_cu, a1);
+  gkyl_array_copy(a2_cu, a2);
+
+  // test a1 = 0.5*a2[a1->ncomp]
+  gkyl_array_clear(a1_cu, 0.5);
+  gkyl_array_clear(a2_cu, 1.5);
+
+  gkyl_array_set_offset_range(a1_cu, 0.5, a2_cu, 1*a1->ncomp, range);
+
+  gkyl_array_copy(a1, a1_cu);
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a1d = gkyl_array_fetch(a1, loc);
+    for (int i=0; i<a1->ncomp; ++i)
+      TEST_CHECK( a1d[i] == 0.5*1.5 );
+  }
+
+  // test a2[a1->ncomp] = 0.5*a1
+  gkyl_array_clear(a1_cu, 0.5);
+  gkyl_array_clear(a2_cu, 1.5);
+
+  gkyl_array_set_offset_range(a2_cu, 0.5, a1_cu, 1*a1->ncomp, range);
+
+  gkyl_array_copy(a2, a2_cu);
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(&range, iter.idx);
+    double *a2d = gkyl_array_fetch(a2, loc);
+    for (int i=0; i<a1->ncomp; ++i) {
+      TEST_CHECK( a2d[i+0*a1->ncomp] == 1.5 );
+      TEST_CHECK( a2d[i+1*a1->ncomp] == 0.5*0.5 );
+      TEST_CHECK( a2d[i+2*a1->ncomp] == 1.5 );
+    }
   }  
 
   gkyl_array_release(a1);
@@ -1959,10 +2190,14 @@ TEST_LIST = {
   { "cu_array_clear_range", test_cu_array_clear_range},
   { "cu_array_accumulate", test_cu_array_accumulate},
   { "cu_array_accumulate_range", test_cu_array_accumulate_range},
+  { "cu_array_accumulate_offset", test_cu_array_accumulate_offset},
+  { "cu_array_accumulate_offset_range", test_cu_array_accumulate_offset_range},
   { "cu_array_accumulate_range_4d", test_cu_array_accumulate_range_4d  },
   { "cu_array_combine", test_cu_array_combine},
   { "cu_array_set", test_cu_array_set },
   { "cu_array_set_range", test_cu_array_set_range },
+  { "cu_array_set_offset", test_cu_array_set_offset },
+  { "cu_array_set_offset_range", test_cu_array_set_offset_range },
   { "cu_array_scale", test_cu_array_scale },
   { "cu_array_scale_by_cell", test_cu_array_scale_by_cell },
   { "cu_array_shiftc0", test_cu_array_shiftc0 },

--- a/zero/array_ops.c
+++ b/zero/array_ops.c
@@ -70,6 +70,34 @@ gkyl_array_set(struct gkyl_array* out, double a,
 }
 
 struct gkyl_array*
+gkyl_array_set_offset(struct gkyl_array* out, double a,
+  const struct gkyl_array* inp, int coff)
+{
+  assert(out->type == GKYL_DOUBLE);
+  assert(out->size == inp->size);
+
+#ifdef GKYL_HAVE_CUDA
+  assert(gkyl_array_is_cu_dev(out)==gkyl_array_is_cu_dev(inp));
+  if (gkyl_array_is_cu_dev(out)) { gkyl_array_set_offset_cu(out, a, inp, coff); return out; }
+#endif
+
+  double *out_d = out->data;
+  const double *inp_d = inp->data;
+  if (NCOM(out) > NCOM(inp)) {
+    // Interpret offset as offset in output components.
+    for (size_t i=0; i<out->size; ++i)
+      for (size_t c=0; c<NCOM(inp); ++c)
+        out_d[i*NCOM(out)+c+coff] = a*inp_d[i*NCOM(inp)+c];
+  } else {
+    // Interpret offset as offset in input components.
+    for (size_t i=0; i<out->size; ++i)
+      for (size_t c=0; c<NCOM(out); ++c)
+        out_d[i*NCOM(out)+c] = a*inp_d[i*NCOM(inp)+c+coff];
+  }
+  return out;
+}
+
+struct gkyl_array*
 gkyl_array_scale(struct gkyl_array* out, double a)
 {
 #ifdef GKYL_HAVE_CUDA
@@ -83,7 +111,7 @@ struct gkyl_array*
 gkyl_array_scale_by_cell(struct gkyl_array* out, const struct gkyl_array* a)
 {
   assert(out->type == GKYL_DOUBLE);
-  assert(out->size == a->size && a->ncomp == 1);
+  assert(out->size == a->size && NCOM(a) == 1);
 #ifdef GKYL_HAVE_CUDA
   if (gkyl_array_is_cu_dev(out)) { gkyl_array_scale_by_cell_cu(out, a); return out; }
 #endif
@@ -91,8 +119,8 @@ gkyl_array_scale_by_cell(struct gkyl_array* out, const struct gkyl_array* a)
   double *out_d = out->data;
   const double *a_d = a->data;
   for (size_t i=0; i<out->size; ++i)
-    for (size_t c=0; c<out->ncomp; ++c)
-      out_d[i*out->ncomp+c] = a_d[i]*out_d[i*out->ncomp+c];
+    for (size_t c=0; c<NCOM(out); ++c)
+      out_d[i*NCOM(out)+c] = a_d[i]*out_d[i*NCOM(out)+c];
   return out;
 }
 
@@ -106,7 +134,7 @@ gkyl_array_shiftc0(struct gkyl_array* out, double a)
 
   double *out_d = out->data;
   for (size_t i=0; i<out->size; ++i)
-    out_d[i*out->ncomp] = a+out_d[i*out->ncomp];
+    out_d[i*NCOM(out)] = a+out_d[i*NCOM(out)];
   return out;
 }
 
@@ -238,6 +266,43 @@ gkyl_array_set_range(struct gkyl_array *out,
     long start = gkyl_range_idx(&range, iter.idx);
     array_set1(n,
       gkyl_array_fetch(out, start), a, gkyl_array_cfetch(inp, start));
+  }
+
+  return out;
+}
+
+struct gkyl_array*
+gkyl_array_set_offset_range(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff, struct gkyl_range range)
+{
+  assert(out->type == GKYL_DOUBLE && inp->type == GKYL_DOUBLE);
+  assert(out->size == inp->size);
+
+#ifdef GKYL_HAVE_CUDA
+  assert(gkyl_array_is_cu_dev(out)==gkyl_array_is_cu_dev(inp));
+  if (gkyl_array_is_cu_dev(out)) { gkyl_array_set_offset_range_cu(out, a, inp, coff, range); return out; }
+#endif
+
+  long outnc = NCOM(out), inpnc = NCOM(inp);
+  long n;
+  int outoff, inoff;
+  if (outnc < inpnc) {
+    n = outnc;
+    outoff = 0;
+    inoff = coff;
+  } else {
+    n = inpnc;
+    outoff = coff;
+    inoff = 0;
+  }
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long start = gkyl_range_idx(&range, iter.idx);
+    double *out_d = (double *)gkyl_array_fetch(out, start);
+    const double *inp_d = (const double *)gkyl_array_cfetch(inp, start);
+    array_set1(n, out_d+outoff, a, inp_d+inoff);
   }
 
   return out;
@@ -420,7 +485,7 @@ gkyl_array_copy_to_buffer_fn(void *data, const struct gkyl_array *arr,
 
     const double *inp = gkyl_array_cfetch(arr, loc);
     double *out = flat_fetch(data, arr->esznc*count);
-    cf->func(arr->ncomp, out, inp, cf->ctx);
+    cf->func(NCOM(arr), out, inp, cf->ctx);
     count += 1;
   }
 }
@@ -454,6 +519,6 @@ gkyl_array_flip_copy_to_buffer_fn(void *data, const struct gkyl_array *arr,
 
     const double *inp = gkyl_array_cfetch(arr, loc);
     double *out = flat_fetch(data, arr->esznc*count);
-    cf->func(arr->ncomp, out, inp, cf->ctx);
+    cf->func(NCOM(arr), out, inp, cf->ctx);
   }  
 }

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -67,6 +67,20 @@ struct gkyl_array* gkyl_array_set(struct gkyl_array *out,
   double a, const struct gkyl_array *inp);
 
 /**
+ * Set out = a*inp[coff] where coff is a component-offset if
+ * out->ncomp > inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp > inp->ncomp. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_set_offset(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff);
+
+/**
  * Scale out = a*out. Returns out.
  *
  * @param out Output array
@@ -126,6 +140,20 @@ struct gkyl_array* gkyl_array_accumulate_range(struct gkyl_array *out,
  */
 struct gkyl_array* gkyl_array_set_range(struct gkyl_array *out,
   double a, const struct gkyl_array *inp, struct gkyl_range range);
+
+/**
+ * Set out = a*inp[coff] where coff is a component-offset if
+ * out->ncomp > inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp > inp->ncomp. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @return out array
+ * @param range Range specifying region to set
+ */
+struct gkyl_array* gkyl_array_set_offset_range(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff, struct gkyl_range range);
 
 /**
  * Scale out = a*ut. Returns out.
@@ -242,6 +270,8 @@ void gkyl_array_accumulate_cu(struct gkyl_array* out, double a, const struct gky
 
 void gkyl_array_set_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp);
 
+void gkyl_array_set_offset_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp, int coff);
+
 void gkyl_array_scale_cu(struct gkyl_array* out, double a);
 
 void gkyl_array_scale_by_cell_cu(struct gkyl_array* out, const struct gkyl_array* a);
@@ -258,6 +288,9 @@ void gkyl_array_accumulate_range_cu(struct gkyl_array *out,
 
 void gkyl_array_set_range_cu(struct gkyl_array *out,
   double a, const struct gkyl_array* inp, struct gkyl_range range);
+
+void gkyl_array_set_offset_range_cu(struct gkyl_array *out,
+  double a, const struct gkyl_array* inp, int coff, struct gkyl_range range);
 
 void gkyl_array_scale_range_cu(struct gkyl_array *out,
   double a, struct gkyl_range range);

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -56,6 +56,20 @@ struct gkyl_array* gkyl_array_accumulate(struct gkyl_array *out,
   double a, const struct gkyl_array *inp);
 
 /**
+ * Compute out = out + a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = out[coff]+ a*inp if
+ * out->ncomp > inp->ncomp. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_accumulate_offset(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff);
+
+/**
  * Set out = a*inp. Returns out.
  *
  * @param out Output array
@@ -68,7 +82,7 @@ struct gkyl_array* gkyl_array_set(struct gkyl_array *out,
 
 /**
  * Set out = a*inp[coff] where coff is a component-offset if
- * out->ncomp > inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp < inp->ncomp, or out[coff] = a*inp if
  * out->ncomp > inp->ncomp. Returns out.
  *
  * @param out Output array
@@ -130,6 +144,20 @@ struct gkyl_array* gkyl_array_accumulate_range(struct gkyl_array *out,
   double a, const struct gkyl_array *inp, struct gkyl_range range);
 
 /**
+ * Compute out = out + a*inp[coff] where coff is a component-offset if
+ * out->ncomp < inp->ncomp, or out[coff] = out[coff]+ a*inp if
+ * out->ncomp > inp->ncomp, over a range of indices. Returns out.
+ *
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param coff Component offset
+ * @return out array
+ */
+struct gkyl_array* gkyl_array_accumulate_offset_range(struct gkyl_array *out,
+  double a, const struct gkyl_array *inp, int coff, struct gkyl_range range);
+
+/**
  * Set out = a*inp. Returns out.
  *
  * @param out Output array
@@ -143,8 +171,8 @@ struct gkyl_array* gkyl_array_set_range(struct gkyl_array *out,
 
 /**
  * Set out = a*inp[coff] where coff is a component-offset if
- * out->ncomp > inp->ncomp, or out[coff] = a*inp if
- * out->ncomp > inp->ncomp. Returns out.
+ * out->ncomp < inp->ncomp, or out[coff] = a*inp if
+ * out->ncomp > inp->ncomp, over a range of indices. Returns out.
  *
  * @param out Output array
  * @param a Factor to multiply input array
@@ -268,6 +296,8 @@ void gkyl_array_clear_cu(struct gkyl_array* out, double val);
 
 void gkyl_array_accumulate_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp);
 
+void gkyl_array_accumulate_offset_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp, int coff);
+
 void gkyl_array_set_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp);
 
 void gkyl_array_set_offset_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp, int coff);
@@ -285,6 +315,9 @@ void gkyl_array_clear_range_cu(struct gkyl_array *out, double val, struct gkyl_r
 
 void gkyl_array_accumulate_range_cu(struct gkyl_array *out,
   double a, const struct gkyl_array* inp, struct gkyl_range range);
+
+void gkyl_array_accumulate_offset_range_cu(struct gkyl_array *out,
+  double a, const struct gkyl_array* inp, int coff, struct gkyl_range range);
 
 void gkyl_array_set_range_cu(struct gkyl_array *out,
   double a, const struct gkyl_array* inp, struct gkyl_range range);


### PR DESCRIPTION
Implement offset methods we had in g2. These do the same as _set and _accumulate, but take the extra ```coff``` (offset) argument to indicate a (DG) component offset. This allows us to do operations with/on a specific component of a vector field.

Make check passes. CPU and GPU tests for these methods are implemented and pass.