### PR TITLE
Add a M2>0 check to GkLBO. Turn off if false.

### DIFF
--- a/zero/dg_lbo_gyrokinetic_diff.c
+++ b/zero/dg_lbo_gyrokinetic_diff.c
@@ -26,7 +26,8 @@ gkyl_lbo_gyrokinetic_diff_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
 
 #ifdef GKYL_HAVE_CUDA
  if (gkyl_array_is_cu_dev(auxin.bmag_inv) && gkyl_array_is_cu_dev(auxin.nuSum) &&
-     gkyl_array_is_cu_dev(auxin.nuUSum) && gkyl_array_is_cu_dev(auxin.nuVtSqSum)) {
+     gkyl_array_is_cu_dev(auxin.nuUSum) && gkyl_array_is_cu_dev(auxin.nuVtSqSum) &&
+     gkyl_array_is_cu_dev(auxin.m2self)) {
    gkyl_lbo_gyrokinetic_diff_set_auxfields_cu(eqn->on_dev, auxin);
    return;
  }
@@ -37,6 +38,7 @@ gkyl_lbo_gyrokinetic_diff_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
   lbo_gyrokinetic_diff->auxfields.nuSum = auxin.nuSum;
   lbo_gyrokinetic_diff->auxfields.nuUSum = auxin.nuUSum;
   lbo_gyrokinetic_diff->auxfields.nuVtSqSum = auxin.nuVtSqSum;
+  lbo_gyrokinetic_diff->auxfields.m2self = auxin.m2self;
 }
 
 struct gkyl_dg_eqn*
@@ -101,6 +103,7 @@ gkyl_dg_lbo_gyrokinetic_diff_new(const struct gkyl_basis* cbasis, const struct g
   lbo_gyrokinetic_diff->auxfields.nuSum = 0;
   lbo_gyrokinetic_diff->auxfields.nuUSum = 0;
   lbo_gyrokinetic_diff->auxfields.nuVtSqSum = 0;
+  lbo_gyrokinetic_diff->auxfields.m2self = 0;
   lbo_gyrokinetic_diff->conf_range = *conf_range;
 
   lbo_gyrokinetic_diff->eqn.flags = 0;

--- a/zero/dg_lbo_gyrokinetic_diff_cu.cu
+++ b/zero/dg_lbo_gyrokinetic_diff_cu.cu
@@ -15,13 +15,15 @@ extern "C" {
 __global__ static void
 gkyl_lbo_gyrokinetic_diff_set_auxfields_cu_kernel(const struct gkyl_dg_eqn *eqn, 
   const struct gkyl_array *bmag_inv, const struct gkyl_array *nuSum,
-  const struct gkyl_array *nuUSum, const struct gkyl_array *nuVtSqSum)
+  const struct gkyl_array *nuUSum, const struct gkyl_array *nuVtSqSum,
+  const struct gkyl_array *m2self)
 {
   struct dg_lbo_gyrokinetic_diff *lbo_gyrokinetic_diff = container_of(eqn, struct dg_lbo_gyrokinetic_diff, eqn);
   lbo_gyrokinetic_diff->auxfields.bmag_inv = bmag_inv;
   lbo_gyrokinetic_diff->auxfields.nuSum = nuSum;
   lbo_gyrokinetic_diff->auxfields.nuUSum = nuUSum;
   lbo_gyrokinetic_diff->auxfields.nuVtSqSum = nuVtSqSum;
+  lbo_gyrokinetic_diff->auxfields.m2self = m2self;
 }
 
 //// Host-side wrapper for device kernels setting nuSum, nuUSum and nuVtSqSum.
@@ -30,7 +32,8 @@ gkyl_lbo_gyrokinetic_diff_set_auxfields_cu(const struct gkyl_dg_eqn *eqn, struct
 {
   gkyl_lbo_gyrokinetic_diff_set_auxfields_cu_kernel<<<1,1>>>(eqn, 
     auxin.bmag_inv->on_dev, auxin.nuSum->on_dev,
-    auxin.nuUSum->on_dev, auxin.nuVtSqSum->on_dev);
+    auxin.nuUSum->on_dev, auxin.nuVtSqSum->on_dev,
+    auxin.m2self->on_dev);
 }
 
 // CUDA kernel to set device pointers to range object and gyrokinetic LBO kernel function
@@ -43,6 +46,7 @@ dg_lbo_gyrokinetic_diff_set_cu_dev_ptrs(struct dg_lbo_gyrokinetic_diff *lbo_gyro
   lbo_gyrokinetic_diff->auxfields.nuSum = 0; 
   lbo_gyrokinetic_diff->auxfields.nuUSum = 0; 
   lbo_gyrokinetic_diff->auxfields.nuVtSqSum = 0; 
+  lbo_gyrokinetic_diff->auxfields.m2self = 0; 
 
   lbo_gyrokinetic_diff->eqn.vol_term = vol;
   lbo_gyrokinetic_diff->eqn.surf_term = surf;

--- a/zero/dg_lbo_gyrokinetic_drag.c
+++ b/zero/dg_lbo_gyrokinetic_drag.c
@@ -26,7 +26,8 @@ gkyl_lbo_gyrokinetic_drag_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
 
 #ifdef GKYL_HAVE_CUDA
  if (gkyl_array_is_cu_dev(auxin.bmag_inv) && gkyl_array_is_cu_dev(auxin.nuSum) &&
-     gkyl_array_is_cu_dev(auxin.nuUSum) && gkyl_array_is_cu_dev(auxin.nuVtSqSum)) {
+     gkyl_array_is_cu_dev(auxin.nuUSum) && gkyl_array_is_cu_dev(auxin.nuVtSqSum) &&
+     gkyl_array_is_cu_dev(auxin.m2self)) {
    gkyl_lbo_gyrokinetic_drag_set_auxfields_cu(eqn->on_dev, auxin);
    return;
  }
@@ -37,6 +38,7 @@ gkyl_lbo_gyrokinetic_drag_set_auxfields(const struct gkyl_dg_eqn *eqn, struct gk
   lbo_gyrokinetic_drag->auxfields.nuSum = auxin.nuSum;
   lbo_gyrokinetic_drag->auxfields.nuUSum = auxin.nuUSum;
   lbo_gyrokinetic_drag->auxfields.nuVtSqSum = auxin.nuVtSqSum;
+  lbo_gyrokinetic_drag->auxfields.m2self = auxin.m2self;
 }
 
 
@@ -102,6 +104,7 @@ gkyl_dg_lbo_gyrokinetic_drag_new(const struct gkyl_basis* cbasis, const struct g
   lbo_gyrokinetic_drag->auxfields.nuSum = 0;
   lbo_gyrokinetic_drag->auxfields.nuUSum = 0;
   lbo_gyrokinetic_drag->auxfields.nuVtSqSum = 0;
+  lbo_gyrokinetic_drag->auxfields.m2self = 0;
   lbo_gyrokinetic_drag->conf_range = *conf_range;
 
   lbo_gyrokinetic_drag->eqn.flags = 0;

--- a/zero/dg_lbo_gyrokinetic_drag_cu.cu
+++ b/zero/dg_lbo_gyrokinetic_drag_cu.cu
@@ -15,13 +15,15 @@ extern "C" {
 __global__ static void
 gkyl_lbo_gyrokinetic_drag_set_auxfields_cu_kernel(const struct gkyl_dg_eqn *eqn, 
   const struct gkyl_array *bmag_inv, const struct gkyl_array *nuSum,
-  const struct gkyl_array *nuUSum, const struct gkyl_array *nuVtSqSum)
+  const struct gkyl_array *nuUSum, const struct gkyl_array *nuVtSqSum,
+  const struct gkyl_array *m2self)
 {
   struct dg_lbo_gyrokinetic_drag *lbo_gyrokinetic_drag = container_of(eqn, struct dg_lbo_gyrokinetic_drag, eqn);
   lbo_gyrokinetic_drag->auxfields.bmag_inv = bmag_inv;
   lbo_gyrokinetic_drag->auxfields.nuSum = nuSum;
   lbo_gyrokinetic_drag->auxfields.nuUSum = nuUSum;
   lbo_gyrokinetic_drag->auxfields.nuVtSqSum = nuVtSqSum;
+  lbo_gyrokinetic_drag->auxfields.m2self = m2self;
 }
 
 //// Host-side wrapper for device kernels setting nuSum, nuUSum and nuVtSqSum.
@@ -30,7 +32,8 @@ gkyl_lbo_gyrokinetic_drag_set_auxfields_cu(const struct gkyl_dg_eqn *eqn, struct
 {
   gkyl_lbo_gyrokinetic_drag_set_auxfields_cu_kernel<<<1,1>>>(eqn, 
     auxin.bmag_inv->on_dev, auxin.nuSum->on_dev,
-    auxin.nuUSum->on_dev, auxin.nuVtSqSum->on_dev);
+    auxin.nuUSum->on_dev, auxin.nuVtSqSum->on_dev,
+    auxin.m2self->on_dev);
 }
 
 // CUDA kernel to set device pointers to range object and gyrokinetic LBO kernel function
@@ -43,6 +46,7 @@ dg_lbo_gyrokinetic_drag_set_cu_dev_ptrs(struct dg_lbo_gyrokinetic_drag *lbo_gyro
   lbo_gyrokinetic_drag->auxfields.nuSum = 0; 
   lbo_gyrokinetic_drag->auxfields.nuUSum = 0; 
   lbo_gyrokinetic_drag->auxfields.nuVtSqSum = 0; 
+  lbo_gyrokinetic_drag->auxfields.m2self = 0; 
 
   lbo_gyrokinetic_drag->eqn.vol_term = vol;
   lbo_gyrokinetic_drag->eqn.surf_term = surf;

--- a/zero/dg_updater_lbo_gyrokinetic.c
+++ b/zero/dg_updater_lbo_gyrokinetic.c
@@ -42,14 +42,15 @@ gkyl_dg_updater_lbo_gyrokinetic_advance(gkyl_dg_updater_lbo_gyrokinetic *lbo,
   const struct gkyl_range *update_rng,
   const struct gkyl_array *bmag_inv,
   const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *m2self, 
   const struct gkyl_array* GKYL_RESTRICT fIn,
   struct gkyl_array* GKYL_RESTRICT cflrate, struct gkyl_array* GKYL_RESTRICT rhs)
 {
   // Set arrays needed
   gkyl_lbo_gyrokinetic_drag_set_auxfields(lbo->coll_drag,
-    (struct gkyl_dg_lbo_gyrokinetic_drag_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq });
+    (struct gkyl_dg_lbo_gyrokinetic_drag_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq, .m2self = m2self });
   gkyl_lbo_gyrokinetic_diff_set_auxfields(lbo->coll_diff,
-    (struct gkyl_dg_lbo_gyrokinetic_diff_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq });
+    (struct gkyl_dg_lbo_gyrokinetic_diff_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq, .m2self = m2self });
   
   gkyl_hyper_dg_advance(lbo->diff, update_rng, fIn, cflrate, rhs);
   gkyl_hyper_dg_advance(lbo->drag, update_rng, fIn, cflrate, rhs);
@@ -72,14 +73,15 @@ gkyl_dg_updater_lbo_gyrokinetic_advance_cu(gkyl_dg_updater_lbo_gyrokinetic *lbo,
   const struct gkyl_range *update_rng,
   const struct gkyl_array *bmag_inv,
   const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *m2self, 
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT cflrate,
   struct gkyl_array* GKYL_RESTRICT rhs)
 {
   // Set arrays needed
   gkyl_lbo_gyrokinetic_drag_set_auxfields(lbo->coll_drag,
-    (struct gkyl_dg_lbo_gyrokinetic_drag_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq });
+    (struct gkyl_dg_lbo_gyrokinetic_drag_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq, .m2self = m2self });
   gkyl_lbo_gyrokinetic_diff_set_auxfields(lbo->coll_diff,
-    (struct gkyl_dg_lbo_gyrokinetic_diff_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq });
+    (struct gkyl_dg_lbo_gyrokinetic_diff_auxfields) { .bmag_inv = bmag_inv, .nuSum = nu_sum, .nuUSum = nu_u, .nuVtSqSum = nu_vthsq, .m2self = m2self });
 
   gkyl_hyper_dg_advance_cu(lbo->diff, update_rng, fIn, cflrate, rhs);
   gkyl_hyper_dg_advance_cu(lbo->drag, update_rng, fIn, cflrate, rhs);
@@ -94,6 +96,7 @@ gkyl_dg_updater_lbo_gyrokinetic_advance_cu(gkyl_dg_updater_lbo_gyrokinetic *lbo,
   const struct gkyl_range *update_rng,
   const struct gkyl_array *bmag_inv,
   const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq, 
+  const struct gkyl_array *m2self, 
   const struct gkyl_array *fIn, struct gkyl_array *cflrate, struct gkyl_array *rhs)
 {
   assert(false);

--- a/zero/gkyl_dg_lbo_gyrokinetic_diff.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_diff.h
@@ -12,6 +12,7 @@ struct gkyl_dg_lbo_gyrokinetic_diff_auxfields {
   const struct gkyl_array *nuSum;
   const struct gkyl_array *nuUSum;
   const struct gkyl_array *nuVtSqSum;
+  const struct gkyl_array *m2self;
 };
 
 /**

--- a/zero/gkyl_dg_lbo_gyrokinetic_diff_priv.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_diff_priv.h
@@ -123,8 +123,10 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.m2self, cidx);
   if ((fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq)) {
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq) &&
+      (m2self_p[0]>0.)) {
     return lbo_gyrokinetic_diff->vol(xc, dx, lbo_gyrokinetic_diff->mass, 
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
       nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
@@ -147,9 +149,11 @@ surf(const struct gkyl_dg_eqn *eqn,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.m2self, cidx);
   if ((dir >= lbo_gyrokinetic_diff->cdim) &&
       (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq))
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq) &&
+      (m2self_p[0]>0.))
   {
     lbo_gyrokinetic_diff->surf[dir-lbo_gyrokinetic_diff->cdim](xcC, dxC, lbo_gyrokinetic_diff->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.bmag_inv, cidx), 
@@ -171,9 +175,11 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuUSum, cidx);
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.nuVtSqSum, cidx);
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_diff->auxfields.m2self, cidx);
   if ((dir >= lbo_gyrokinetic_diff->cdim) &&
       (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_diff->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq))
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_diff->vparMaxSq) &&
+      (m2self_p[0]>0.))
   {
     lbo_gyrokinetic_diff->boundary_surf[dir-lbo_gyrokinetic_diff->cdim](xcSkin, dxSkin, 
       lbo_gyrokinetic_diff->mass,

--- a/zero/gkyl_dg_lbo_gyrokinetic_drag.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_drag.h
@@ -12,6 +12,7 @@ struct gkyl_dg_lbo_gyrokinetic_drag_auxfields {
   const struct gkyl_array *nuSum;
   const struct gkyl_array *nuUSum;
   const struct gkyl_array *nuVtSqSum;
+  const struct gkyl_array *m2self;
 };
 
 /**

--- a/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
+++ b/zero/gkyl_dg_lbo_gyrokinetic_drag_priv.h
@@ -123,8 +123,10 @@ vol(const struct gkyl_dg_eqn *eqn, const double*  xc, const double*  dx,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx);
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx);
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.m2self, cidx);
   if ((fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq)) {
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq) &&
+      (m2self_p[0]>0.)) {
     return lbo_gyrokinetic_drag->vol(xc, dx, lbo_gyrokinetic_drag->mass, 
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
       nuSum_p, nuUSum_p, nuVtSqSum_p, qIn, qRhsOut);
@@ -147,9 +149,11 @@ surf(const struct gkyl_dg_eqn *eqn,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx);
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx); 
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.m2self, cidx);
   if ((dir >= lbo_gyrokinetic_drag->cdim) &&
       (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq))
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq) &&
+      (m2self_p[0]>0.))
   {
     lbo_gyrokinetic_drag->surf[dir-lbo_gyrokinetic_drag->cdim](xcC, dxC, lbo_gyrokinetic_drag->mass,
       (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.bmag_inv, cidx), 
@@ -171,9 +175,11 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
   const double* nuSum_p     = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuSum, cidx);
   const double* nuUSum_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuUSum, cidx); 
   const double* nuVtSqSum_p = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.nuVtSqSum, cidx);
+  const double* m2self_p    = (const double*) gkyl_array_cfetch(lbo_gyrokinetic_drag->auxfields.m2self, cidx);
   if ((dir >= lbo_gyrokinetic_drag->cdim) &&
       (fabs(nuUSum_p[0]/nuSum_p[0]) < lbo_gyrokinetic_drag->vparMax) &&
-      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq))
+      (nuVtSqSum_p[0]>0.) && (nuVtSqSum_p[0]/nuSum_p[0] < lbo_gyrokinetic_drag->vparMaxSq) &&
+      (m2self_p[0]>0.))
   {
     lbo_gyrokinetic_drag->boundary_surf[dir-lbo_gyrokinetic_drag->cdim](xcSkin, dxSkin, 
       lbo_gyrokinetic_drag->mass,

--- a/zero/gkyl_dg_updater_lbo_gyrokinetic.h
+++ b/zero/gkyl_dg_updater_lbo_gyrokinetic.h
@@ -34,6 +34,7 @@ gkyl_dg_updater_lbo_gyrokinetic* gkyl_dg_updater_lbo_gyrokinetic_new(const struc
  * @param nu_sum Sum of coll freq
  * @param nu_u Sum of coll freq*u
  * @param nu_vthsq Sum of coll freq*vth
+ * @param m2self 2nd velocity moment of this species.
  * @param fIn Input to updater
  * @param cflrate CFL scalar rate (frequency) array (units of 1/[T])
  * @param rhs RHS output
@@ -42,6 +43,7 @@ void gkyl_dg_updater_lbo_gyrokinetic_advance(gkyl_dg_updater_lbo_gyrokinetic *lb
   const struct gkyl_range *update_rng,
   const struct gkyl_array *bmag_inv,
   const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *m2self, 
   const struct gkyl_array* GKYL_RESTRICT fIn,
   struct gkyl_array* GKYL_RESTRICT cflrate, struct gkyl_array* GKYL_RESTRICT rhs);
 
@@ -49,6 +51,7 @@ void gkyl_dg_updater_lbo_gyrokinetic_advance_cu(gkyl_dg_updater_lbo_gyrokinetic 
   const struct gkyl_range *update_rng,
   const struct gkyl_array *bmag_inv,
   const struct gkyl_array *nu_sum, const struct gkyl_array *nu_u, const struct gkyl_array *nu_vthsq,
+  const struct gkyl_array *m2self, 
   const struct gkyl_array* GKYL_RESTRICT fIn,
   struct gkyl_array* GKYL_RESTRICT cflrate, struct gkyl_array* GKYL_RESTRICT rhs);
 


### PR DESCRIPTION
We had this check in g2.

I've done at least 1 simulation (1x2v p1, hot electron LTX case with constant B, showing unphysical oscillations at the boundaries) which used to run in g2 (although I later found an important error in the initial condition of the g2 simulation) but now crashes in g0-g2. After adding this check on M2, the simulation appears to run longer.

I think is is a temporary bandaid, and as @JunoRavin said in another PR (or private comm), perhaps a simulation that incurs in this M2<0 scenario should be discarded. I still think it is useful to keep a simulation that may have some negativity, but the result should be examined critically (for which we need more diagnostics), and it is certainly the case here that the result is unphysical (i.e. oscillatory near the sheath).

Interestingly, when I corrected the ICs (the initial upar_i was far too high), the simulation did not seem to run in g2 anymore. But after adding this M2>0 check in g0-g2 the simulation survived there. Maybe speaks to g0-g2 being more robust (?), at least in some cases, but more tests/applications are needed.

Only added it in GK since Vlasov devs do not seem as concerned (and it wasn't there in g2 anyway).

GkLBO regression tests pass