### PR TITLE
LBO checks

### DIFF
--- a/zero/dg_lbo_gyrokinetic_diff.c
+++ b/zero/dg_lbo_gyrokinetic_diff.c
@@ -41,11 +41,11 @@ gkyl_lbo_gyrokinetic_diff_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_diff_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass, bool use_gpu)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass, bool use_gpu)
 {
 #ifdef GKYL_HAVE_CUDA
   if (use_gpu)
-    return gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(cbasis, pbasis, conf_range, mass);
+    return gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(cbasis, pbasis, conf_range, pgrid, mass);
 #endif
   struct dg_lbo_gyrokinetic_diff* lbo_gyrokinetic_diff = gkyl_malloc(sizeof(struct dg_lbo_gyrokinetic_diff));
 
@@ -59,6 +59,9 @@ gkyl_dg_lbo_gyrokinetic_diff_new(const struct gkyl_basis* cbasis, const struct g
   lbo_gyrokinetic_diff->eqn.vol_term = vol;
   lbo_gyrokinetic_diff->eqn.surf_term = surf;
   lbo_gyrokinetic_diff->eqn.boundary_surf_term = boundary_surf;
+
+  lbo_gyrokinetic_diff->vparMax = pgrid->upper[cdim];
+  lbo_gyrokinetic_diff->vparMaxSq = pow(pgrid->upper[cdim],2);
 
   const gkyl_dg_lbo_gyrokinetic_diff_vol_kern_list *vol_kernels;
   const gkyl_dg_lbo_gyrokinetic_diff_surf_kern_list *surf_vpar_kernels, *surf_mu_kernels;
@@ -112,7 +115,7 @@ gkyl_dg_lbo_gyrokinetic_diff_new(const struct gkyl_basis* cbasis, const struct g
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass)
 {
   assert(false);
   return 0;

--- a/zero/dg_lbo_gyrokinetic_diff_cu.cu
+++ b/zero/dg_lbo_gyrokinetic_diff_cu.cu
@@ -80,7 +80,7 @@ dg_lbo_gyrokinetic_diff_set_cu_dev_ptrs(struct dg_lbo_gyrokinetic_diff *lbo_gyro
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis,
-  const struct gkyl_range* conf_range, double mass)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass)
 {
   struct dg_lbo_gyrokinetic_diff *lbo_gyrokinetic_diff =
     (struct dg_lbo_gyrokinetic_diff*) gkyl_malloc(sizeof(struct dg_lbo_gyrokinetic_diff));
@@ -94,6 +94,9 @@ gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(const struct gkyl_basis* cbasis, const s
   lbo_gyrokinetic_diff->eqn.num_equations = 1;
   lbo_gyrokinetic_diff->mass = mass;
   lbo_gyrokinetic_diff->conf_range = *conf_range;
+
+  lbo_gyrokinetic_diff->vparMax = pgrid->upper[cdim];
+  lbo_gyrokinetic_diff->vparMaxSq = pow(pgrid->upper[cdim],2);
 
   lbo_gyrokinetic_diff->eqn.flags = 0;
   GKYL_SET_CU_ALLOC(lbo_gyrokinetic_diff->eqn.flags);

--- a/zero/dg_lbo_gyrokinetic_drag.c
+++ b/zero/dg_lbo_gyrokinetic_drag.c
@@ -42,11 +42,11 @@ gkyl_lbo_gyrokinetic_drag_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_drag_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass, bool use_gpu)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass, bool use_gpu)
 {
 #ifdef GKYL_HAVE_CUDA
   if (use_gpu)
-    return gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(cbasis, pbasis, conf_range, mass);
+    return gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(cbasis, pbasis, conf_range, pgrid, mass);
 #endif
   struct dg_lbo_gyrokinetic_drag* lbo_gyrokinetic_drag = gkyl_malloc(sizeof(struct dg_lbo_gyrokinetic_drag));
 
@@ -60,6 +60,9 @@ gkyl_dg_lbo_gyrokinetic_drag_new(const struct gkyl_basis* cbasis, const struct g
   lbo_gyrokinetic_drag->eqn.vol_term = vol;
   lbo_gyrokinetic_drag->eqn.surf_term = surf;
   lbo_gyrokinetic_drag->eqn.boundary_surf_term = boundary_surf;
+
+  lbo_gyrokinetic_drag->vparMax = pgrid->upper[cdim];
+  lbo_gyrokinetic_drag->vparMaxSq = pow(pgrid->upper[cdim],2);
 
   const gkyl_dg_lbo_gyrokinetic_drag_vol_kern_list *vol_kernels;
   const gkyl_dg_lbo_gyrokinetic_drag_surf_kern_list *surf_vpar_kernels, *surf_mu_kernels;
@@ -113,7 +116,7 @@ gkyl_dg_lbo_gyrokinetic_drag_new(const struct gkyl_basis* cbasis, const struct g
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass)
 {
   assert(false);
   return 0;

--- a/zero/dg_lbo_gyrokinetic_drag_cu.cu
+++ b/zero/dg_lbo_gyrokinetic_drag_cu.cu
@@ -80,7 +80,7 @@ dg_lbo_gyrokinetic_drag_set_cu_dev_ptrs(struct dg_lbo_gyrokinetic_drag *lbo_gyro
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis,
-  const struct gkyl_range* conf_range, double mass)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass)
 {
   struct dg_lbo_gyrokinetic_drag *lbo_gyrokinetic_drag =
     (struct dg_lbo_gyrokinetic_drag*) gkyl_malloc(sizeof(struct dg_lbo_gyrokinetic_drag));
@@ -94,6 +94,9 @@ gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(const struct gkyl_basis* cbasis, const s
   lbo_gyrokinetic_drag->eqn.num_equations = 1;
   lbo_gyrokinetic_drag->mass = mass;
   lbo_gyrokinetic_drag->conf_range = *conf_range;
+
+  lbo_gyrokinetic_drag->vparMax = pgrid->upper[cdim];
+  lbo_gyrokinetic_drag->vparMaxSq = pow(pgrid->upper[cdim],2);
 
   lbo_gyrokinetic_drag->eqn.flags = 0;
   GKYL_SET_CU_ALLOC(lbo_gyrokinetic_drag->eqn.flags);

--- a/zero/dg_lbo_vlasov_diff_cu.cu
+++ b/zero/dg_lbo_vlasov_diff_cu.cu
@@ -93,7 +93,7 @@ dg_lbo_vlasov_diff_set_cu_dev_ptrs(struct dg_lbo_vlasov_diff *lbo_vlasov_diff, e
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_vlasov_diff_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis,
-  const struct gkyl_range* conf_range)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid)
 {
   struct dg_lbo_vlasov_diff *lbo_vlasov_diff =
     (struct dg_lbo_vlasov_diff*) gkyl_malloc(sizeof(struct dg_lbo_vlasov_diff));
@@ -102,10 +102,18 @@ gkyl_dg_lbo_vlasov_diff_cu_dev_new(const struct gkyl_basis* cbasis, const struct
   int poly_order = cbasis->poly_order;
 
   lbo_vlasov_diff->cdim = cdim;
+  lbo_vlasov_diff->vdim = vdim;
   lbo_vlasov_diff->pdim = pdim;
 
   lbo_vlasov_diff->eqn.num_equations = 1;
   lbo_vlasov_diff->conf_range = *conf_range;
+
+  lbo_vlasov_diff->vMaxSq = -1.;
+  for (int d=0; d<vdim; d++) {
+    lbo_vlasov_diff->viMax[d] = pgrid->upper[cdim+d];
+    lbo_vlasov_diff->vMaxSq = fmax(lbo_vlasov_diff->vMaxSq, pow(pgrid->upper[cdim+d],2));
+  }
+  lbo_vlasov_diff->num_cbasis = cbasis->num_basis;
 
   lbo_vlasov_diff->eqn.flags = 0;
   GKYL_SET_CU_ALLOC(lbo_vlasov_diff->eqn.flags);

--- a/zero/dg_lbo_vlasov_drag_cu.cu
+++ b/zero/dg_lbo_vlasov_drag_cu.cu
@@ -93,7 +93,7 @@ dg_lbo_vlasov_drag_set_cu_dev_ptrs(struct dg_lbo_vlasov_drag *lbo_vlasov_drag, e
 
 struct gkyl_dg_eqn*
 gkyl_dg_lbo_vlasov_drag_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis,
-  const struct gkyl_range* conf_range)
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid)
 {
   struct dg_lbo_vlasov_drag *lbo_vlasov_drag =
     (struct dg_lbo_vlasov_drag*) gkyl_malloc(sizeof(struct dg_lbo_vlasov_drag));
@@ -102,10 +102,18 @@ gkyl_dg_lbo_vlasov_drag_cu_dev_new(const struct gkyl_basis* cbasis, const struct
   int poly_order = cbasis->poly_order;
 
   lbo_vlasov_drag->cdim = cdim;
+  lbo_vlasov_drag->vdim = vdim;
   lbo_vlasov_drag->pdim = pdim;
 
   lbo_vlasov_drag->eqn.num_equations = 1;
   lbo_vlasov_drag->conf_range = *conf_range;
+
+  lbo_vlasov_drag->vMaxSq = -1.;
+  for (int d=0; d<vdim; d++) {
+    lbo_vlasov_drag->viMax[d] = pgrid->upper[cdim+d];
+    lbo_vlasov_drag->vMaxSq = fmax(lbo_vlasov_drag->vMaxSq, pow(pgrid->upper[cdim+d],2));
+  }
+  lbo_vlasov_drag->num_cbasis = cbasis->num_basis;
 
   lbo_vlasov_drag->eqn.flags = 0;
   GKYL_SET_CU_ALLOC(lbo_vlasov_drag->eqn.flags);

--- a/zero/dg_updater_lbo_gyrokinetic.c
+++ b/zero/dg_updater_lbo_gyrokinetic.c
@@ -17,8 +17,8 @@ gkyl_dg_updater_lbo_gyrokinetic_new(const struct gkyl_rect_grid *grid, const str
 {
   gkyl_dg_updater_lbo_gyrokinetic *up = gkyl_malloc(sizeof(gkyl_dg_updater_lbo_gyrokinetic));
 
-  up->coll_drag = gkyl_dg_lbo_gyrokinetic_drag_new(cbasis, pbasis, conf_range, mass, use_gpu);
-  up->coll_diff = gkyl_dg_lbo_gyrokinetic_diff_new(cbasis, pbasis, conf_range, mass, use_gpu);
+  up->coll_drag = gkyl_dg_lbo_gyrokinetic_drag_new(cbasis, pbasis, conf_range, grid, mass, use_gpu);
+  up->coll_diff = gkyl_dg_lbo_gyrokinetic_diff_new(cbasis, pbasis, conf_range, grid, mass, use_gpu);
 
   int cdim = cbasis->ndim, pdim = pbasis->ndim;
   int vdim = pdim-cdim;

--- a/zero/dg_updater_lbo_vlasov.c
+++ b/zero/dg_updater_lbo_vlasov.c
@@ -17,8 +17,8 @@ gkyl_dg_updater_lbo_vlasov_new(const struct gkyl_rect_grid *grid, const struct g
 {
   gkyl_dg_updater_lbo_vlasov *up = gkyl_malloc(sizeof(gkyl_dg_updater_lbo_vlasov));
 
-  up->coll_drag = gkyl_dg_lbo_vlasov_drag_new(cbasis, pbasis, conf_range, use_gpu);
-  up->coll_diff = gkyl_dg_lbo_vlasov_diff_new(cbasis, pbasis, conf_range, use_gpu);
+  up->coll_drag = gkyl_dg_lbo_vlasov_drag_new(cbasis, pbasis, conf_range, grid, use_gpu);
+  up->coll_diff = gkyl_dg_lbo_vlasov_diff_new(cbasis, pbasis, conf_range, grid, use_gpu);
 
   int cdim = cbasis->ndim, pdim = pbasis->ndim;
   int vdim = pdim-cdim;

--- a/zero/gkyl_dg_lbo_gyrokinetic_diff.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_diff.h
@@ -4,6 +4,7 @@
 #include <gkyl_basis.h>
 #include <gkyl_dg_eqn.h>
 #include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
 
 // Struct containing the pointers to auxiliary fields.
 struct gkyl_dg_lbo_gyrokinetic_diff_auxfields { 
@@ -19,17 +20,18 @@ struct gkyl_dg_lbo_gyrokinetic_diff_auxfields {
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @param mass Species mass
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_gyrokinetic_diff_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass, bool use_gpu);
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass, bool use_gpu);
 
 /**
  * Create a new LBO equation object that lives on NV-GPU
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_gyrokinetic_diff_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass);
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass);
 
 /**
  * Set auxiliary fields needed in updating the diffusion flux term.

--- a/zero/gkyl_dg_lbo_gyrokinetic_diff_priv.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_diff_priv.h
@@ -108,6 +108,7 @@ struct dg_lbo_gyrokinetic_diff {
   struct gkyl_range conf_range; // Configuration space range.
   double mass; // Species mass.
   struct gkyl_dg_lbo_gyrokinetic_diff_auxfields auxfields; // Auxiliary fields.
+  double vparMax, vparMaxSq;
 };
 
 void gkyl_lbo_gyrokinetic_diff_free(const struct gkyl_ref_count* ref);
@@ -119,12 +120,17 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
 {
   struct dg_lbo_gyrokinetic_diff *lbo_gyrokinetic_diff = container_of(eqn, struct dg_lbo_gyrokinetic_diff, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_diff->conf_range, idx);
-  return lbo_gyrokinetic_diff->vol(xc, dx, lbo_gyrokinetic_diff->mass, 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx), 
-    qIn, qRhsOut);
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  if ((fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq)) {
+    return lbo_gyrokinetic_diff->vol(xc, dx, lbo_gyrokinetic_diff->mass, 
+      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
+  } else {
+    return 0.;
+  };
 }
 
 GKYL_CU_D
@@ -138,13 +144,16 @@ surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_gyrokinetic_diff *lbo_gyrokinetic_diff = container_of(eqn, struct dg_lbo_gyrokinetic_diff, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_diff->conf_range, idxC);
-  if (dir >= lbo_gyrokinetic_diff->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  if ((dir >= lbo_gyrokinetic_diff->cdim) &&
+      (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq))
+  {
     lbo_gyrokinetic_diff->surf[dir-lbo_gyrokinetic_diff->cdim](xcC, dxC, lbo_gyrokinetic_diff->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx), 
-      qInL, qInC, qInR, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qInL, qInC, qInR, qRhsOut);
   }
 }
 
@@ -159,14 +168,17 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_gyrokinetic_diff *lbo_gyrokinetic_diff = container_of(eqn, struct dg_lbo_gyrokinetic_diff, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_diff->conf_range, idxSkin);
-  if (dir >= lbo_gyrokinetic_diff->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  if ((dir >= lbo_gyrokinetic_diff->cdim) &&
+      (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq))
+  {
     lbo_gyrokinetic_diff->boundary_surf[dir-lbo_gyrokinetic_diff->cdim](xcSkin, dxSkin, 
       lbo_gyrokinetic_diff->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx),   
-      edge, qInEdge, qInSkin, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, edge, qInEdge, qInSkin, qRhsOut);
   }
 }
 

--- a/zero/gkyl_dg_lbo_gyrokinetic_drag.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_drag.h
@@ -4,6 +4,7 @@
 #include <gkyl_basis.h>
 #include <gkyl_dg_eqn.h>
 #include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
 
 // Struct containing the pointers to auxiliary fields.
 struct gkyl_dg_lbo_gyrokinetic_drag_auxfields { 
@@ -19,17 +20,18 @@ struct gkyl_dg_lbo_gyrokinetic_drag_auxfields {
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @param mass Species mass
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_gyrokinetic_drag_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass, bool use_gpu);
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass, bool use_gpu);
 
 /**
  * Create a new LBO equation object that lives on NV-GPU
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_gyrokinetic_drag_cu_dev_new(const struct gkyl_basis* cbasis, const struct gkyl_basis* pbasis, 
-  const struct gkyl_range* conf_range, double mass);
+  const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid, double mass);
 
 /**
  * Set auxiliary fields needed in updating the drag flux term.

--- a/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
@@ -130,7 +130,7 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
       nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
   } else {
     return 0.;
-  };
+  }
 }
 
 GKYL_CU_D

--- a/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
@@ -108,6 +108,7 @@ struct dg_lbo_gyrokinetic_drag {
   struct gkyl_range conf_range; // Configuration space range.
   double mass; // Species mass.
   struct gkyl_dg_lbo_gyrokinetic_drag_auxfields auxfields; // Auxiliary fields.
+  double vparMax, vparMaxSq;
 };
 
 void gkyl_lbo_gyrokinetic_drag_free(const struct gkyl_ref_count* ref);
@@ -119,12 +120,17 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
 {
   struct dg_lbo_gyrokinetic_drag *lbo_gyrokinetic_drag = container_of(eqn, struct dg_lbo_gyrokinetic_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_drag->conf_range, idx);
-  return lbo_gyrokinetic_drag->vol(xc, dx, lbo_gyrokinetic_drag->mass, 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx), 
-    qIn, qRhsOut);
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx);
+  if ((fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq)) {
+    return lbo_gyrokinetic_drag->vol(xc, dx, lbo_gyrokinetic_drag->mass, 
+      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
+  } else {
+    return 0.;
+  };
 }
 
 GKYL_CU_D
@@ -138,13 +144,16 @@ surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_gyrokinetic_drag *lbo_gyrokinetic_drag = container_of(eqn, struct dg_lbo_gyrokinetic_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_drag->conf_range, idxC);
-  if (dir >= lbo_gyrokinetic_drag->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx); 
+  if ((dir >= lbo_gyrokinetic_drag->cdim) &&
+      (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq))
+  {
     lbo_gyrokinetic_drag->surf[dir-lbo_gyrokinetic_drag->cdim](xcC, dxC, lbo_gyrokinetic_drag->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx), 
-      qInL, qInC, qInR, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qInL, qInC, qInR, qRhsOut);
   }
 }
 
@@ -159,14 +168,17 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_gyrokinetic_drag *lbo_gyrokinetic_drag = container_of(eqn, struct dg_lbo_gyrokinetic_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_gyrokinetic_drag->conf_range, idxSkin);
-  if (dir >= lbo_gyrokinetic_drag->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx); 
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx);
+  if ((dir >= lbo_gyrokinetic_drag->cdim) &&
+      (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq))
+  {
     lbo_gyrokinetic_drag->boundary_surf[dir-lbo_gyrokinetic_drag->cdim](xcSkin, dxSkin, 
       lbo_gyrokinetic_drag->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx),  
-      edge, qInSkin, qInEdge, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, edge, qInSkin, qInEdge, qRhsOut);
   }
 }
 

--- a/zero/gkyl_dg_lbo_vlasov_diff.h
+++ b/zero/gkyl_dg_lbo_vlasov_diff.h
@@ -4,6 +4,7 @@
 #include <gkyl_basis.h>
 #include <gkyl_dg_eqn.h>
 #include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
 
 // Struct containing the pointers to auxiliary fields.
 struct gkyl_dg_lbo_vlasov_diff_auxfields { 
@@ -18,10 +19,12 @@ struct gkyl_dg_lbo_vlasov_diff_auxfields {
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_diff_new(const struct gkyl_basis* cbasis,
-  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range, bool use_gpu);
+  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range,
+  const struct gkyl_rect_grid *pgrid, bool use_gpu);
 
 /**
  * Create a new LBO equation object that lives on NV-GPU
@@ -29,10 +32,11 @@ struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_diff_new(const struct gkyl_basis* cbasis,
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_diff_cu_dev_new(const struct gkyl_basis* cbasis,
-  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range);
+  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid);
 
 /**
  * Set auxiliary fields needed in updating the diffusion flux term.

--- a/zero/gkyl_dg_lbo_vlasov_drag.h
+++ b/zero/gkyl_dg_lbo_vlasov_drag.h
@@ -4,6 +4,7 @@
 #include <gkyl_basis.h>
 #include <gkyl_dg_eqn.h>
 #include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
 
 // Struct containing the pointers to auxiliary fields.
 struct gkyl_dg_lbo_vlasov_drag_auxfields {
@@ -18,10 +19,12 @@ struct gkyl_dg_lbo_vlasov_drag_auxfields {
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_drag_new(const struct gkyl_basis* cbasis,
-  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range, bool use_gpu);
+  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range,
+  const struct gkyl_rect_grid *pgrid, bool use_gpu);
 
 /**
  * Create a new LBO equation object that lives on NV-GPU
@@ -29,10 +32,11 @@ struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_drag_new(const struct gkyl_basis* cbasis,
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis functions
  * @param conf_range Configuration space range for use in indexing primitive moments
+ * @param pgrid Phase-space grid object.
  * @return Pointer to LBO equation object
  */
 struct gkyl_dg_eqn* gkyl_dg_lbo_vlasov_drag_cu_dev_new(const struct gkyl_basis* cbasis,
-  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range);
+  const struct gkyl_basis* pbasis, const struct gkyl_range* conf_range, const struct gkyl_rect_grid *pgrid);
 
 /**
  * Set auxiliary fields needed in updating the drag flux term.

--- a/zero/gkyl_dg_lbo_vlasov_drag_priv.h
+++ b/zero/gkyl_dg_lbo_vlasov_drag_priv.h
@@ -238,16 +238,36 @@ static const gkyl_dg_lbo_vlasov_drag_boundary_surf_kern_list ser_boundary_surf_v
 
 struct dg_lbo_vlasov_drag {
   struct gkyl_dg_eqn eqn; // Base object
-  int cdim; // Config-space dimensions
-  int pdim; // Phase-space dimensions
+  int cdim; // Config-space dimensions.
+  int vdim; // Velocity-space dimensions.
+  int pdim; // Phase-space dimensions.
   lbo_vlasov_drag_vol_t vol; // Volume kernel
   lbo_vlasov_drag_surf_t surf[3]; // Surface terms for acceleration
   lbo_vlasov_drag_boundary_surf_t boundary_surf[3]; // Surface terms for acceleration
   struct gkyl_range conf_range; // Configuration space range.
   struct gkyl_dg_lbo_vlasov_drag_auxfields auxfields; // Auxiliary fields.
+  double viMax[3], vMaxSq;
+  int num_cbasis;
 };
 
 void gkyl_lbo_vlasov_drag_free(const struct gkyl_ref_count* ref);
+
+GKYL_CU_D
+static inline bool
+checkPrimMomCross(struct dg_lbo_vlasov_drag *lbo_vlasov_drag,
+  const double* nuSum_p, const double* nuUSum_p, const double* nuVtSqSum_p) {
+  bool noPrimMomCross = true;
+  for (int d=0; d<lbo_vlasov_drag->vdim; d++) {
+    if (fabs(nuUSum_p[d*lbo_vlasov_drag->num_cbasis]/nuSum_p[0]) > lbo_vlasov_drag->viMax[d]) {
+       noPrimMomCross = false;
+       break;
+    }
+  }
+  noPrimMomCross = noPrimMomCross && ((nuVtSqSum_p[0]>0.)
+    && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_vlasov_drag->vMaxSq));
+  return noPrimMomCross;
+}
+
 
 GKYL_CU_D
 static double
@@ -256,11 +276,17 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
 {
   struct dg_lbo_vlasov_drag *lbo_vlasov_drag = container_of(eqn, struct dg_lbo_vlasov_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_vlasov_drag->conf_range, idx);
-  return lbo_vlasov_drag->vol(xc, dx, 
-    (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx), 
-    (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx), 
-    qIn, qRhsOut);
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx);
+  bool noPrimMomCross = checkPrimMomCross(lbo_vlasov_drag, nuSum_p, nuUSum_p, nuVtSqSum_p);
+  if (noPrimMomCross) {
+    return lbo_vlasov_drag->vol(xc, dx,
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
+  } else {
+    return 0.;
+  }
+
 }
 
 GKYL_CU_D
@@ -274,12 +300,13 @@ surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_vlasov_drag *lbo_vlasov_drag = container_of(eqn, struct dg_lbo_vlasov_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_vlasov_drag->conf_range, idxC);
-  if (dir >= lbo_vlasov_drag->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx);
+  bool noPrimMomCross = checkPrimMomCross(lbo_vlasov_drag, nuSum_p, nuUSum_p, nuVtSqSum_p);
+  if ((dir >= lbo_vlasov_drag->cdim) && (noPrimMomCross)) {
     lbo_vlasov_drag->surf[dir-lbo_vlasov_drag->cdim](xcC, dxC, 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx), 
-      qInL, qInC, qInR, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, qInL, qInC, qInR, qRhsOut);
   }
 }
 
@@ -294,12 +321,13 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
 {
   struct dg_lbo_vlasov_drag *lbo_vlasov_drag = container_of(eqn, struct dg_lbo_vlasov_drag, eqn);
   long cidx = gkyl_range_idx(&lbo_vlasov_drag->conf_range, idxSkin);
-  if (dir >= lbo_vlasov_drag->cdim) {
+  const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx);
+  const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx);
+  const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx);
+  bool noPrimMomCross = checkPrimMomCross(lbo_vlasov_drag, nuSum_p, nuUSum_p, nuVtSqSum_p);
+  if ((dir >= lbo_vlasov_drag->cdim) && (noPrimMomCross)) {
     lbo_vlasov_drag->boundary_surf[dir-lbo_vlasov_drag->cdim](xcSkin, dxSkin, 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuUSum, cidx), 
-      (const double*) gkyl_array_cfetch(lbo_vlasov_drag->auxfields.nuVtSqSum, cidx),  
-      edge, qInSkin, qInEdge, qRhsOut);
+      nuSum_p, nuUSum_p, nuVtSqSum_p, edge, qInSkin, qInEdge, qRhsOut);
   }
 }
 


### PR DESCRIPTION
Under certain circumstances the LBO cross primitive moments, u and vtSq, can acquire unreasonable results, like

u > v_max
vtSq < 0
vtSq > v_max^2

Add if-statements in the LBO equation objects so that in these cases we turn the LBO off. We had this in g2 and it may improve stability. 

In g2 we did two more things:
- We kept track of how often the LBO gets turned off.
- We also turned the LBO off if M2<0.
at some point we should implement these in g0 as well, but for now I want to check if these are sufficient to get rid of some numerical instabilities.