### PR TITLE
Spitzer and pow(sqrt()) updaters

### DIFF
--- a/unit/README.md
+++ b/unit/README.md
@@ -7,4 +7,4 @@ To create/run a new unit test:
 
 1. Write and save your unit test file in this folder (with a `ctest_` prefix).
 2. In the main directory re-compile the code.
-3. Run the test's executable in `build/unit`.
+3. Run the test's executable in `build/unit` (or in `cuda-build/unit` if running on GPU).

--- a/unit/ctest_proj_powsqrt_on_basis.c
+++ b/unit/ctest_proj_powsqrt_on_basis.c
@@ -1,0 +1,358 @@
+#include "gkyl_array.h"
+#include "gkyl_util.h"
+#include <acutest.h>
+#include "math.h"
+
+#include <gkyl_array_rio.h>
+#include <gkyl_proj_powsqrt_on_basis.h>
+#include <gkyl_proj_on_basis.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_decomp.h>
+#include <gkyl_rect_grid.h>
+
+// allocate array (filled with zeros)
+static struct gkyl_array*
+mkarr(long nc, long size)
+{
+  struct gkyl_array* a = gkyl_array_new(GKYL_DOUBLE, nc, size);
+  return a;
+}
+
+void eval_fun_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx));
+}
+void eval_powsqrt_fun_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  double exponent = 3;
+  double fun[1];
+  eval_fun_1x(t, xn, fun, ctx);
+  fout[0] = pow( sqrt(fun[0]), exponent);
+}
+
+void
+test_1x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI;
+  double lower[] = {-Lx/2.}, upper[] = {Lx/2.};
+  int cells[] = {32};
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create f, g=pow(sqrt(f), q) arrays.
+  struct gkyl_array *f, *g;
+  f = mkarr(basis.num_basis, local_ext.volume);
+  g = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *f_cu, *g_cu;
+  if (use_gpu) { // Create device copies
+    f_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    g_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_f = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_fun_1x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_f, 0.0, &local, f);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(f_cu, f);
+  }
+
+  // Create pow(sqrt( ), ) updater.
+  gkyl_proj_powsqrt_on_basis *proj_up = gkyl_proj_powsqrt_on_basis_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f_cu, g_cu);
+    gkyl_array_copy(g, g_cu);
+  } else {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f, g);
+  }
+
+  // Project expected g.
+  struct gkyl_array *gA;
+  gA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_g = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_powsqrt_fun_1x, NULL);
+  gkyl_proj_on_basis_advance(proj_g, 0.0, &local, gA);
+
+  for (int k=0; k<cells[0]; k++) {
+    int idx[] = {k+1};
+    long linidx = gkyl_range_idx(&local, idx);
+    const double *g_p = gkyl_array_cfetch(g, linidx);
+    const double *gA_p = gkyl_array_cfetch(gA, linidx);
+    for (int m=0; m<basis.num_basis; m++) {
+      TEST_CHECK( gkyl_compare(gA_p[m], g_p[m], 1e-10) );
+      TEST_MSG("Expected: %.13e in cell (%d)", gA_p[m], idx[0]);
+      TEST_MSG("Produced: %.13e", g_p[m]);
+    }
+  }
+
+  gkyl_array_release(f); gkyl_array_release(g); gkyl_array_release(gA);
+  if (use_gpu) {
+    gkyl_array_release(f_cu); gkyl_array_release(g_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_f);
+  gkyl_proj_on_basis_release(proj_g);
+
+  gkyl_proj_powsqrt_on_basis_release(proj_up);
+}
+
+void eval_fun_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly);
+}
+void eval_powsqrt_fun_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  double exponent = 3;
+  double fun[1];
+  eval_fun_2x(t, xn, fun, ctx);
+  fout[0] = pow( sqrt(fun[0]), exponent);
+}
+
+void
+test_2x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  double lower[] = {-Lx/2., -Ly/2.}, upper[] = {Lx/2., Ly/2.};
+  int cells[] = {16, 64};
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create f, g=pow(sqrt(f), q) arrays.
+  struct gkyl_array *f, *g;
+  f = mkarr(basis.num_basis, local_ext.volume);
+  g = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *f_cu, *g_cu;
+  if (use_gpu) { // Create device copies
+    f_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    g_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_f = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_fun_2x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_f, 0.0, &local, f);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(f_cu, f);
+  }
+
+  // Create pow(sqrt( ), ) updater.
+  gkyl_proj_powsqrt_on_basis *proj_up = gkyl_proj_powsqrt_on_basis_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f_cu, g_cu);
+    gkyl_array_copy(g, g_cu);
+  } else {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f, g);
+  }
+
+  // Project expected g.
+  struct gkyl_array *gA;
+  gA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_g = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_powsqrt_fun_2x, NULL);
+  gkyl_proj_on_basis_advance(proj_g, 0.0, &local, gA);
+
+  for (int j=0; j<cells[0]; j++) {
+    for (int k=0; k<cells[0]; k++) {
+      int idx[] = {j+1,k+1};
+      long linidx = gkyl_range_idx(&local, idx);
+      const double *g_p = gkyl_array_cfetch(g, linidx);
+      const double *gA_p = gkyl_array_cfetch(gA, linidx);
+      for (int m=0; m<basis.num_basis; m++) {
+        TEST_CHECK( gkyl_compare(gA_p[m], g_p[m], 4e-9) );
+        TEST_MSG("Expected: %.13e in cell (%d)", gA_p[m], idx[0]);
+        TEST_MSG("Produced: %.13e", g_p[m]);
+      }
+    }
+  }
+
+  gkyl_array_release(f); gkyl_array_release(g); gkyl_array_release(gA);
+  if (use_gpu) {
+    gkyl_array_release(f_cu); gkyl_array_release(g_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_f);
+  gkyl_proj_on_basis_release(proj_g);
+
+  gkyl_proj_powsqrt_on_basis_release(proj_up);
+}
+
+void eval_fun_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly)*(Lz/2.-0.5*fabs(z));
+}
+void eval_powsqrt_fun_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  double exponent = 3;
+  double fun[1];
+  eval_fun_3x(t, xn, fun, ctx);
+  fout[0] = pow( sqrt(fun[0]), exponent);
+}
+
+void
+test_3x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  double lower[] = {-Lx/2., -Ly/2., -Lz/2.}, upper[] = {Lx/2., Ly/2., Lz/2.};
+  int cells[] = {16, 64, 32};
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 1, 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create f, g=pow(sqrt(f), q) arrays.
+  struct gkyl_array *f, *g;
+  f = mkarr(basis.num_basis, local_ext.volume);
+  g = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *f_cu, *g_cu;
+  if (use_gpu) { // Create device copies
+    f_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    g_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_f = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_fun_3x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_f, 0.0, &local, f);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(f_cu, f);
+  }
+
+  // Create pow(sqrt( ), ) updater.
+  gkyl_proj_powsqrt_on_basis *proj_up = gkyl_proj_powsqrt_on_basis_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f_cu, g_cu);
+    gkyl_array_copy(g, g_cu);
+  } else {
+    gkyl_proj_powsqrt_on_basis_advance(proj_up, &local, 3, f, g);
+  }
+
+  // Project expected g.
+  struct gkyl_array *gA;
+  gA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_g = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_powsqrt_fun_3x, NULL);
+  gkyl_proj_on_basis_advance(proj_g, 0.0, &local, gA);
+
+  for (int i=0; i<cells[0]; i++) {
+    for (int j=0; j<cells[0]; j++) {
+      for (int k=0; k<cells[0]; k++) {
+        int idx[] = {i+1,j+1,k+1};
+        long linidx = gkyl_range_idx(&local, idx);
+        const double *g_p = gkyl_array_cfetch(g, linidx);
+        const double *gA_p = gkyl_array_cfetch(gA, linidx);
+        for (int m=0; m<basis.num_basis; m++) {
+          TEST_CHECK( gkyl_compare(gA_p[m], g_p[m], 1e-7) );
+          TEST_MSG("Expected: %.13e in cell (%d)", gA_p[m], idx[0]);
+          TEST_MSG("Produced: %.13e", g_p[m]);
+        }
+      }
+    }
+  }
+
+  gkyl_array_release(f); gkyl_array_release(g); gkyl_array_release(gA);
+  if (use_gpu) {
+    gkyl_array_release(f_cu); gkyl_array_release(g_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_f);
+  gkyl_proj_on_basis_release(proj_g);
+
+  gkyl_proj_powsqrt_on_basis_release(proj_up);
+}
+
+void test_1x_p1() { test_1x(1, false); }
+void test_1x_p2() { test_1x(2, false); }
+
+void test_2x_p1() { test_2x(1, false); }
+void test_2x_p2() { test_2x(2, false); }
+
+void test_3x_p1() { test_3x(1, false); }
+void test_3x_p2() { test_3x(2, false); }
+
+#ifdef GKYL_HAVE_CUDA
+void test_1x_p1_gpu() { test_1x(1, true); }
+void test_1x_p2_gpu() { test_1x(2, true); }
+
+void test_2x_p1_gpu() { test_2x(1, true); }
+void test_2x_p2_gpu() { test_2x(2, true); }
+
+void test_3x_p1_gpu() { test_3x(1, true); }
+void test_3x_p2_gpu() { test_3x(2, true); }
+#endif
+
+TEST_LIST = {
+  { "test_1x_p1", test_1x_p1 },
+  { "test_1x_p2", test_1x_p2 },
+
+  { "test_2x_p1", test_2x_p1 },
+  { "test_2x_p2", test_2x_p2 },
+
+  { "test_3x_p1", test_3x_p1 },
+  { "test_3x_p2", test_3x_p2 },
+#ifdef GKYL_HAVE_CUDA
+  { "test_1x_p1_gpu", test_1x_p1_gpu },
+  { "test_1x_p2_gpu", test_1x_p2_gpu },
+
+  { "test_2x_p1_gpu", test_2x_p1_gpu },
+  { "test_2x_p2_gpu", test_2x_p2_gpu },
+
+  { "test_3x_p1_gpu", test_3x_p1_gpu },
+  { "test_3x_p2_gpu", test_3x_p2_gpu },
+#endif
+  { NULL, NULL },
+};

--- a/unit/ctest_spitzer_coll_freq.c
+++ b/unit/ctest_spitzer_coll_freq.c
@@ -1,0 +1,505 @@
+#include "gkyl_array.h"
+#include "gkyl_util.h"
+#include <acutest.h>
+#include "math.h"
+
+#include <gkyl_array_rio.h>
+#include <gkyl_spitzer_coll_freq.h>
+#include <gkyl_proj_on_basis.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_decomp.h>
+#include <gkyl_rect_grid.h>
+
+// allocate array (filled with zeros)
+static struct gkyl_array*
+mkarr(long nc, long size)
+{
+  struct gkyl_array* a = gkyl_array_new(GKYL_DOUBLE, nc, size);
+  return a;
+}
+
+void eval_m0s_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx));
+}
+void eval_m0r_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx));
+}
+void eval_vtsqs_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  fout[0] = -x*x+1.5*pow(M_PI,2);
+}
+void eval_vtsqr_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  fout[0] = -x*x+3.5*pow(M_PI,2);
+}
+void eval_nu_1x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double Lx = 2.*M_PI;
+  double norm_nu = 1./3.;
+  double vtsqs[1], m0r[1], vtsqr[1];
+  eval_vtsqs_1x(t, xn, vtsqs, ctx);
+  eval_m0r_1x(t, xn, m0r, ctx);
+  eval_vtsqr_1x(t, xn, vtsqr, ctx);
+  fout[0] = norm_nu * m0r[0]/pow(vtsqs[0]+vtsqr[0],1.5);
+}
+
+void
+test_1x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI;
+  double lower[] = {-Lx/2.}, upper[] = {Lx/2.};
+  int cells[] = {32};
+
+  double norm_nu = 1./3.;
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create density and v_t^2 arrays.
+  struct gkyl_array *m0s, *vtsqs, *m0r, *vtsqr;
+  m0s = mkarr(basis.num_basis, local_ext.volume);
+  vtsqs = mkarr(basis.num_basis, local_ext.volume);
+  m0r = mkarr(basis.num_basis, local_ext.volume);
+  vtsqr = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *m0s_cu, *vtsqs_cu, *m0r_cu, *vtsqr_cu;
+  if (use_gpu) { // Create device copies
+    m0s_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqs_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    m0r_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqr_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_m0s = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0s_1x, NULL);
+  gkyl_proj_on_basis *proj_vtsqs = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqs_1x, NULL);
+  gkyl_proj_on_basis *proj_m0r = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0r_1x, NULL);
+  gkyl_proj_on_basis *proj_vtsqr = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqr_1x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_m0s, 0.0, &local, m0s);
+  gkyl_proj_on_basis_advance(proj_vtsqs, 0.0, &local, vtsqs);
+  gkyl_proj_on_basis_advance(proj_m0r, 0.0, &local, m0r);
+  gkyl_proj_on_basis_advance(proj_vtsqr, 0.0, &local, vtsqr);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(m0s_cu , m0s );
+    gkyl_array_copy(vtsqs_cu, vtsqs);
+    gkyl_array_copy(m0r_cu , m0r );
+    gkyl_array_copy(vtsqr_cu, vtsqr);
+  }
+
+  // Create collision frequency array.
+  struct gkyl_array *nu, *nu_cu;
+  nu = mkarr(basis.num_basis, local_ext.volume);
+  if (use_gpu)  // create device copy.
+    nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+
+  // Create Spitzer collision frequency updater.
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_array_copy(nu, nu_cu);
+  } else {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
+  }
+
+  // Project expected collision frequency and compare.
+  struct gkyl_array *nuA, *nuA_cu;
+  nuA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_nu_1x, NULL);
+  gkyl_proj_on_basis_advance(proj_nu, 0.0, &local, nuA);
+
+  for (int k=0; k<cells[0]; k++) {
+    int idx[] = {k+1};
+    long linidx = gkyl_range_idx(&local, idx);
+    const double *nu_p = gkyl_array_cfetch(nu, linidx);
+    const double *nuA_p = gkyl_array_cfetch(nuA, linidx);
+    for (int m=0; m<basis.num_basis; m++) {
+      TEST_CHECK( gkyl_compare(nuA_p[m], nu_p[m], 1e-10) );
+      TEST_MSG("Expected: %.13e in cell (%d)", nuA_p[m], idx[0]);
+      TEST_MSG("Produced: %.13e", nu_p[m]);
+    }
+  }
+
+  gkyl_array_release(m0s); gkyl_array_release(vtsqs); gkyl_array_release(m0r); gkyl_array_release(vtsqr);
+  gkyl_array_release(nu); gkyl_array_release(nuA);
+  if (use_gpu) {
+    gkyl_array_release(m0s_cu); gkyl_array_release(vtsqs_cu); gkyl_array_release(m0r_cu); gkyl_array_release(vtsqr_cu);
+    gkyl_array_release(nu_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_m0s);
+  gkyl_proj_on_basis_release(proj_vtsqs);
+  gkyl_proj_on_basis_release(proj_m0r);
+  gkyl_proj_on_basis_release(proj_vtsqr);
+  gkyl_proj_on_basis_release(proj_nu);
+
+  gkyl_spitzer_coll_freq_release(spitz_up);
+}
+
+void eval_m0s_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly);
+}
+void eval_m0r_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly);
+}
+void eval_vtsqs_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  fout[0] = (-x*x+1.5*pow(M_PI,2))*0.5*(1.+cos(0.5*2.*M_PI*y/Ly));
+}
+void eval_vtsqr_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  fout[0] = (-x*x+3.5*pow(M_PI,2))*0.5*(1.+cos(0.5*2.*M_PI*y/Ly));
+}
+void eval_nu_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  double norm_nu = 1./3.;
+  double vtsqs[1], m0r[1], vtsqr[1];
+  eval_vtsqs_2x(t, xn, vtsqs, ctx);
+  eval_m0r_2x(t, xn, m0r, ctx);
+  eval_vtsqr_2x(t, xn, vtsqr, ctx);
+  fout[0] = norm_nu * m0r[0]/pow(vtsqs[0]+vtsqr[0],1.5);
+}
+
+void
+test_2x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI, Ly = 8.*M_PI;
+  double lower[] = {-Lx/2., -Ly/2.}, upper[] = {Lx/2., Ly/2.};
+  int cells[] = {32, 128};
+
+  double norm_nu = 1./3.;
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create density and v_t^2 arrays.
+  struct gkyl_array *m0s, *vtsqs, *m0r, *vtsqr;
+  m0s = mkarr(basis.num_basis, local_ext.volume);
+  vtsqs = mkarr(basis.num_basis, local_ext.volume);
+  m0r = mkarr(basis.num_basis, local_ext.volume);
+  vtsqr = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *m0s_cu, *vtsqs_cu, *m0r_cu, *vtsqr_cu;
+  if (use_gpu) { // Create device copies
+    m0s_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqs_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    m0r_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqr_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_m0s = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0s_2x, NULL);
+  gkyl_proj_on_basis *proj_vtsqs = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqs_2x, NULL);
+  gkyl_proj_on_basis *proj_m0r = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0r_2x, NULL);
+  gkyl_proj_on_basis *proj_vtsqr = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqr_2x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_m0s, 0.0, &local, m0s);
+  gkyl_proj_on_basis_advance(proj_vtsqs, 0.0, &local, vtsqs);
+  gkyl_proj_on_basis_advance(proj_m0r, 0.0, &local, m0r);
+  gkyl_proj_on_basis_advance(proj_vtsqr, 0.0, &local, vtsqr);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(m0s_cu , m0s );
+    gkyl_array_copy(vtsqs_cu, vtsqs);
+    gkyl_array_copy(m0r_cu , m0r );
+    gkyl_array_copy(vtsqr_cu, vtsqr);
+  }
+
+  // Create collision frequency array.
+  struct gkyl_array *nu, *nu_cu;
+  nu = mkarr(basis.num_basis, local_ext.volume);
+  if (use_gpu)  // create device copy.
+    nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+
+  // Create Spitzer collision frequency updater.
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_array_copy(nu, nu_cu);
+  } else {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
+  }
+
+  // Project expected collision frequency and compare.
+  struct gkyl_array *nuA, *nuA_cu;
+  nuA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_nu_2x, NULL);
+  gkyl_proj_on_basis_advance(proj_nu, 0.0, &local, nuA);
+
+  for (int j=0; j<cells[0]; j++) {
+    for (int k=0; k<cells[1]; k++) {
+      int idx[] = {j+1,k+1};
+      long linidx = gkyl_range_idx(&local, idx);
+      const double *nu_p = gkyl_array_cfetch(nu, linidx);
+      const double *nuA_p = gkyl_array_cfetch(nuA, linidx);
+      for (int m=0; m<basis.num_basis; m++) {
+        TEST_CHECK( gkyl_compare(nuA_p[m], nu_p[m], 1e-6) );
+        TEST_MSG("Expected: %.13e in cell (%d)", nuA_p[m], idx[0]);
+        TEST_MSG("Produced: %.13e", nu_p[m]);
+      }
+    }
+  }
+
+  gkyl_array_release(m0s); gkyl_array_release(vtsqs); gkyl_array_release(m0r); gkyl_array_release(vtsqr);
+  gkyl_array_release(nu); gkyl_array_release(nuA);
+  if (use_gpu) {
+    gkyl_array_release(m0s_cu); gkyl_array_release(vtsqs_cu); gkyl_array_release(m0r_cu); gkyl_array_release(vtsqr_cu);
+    gkyl_array_release(nu_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_m0s);
+  gkyl_proj_on_basis_release(proj_vtsqs);
+  gkyl_proj_on_basis_release(proj_m0r);
+  gkyl_proj_on_basis_release(proj_vtsqr);
+  gkyl_proj_on_basis_release(proj_nu);
+
+  gkyl_spitzer_coll_freq_release(spitz_up);
+}
+
+void eval_m0s_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly)*(Lz/2.-0.5*fabs(z));
+}
+void eval_m0r_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  fout[0] = 0.5*(1.+cos(0.5*2.*M_PI*x/Lx))*(y+Ly)*(Lz/2.-0.5*fabs(z));;
+}
+void eval_vtsqs_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  fout[0] = (-x*x+1.5*pow(M_PI,2))*0.5*(1.+cos(0.5*2.*M_PI*y/Ly))*(1.5+tanh(z));
+}
+void eval_vtsqr_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  fout[0] = (-x*x+3.5*pow(M_PI,2))*0.5*(1.+cos(0.5*2.*M_PI*y/Ly))*(1.5+tanh(z));;
+}
+void eval_nu_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  double norm_nu = 1./3.;
+  double vtsqs[1], m0r[1], vtsqr[1];
+  eval_vtsqs_3x(t, xn, vtsqs, ctx);
+  eval_m0r_3x(t, xn, m0r, ctx);
+  eval_vtsqr_3x(t, xn, vtsqr, ctx);
+  fout[0] = norm_nu * m0r[0]/pow(vtsqs[0]+vtsqr[0],1.5);
+}
+
+void
+test_3x(int poly_order, bool use_gpu)
+{
+  double Lx = 2.*M_PI, Ly = 8.*M_PI, Lz = 4.*M_PI;
+  double lower[] = {-Lx/2., -Ly/2., -Lz/2.}, upper[] = {Lx/2., Ly/2., Lz/2.};
+  int cells[] = {32, 128, 64};
+
+  double norm_nu = 1./3.;
+
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 1, 1 };
+  struct gkyl_range local, local_ext; // Local, local-ext phase-space ranges.
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create density and v_t^2 arrays.
+  struct gkyl_array *m0s, *vtsqs, *m0r, *vtsqr;
+  m0s = mkarr(basis.num_basis, local_ext.volume);
+  vtsqs = mkarr(basis.num_basis, local_ext.volume);
+  m0r = mkarr(basis.num_basis, local_ext.volume);
+  vtsqr = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *m0s_cu, *vtsqs_cu, *m0r_cu, *vtsqr_cu;
+  if (use_gpu) { // Create device copies
+    m0s_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqs_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    m0r_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+    vtsqr_cu  = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+  }
+
+  gkyl_proj_on_basis *proj_m0s = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0s_3x, NULL);
+  gkyl_proj_on_basis *proj_vtsqs = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqs_3x, NULL);
+  gkyl_proj_on_basis *proj_m0r = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_m0r_3x, NULL);
+  gkyl_proj_on_basis *proj_vtsqr = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_vtsqr_3x, NULL);
+
+  gkyl_proj_on_basis_advance(proj_m0s, 0.0, &local, m0s);
+  gkyl_proj_on_basis_advance(proj_vtsqs, 0.0, &local, vtsqs);
+  gkyl_proj_on_basis_advance(proj_m0r, 0.0, &local, m0r);
+  gkyl_proj_on_basis_advance(proj_vtsqr, 0.0, &local, vtsqr);
+
+  if (use_gpu) {
+    // Copy host array to device.
+    gkyl_array_copy(m0s_cu , m0s );
+    gkyl_array_copy(vtsqs_cu, vtsqs);
+    gkyl_array_copy(m0r_cu , m0r );
+    gkyl_array_copy(vtsqr_cu, vtsqr);
+  }
+
+  // Create collision frequency array.
+  struct gkyl_array *nu, *nu_cu;
+  nu = mkarr(basis.num_basis, local_ext.volume);
+  if (use_gpu)  // create device copy.
+    nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
+
+  // Create Spitzer collision frequency updater.
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+
+  if (use_gpu) {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_array_copy(nu, nu_cu);
+  } else {
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
+  }
+
+  // Project expected collision frequency and compare.
+  struct gkyl_array *nuA, *nuA_cu;
+  nuA = mkarr(basis.num_basis, local_ext.volume);
+  gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_nu_3x, NULL);
+  gkyl_proj_on_basis_advance(proj_nu, 0.0, &local, nuA);
+
+  for (int i=0; i<cells[0]; i++) {
+    for (int j=0; j<cells[1]; j++) {
+      for (int k=0; k<cells[2]; k++) {
+        int idx[] = {i+1,j+1,k+1};
+        long linidx = gkyl_range_idx(&local, idx);
+        const double *nu_p = gkyl_array_cfetch(nu, linidx);
+        const double *nuA_p = gkyl_array_cfetch(nuA, linidx);
+        for (int m=0; m<basis.num_basis; m++) {
+          TEST_CHECK( gkyl_compare(nuA_p[m], nu_p[m], 1e-4) );
+          TEST_MSG("Expected: %.13e in cell (%d)", nuA_p[m], idx[0]);
+          TEST_MSG("Produced: %.13e", nu_p[m]);
+        }
+      }
+    }
+  }
+
+  gkyl_array_release(m0s); gkyl_array_release(vtsqs); gkyl_array_release(m0r); gkyl_array_release(vtsqr);
+  gkyl_array_release(nu); gkyl_array_release(nuA);
+  if (use_gpu) {
+    gkyl_array_release(m0s_cu); gkyl_array_release(vtsqs_cu); gkyl_array_release(m0r_cu); gkyl_array_release(vtsqr_cu);
+    gkyl_array_release(nu_cu);
+  }
+
+  gkyl_proj_on_basis_release(proj_m0s);
+  gkyl_proj_on_basis_release(proj_vtsqs);
+  gkyl_proj_on_basis_release(proj_m0r);
+  gkyl_proj_on_basis_release(proj_vtsqr);
+  gkyl_proj_on_basis_release(proj_nu);
+
+  gkyl_spitzer_coll_freq_release(spitz_up);
+}
+
+void test_1x_p1() { test_1x(1, false); }
+void test_1x_p2() { test_1x(2, false); }
+
+void test_2x_p1() { test_2x(1, false); }
+void test_2x_p2() { test_2x(2, false); }
+
+void test_3x_p1() { test_3x(1, false); }
+void test_3x_p2() { test_3x(2, false); }
+
+#ifdef GKYL_HAVE_CUDA
+void test_1x_p1_gpu() { test_1x(1, true); }
+void test_1x_p2_gpu() { test_1x(2, true); }
+
+void test_2x_p1_gpu() { test_2x(1, true); }
+void test_2x_p2_gpu() { test_2x(2, true); }
+
+void test_3x_p1_gpu() { test_3x(1, true); }
+void test_3x_p2_gpu() { test_3x(2, true); }
+#endif
+
+TEST_LIST = {
+  { "test_1x_p1", test_1x_p1 },
+  { "test_1x_p2", test_1x_p2 },
+
+  { "test_2x_p1", test_2x_p1 },
+  { "test_2x_p2", test_2x_p2 },
+
+  { "test_3x_p1", test_3x_p1 },
+  { "test_3x_p2", test_3x_p2 },
+#ifdef GKYL_HAVE_CUDA
+  { "test_1x_p1_gpu", test_1x_p1_gpu },
+  { "test_1x_p2_gpu", test_1x_p2_gpu },
+
+  { "test_2x_p1_gpu", test_2x_p1_gpu },
+  { "test_2x_p2_gpu", test_2x_p2_gpu },
+
+  { "test_3x_p1_gpu", test_3x_p1_gpu },
+  { "test_3x_p2_gpu", test_3x_p2_gpu },
+#endif
+  { NULL, NULL },
+};

--- a/unit/ctest_spitzer_coll_freq.c
+++ b/unit/ctest_spitzer_coll_freq.c
@@ -123,14 +123,14 @@ test_1x(int poly_order, bool use_gpu)
   gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
 
   if (use_gpu) {
-    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);
     gkyl_array_copy(nu, nu_cu);
   } else {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
   }
 
   // Project expected collision frequency and compare.
-  struct gkyl_array *nuA, *nuA_cu;
+  struct gkyl_array *nuA;
   nuA = mkarr(basis.num_basis, local_ext.volume);
   gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, eval_nu_1x, NULL);
@@ -269,14 +269,14 @@ test_2x(int poly_order, bool use_gpu)
   gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
 
   if (use_gpu) {
-    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);
     gkyl_array_copy(nu, nu_cu);
   } else {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
   }
 
   // Project expected collision frequency and compare.
-  struct gkyl_array *nuA, *nuA_cu;
+  struct gkyl_array *nuA;
   nuA = mkarr(basis.num_basis, local_ext.volume);
   gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, eval_nu_2x, NULL);
@@ -417,14 +417,14 @@ test_3x(int poly_order, bool use_gpu)
   gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
 
   if (use_gpu) {
-    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu);
+    gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);
     gkyl_array_copy(nu, nu_cu);
   } else {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs, m0r, vtsqr, norm_nu, nu);
   }
 
   // Project expected collision frequency and compare.
-  struct gkyl_array *nuA, *nuA_cu;
+  struct gkyl_array *nuA;
   nuA = mkarr(basis.num_basis, local_ext.volume);
   gkyl_proj_on_basis *proj_nu = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, eval_nu_3x, NULL);

--- a/zero/gkyl_proj_powsqrt_on_basis.h
+++ b/zero/gkyl_proj_powsqrt_on_basis.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+
+// Object type
+typedef struct gkyl_proj_powsqrt_on_basis gkyl_proj_powsqrt_on_basis;
+
+/**
+ * Create new updater to project pow( sqrt(f), e ) onto the basis via quadrature.
+ *
+ * @param basis Basis object (configuration space).
+ * @param num_quad Number of quadrature nodes.
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
+gkyl_proj_powsqrt_on_basis* gkyl_proj_powsqrt_on_basis_new(
+  const struct gkyl_basis *basis, int num_quad, bool use_gpu);
+
+/**
+ * Compute pow( sqrt(fIn), expIn) via quadrature.
+ *
+ * @param up Spizer collision frequency updater object.
+ * @param range Config-space range
+ * @param expIn Exponent.
+ * @param fIn Input scalar field.
+ * @param fOut Ouput scalar field.
+ */
+void gkyl_proj_powsqrt_on_basis_advance(const gkyl_proj_powsqrt_on_basis *up,
+  const struct gkyl_range *range, double expIn, const struct gkyl_array *fIn,
+  struct gkyl_array *fOut);
+
+/**
+ * Delete updater.
+ *
+ * @param pob Updater to delete.
+ */
+void gkyl_proj_powsqrt_on_basis_release(gkyl_proj_powsqrt_on_basis* up);

--- a/zero/gkyl_proj_powsqrt_on_basis_priv.h
+++ b/zero/gkyl_proj_powsqrt_on_basis_priv.h
@@ -18,6 +18,6 @@ struct gkyl_proj_powsqrt_on_basis {
 };
 
 void
-gkyl_proj_powsqrt_on_basis_advance_normnu_cu(const gkyl_proj_powsqrt_on_basis *up,
+gkyl_proj_powsqrt_on_basis_advance_cu(const gkyl_proj_powsqrt_on_basis *up,
   const struct gkyl_range *range, double expIn, const struct gkyl_array *fIn,
   struct gkyl_array *fOut);

--- a/zero/gkyl_proj_powsqrt_on_basis_priv.h
+++ b/zero/gkyl_proj_powsqrt_on_basis_priv.h
@@ -1,0 +1,23 @@
+#include <gkyl_proj_powsqrt_on_basis.h>
+
+struct gkyl_proj_powsqrt_on_basis {
+  int num_quad; // number of quadrature points to use in each direction
+  int ndim; // Configuration-space dimension
+
+  int num_basis; // number of conf-space basis functions
+
+  bool use_gpu;
+
+  // for quadrature in conf space
+  int tot_quad; // total number of quadrature points
+  struct gkyl_array *weights; // weights for conf-space quadrature
+  struct gkyl_array *basis_at_ords; // conf-space basis functions at ordinates
+
+  struct gkyl_array *fun_at_ords; // function (Maxwellian) evaluated at
+                                  // ordinates in a cell.
+};
+
+void
+gkyl_proj_powsqrt_on_basis_advance_normnu_cu(const gkyl_proj_powsqrt_on_basis *up,
+  const struct gkyl_range *range, double expIn, const struct gkyl_array *fIn,
+  struct gkyl_array *fOut);

--- a/zero/gkyl_spitzer_coll_freq.h
+++ b/zero/gkyl_spitzer_coll_freq.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+
+// Object type
+typedef struct gkyl_spitzer_coll_freq gkyl_spitzer_coll_freq;
+
+/**
+ * Create new updater to either compute the Spitzer collision frequency from
+ * scratch based on local parameters, or scale a normalized collision frequency
+ * by the local n_r/(v_ts^2+v_tr^2)^(3/2).
+ *
+ * @param basis Basis object (configuration space).
+ * @param num_quad Number of quadrature nodes.
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
+gkyl_spitzer_coll_freq* gkyl_spitzer_coll_freq_new(
+  const struct gkyl_basis *basis, int num_quad, bool use_gpu);
+
+/**
+ * Scale the normalized collision frequency, normNu, by
+ * n_r/(v_ts^2+v_tr^2)^(3/2) and project it on to the basis.
+ *
+ * @param up Spizer collision frequency updater object.
+ * @param range Config-space range
+ * @param vtSqSelf Thermal speed squared of this species. 
+ * @param m0Other Thermal speed squared of the other species. 
+ * @param vtSqOther Thermal speed squared of the other species. 
+ * @param normNu Normalized collision frequency to scale.
+ * @param nuOut Output collision frequency.
+ */
+void gkyl_spitzer_coll_freq_advance_normnu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *vtSqSelf,
+  const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  double normNu, struct gkyl_array *nuOut);
+
+/**
+ * Compute the Spitzer collision frequency from scratch. Coulomb Logarithm
+ * is computed using cell averaged values.
+ *
+ * @param up Spizer collision frequency updater object.
+ * @param range Config-space range
+ * @param qSelf Charge of this species.
+ * @param mSelf Mass of this species.
+ * @param m0Self Thermal speed squared of the other species. 
+ * @param vtSqSelf Thermal speed squared of this species. 
+ * @param qOther Charge of this species.
+ * @param mOther Mass of this species.
+ * @param m0Other Thermal speed squared of the other species. 
+ * @param vtSqOther Thermal speed squared of the other species. 
+ * @param nuOut Output collision frequency.
+ */
+void gkyl_spitzer_coll_freq_advance(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range,
+  double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  struct gkyl_array *nuOut);
+
+/**
+ * Delete updater.
+ *
+ * @param pob Updater to delete.
+ */
+void gkyl_spitzer_coll_freq_release(gkyl_spitzer_coll_freq* up);

--- a/zero/gkyl_spitzer_coll_freq_priv.h
+++ b/zero/gkyl_spitzer_coll_freq_priv.h
@@ -1,0 +1,32 @@
+#include <gkyl_spitzer_coll_freq.h>
+
+struct gkyl_spitzer_coll_freq {
+  int num_quad; // number of quadrature points to use in each direction
+  int ndim; // Configuration-space dimension
+
+  int num_basis; // number of conf-space basis functions
+
+  bool use_gpu;
+
+  // for quadrature in conf space
+  int tot_quad; // total number of quadrature points
+  struct gkyl_array *ordinates; // conf-space ordinates for quadrature
+  struct gkyl_array *weights; // weights for conf-space quadrature
+  struct gkyl_array *basis_at_ords; // conf-space basis functions at ordinates
+
+  struct gkyl_array *fun_at_ords; // function (Maxwellian) evaluated at
+                                  // ordinates in a cell.
+};
+
+void
+gkyl_spitzer_coll_freq_advance_normnu_cu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *vtSqSelf,
+  const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  double normNu, struct gkyl_array *nuOut);
+
+void
+gkyl_spitzer_coll_freq_advance_cu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range,
+  double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  struct gkyl_array *nuOut);

--- a/zero/gkyl_spitzer_coll_freq_priv.h
+++ b/zero/gkyl_spitzer_coll_freq_priv.h
@@ -10,7 +10,6 @@ struct gkyl_spitzer_coll_freq {
 
   // for quadrature in conf space
   int tot_quad; // total number of quadrature points
-  struct gkyl_array *ordinates; // conf-space ordinates for quadrature
   struct gkyl_array *weights; // weights for conf-space quadrature
   struct gkyl_array *basis_at_ords; // conf-space basis functions at ordinates
 

--- a/zero/proj_powsqrt_on_basis_cu.cu
+++ b/zero/proj_powsqrt_on_basis_cu.cu
@@ -16,7 +16,7 @@ gkyl_proj_powsqrt_on_basis_advance_cu_ker(int num_quad,
   int num_basis = basis_at_ords->ncomp;
   int tot_quad = basis_at_ords->size;
 
-  int idx[3];
+  int idx[GKYL_MAX_DIM];
 
   for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
       tid < range.volume; tid += blockDim.x*gridDim.x) {

--- a/zero/proj_powsqrt_on_basis_cu.cu
+++ b/zero/proj_powsqrt_on_basis_cu.cu
@@ -58,7 +58,7 @@ gkyl_proj_powsqrt_on_basis_advance_cu(const gkyl_proj_powsqrt_on_basis *up,
   const struct gkyl_array *fIn, struct gkyl_array *fOut)
 {
   int nblocks = range->nblocks, nthreads = range->nthreads;
-  gkyl_proj_powsqrt_on_basis_advance_normnu_cu_ker<<<nblocks, nthreads>>>
+  gkyl_proj_powsqrt_on_basis_advance_cu_ker<<<nblocks, nthreads>>>
     (up->num_quad, *range, up->basis_at_ords->on_dev,
      up->weights->on_dev, expIn, fIn->on_dev, fOut->on_dev);
 }

--- a/zero/proj_powsqrt_on_basis_cu.cu
+++ b/zero/proj_powsqrt_on_basis_cu.cu
@@ -1,0 +1,64 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_proj_powsqrt_on_basis.h>
+#include <gkyl_proj_powsqrt_on_basis_priv.h>
+#include <gkyl_const.h>
+#include <gkyl_range.h>
+}
+
+__global__ static void
+gkyl_proj_powsqrt_on_basis_advance_cu_ker(int num_quad, 
+  const struct gkyl_range range, const struct gkyl_array* GKYL_RESTRICT basis_at_ords,
+  const struct gkyl_array* GKYL_RESTRICT weights, double expIn,
+  const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT fOut)
+{
+  int num_basis = basis_at_ords->ncomp;
+  int tot_quad = basis_at_ords->size;
+
+  int idx[3];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < range.volume; tid += blockDim.x*gridDim.x) {
+
+    gkyl_sub_range_inv_idx(&range, tid, idx);
+    long linidx = gkyl_range_idx(&range, idx);
+
+    const double *fIn_d = (const double *) gkyl_array_cfetch(fIn, linidx);
+
+    double *fOut_d = (double *) gkyl_array_fetch(fOut, linidx);
+    for (int k=0; k<num_basis; ++k) fOut_d[k] = 0.0;
+
+    // Compute expansion coefficients of nuOut using quadrature.
+    const double *w_d = (const double *) weights->data;
+    const double *bo_d = (const double *) basis_at_ords->data;
+
+    for (int n=0; n<tot_quad; ++n) {
+
+      const double *b_ord = (const double *) gkyl_array_cfetch(basis_at_ords, n);
+
+      // Evaluate densities and thermal speeds (squared) at quad point.
+      double fIn_q=0.;
+      for (int k=0; k<num_basis; ++k)
+        fIn_q += fIn_d[k]*b_ord[k];
+
+      double fOut_o = fIn_q<0. ? 1.e-40 : pow(sqrt(fIn_q),expIn);
+
+      double tmp = w_d[n]*fOut_o;
+      for (int k=0; k<num_basis; ++k)
+        fOut_d[k] += tmp*bo_d[k+num_basis*n];
+    }
+
+  }
+}
+
+void
+gkyl_proj_powsqrt_on_basis_advance_cu(const gkyl_proj_powsqrt_on_basis *up,
+  const struct gkyl_range *range, double expIn,
+  const struct gkyl_array *fIn, struct gkyl_array *fOut)
+{
+  int nblocks = range->nblocks, nthreads = range->nthreads;
+  gkyl_proj_powsqrt_on_basis_advance_normnu_cu_ker<<<nblocks, nthreads>>>
+    (up->num_quad, *range, up->basis_at_ords->on_dev,
+     up->weights->on_dev, expIn, fIn->on_dev, fOut->on_dev);
+}

--- a/zero/spitzer_coll_freq.c
+++ b/zero/spitzer_coll_freq.c
@@ -8,7 +8,6 @@
 #include <gkyl_spitzer_coll_freq.h>
 #include <gkyl_spitzer_coll_freq_priv.h>
 #include <gkyl_range.h>
-#include <assert.h>
 
 // create range to loop over quadrature points.
 static inline struct gkyl_range get_qrange(int dim, int num_quad) {
@@ -101,9 +100,6 @@ gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis, int num_quad, bool us
   up->num_quad = num_quad;
   up->num_basis = basis->num_basis;
   up->use_gpu = use_gpu;
-
-  // MF 2022/10/01: device kernel has arrays hard-coded to 3x p=2 for now.
-  if (use_gpu) assert(basis->poly_order<3);
 
   // initialize data needed for quadrature
   up->tot_quad = init_quad_values(basis, num_quad, &up->ordinates, &up->weights,

--- a/zero/spitzer_coll_freq.c
+++ b/zero/spitzer_coll_freq.c
@@ -1,0 +1,203 @@
+#include <string.h>
+#include <math.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_array.h>
+#include <gkyl_const.h>
+#include <gkyl_gauss_quad_data.h>
+#include <gkyl_spitzer_coll_freq.h>
+#include <gkyl_spitzer_coll_freq_priv.h>
+#include <gkyl_range.h>
+#include <assert.h>
+
+// create range to loop over quadrature points.
+static inline struct gkyl_range get_qrange(int dim, int num_quad) {
+  int qshape[GKYL_MAX_DIM];
+  for (int i=0; i<dim; ++i) qshape[i] = num_quad;
+  struct gkyl_range qrange;
+  gkyl_range_init_from_shape(&qrange, dim, qshape);
+  return qrange;
+}
+
+// Sets ordinates, weights and basis functions at ords. Returns total
+// number of quadrature nodes
+static int
+init_quad_values(const struct gkyl_basis *basis, int num_quad, struct gkyl_array **ordinates,
+  struct gkyl_array **weights, struct gkyl_array **basis_at_ords, bool use_gpu)
+{
+  int ndim = basis->ndim;
+  double ordinates1[num_quad], weights1[num_quad];
+
+  if (num_quad <= gkyl_gauss_max) {
+    // use pre-computed values if possible (these are more accurate
+    // than computing them on the fly)
+    memcpy(ordinates1, gkyl_gauss_ordinates[num_quad], sizeof(double[num_quad]));
+    memcpy(weights1, gkyl_gauss_weights[num_quad], sizeof(double[num_quad]));
+  }
+  else {
+    gkyl_gauleg(-1, 1, ordinates1, weights1, num_quad);
+  }
+
+  struct gkyl_range qrange = get_qrange(ndim, num_quad);
+
+  int tot_quad = qrange.volume;
+
+  // create ordinates and weights for multi-D quadrature
+  struct gkyl_array *ordinates_ho = gkyl_array_new(GKYL_DOUBLE, ndim, tot_quad);
+  struct gkyl_array *weights_ho = gkyl_array_new(GKYL_DOUBLE, 1, tot_quad);
+  if (use_gpu) {
+    *ordinates = gkyl_array_cu_dev_new(GKYL_DOUBLE, ndim, tot_quad);
+    *weights = gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, tot_quad);
+  } else {
+    *ordinates = gkyl_array_new(GKYL_DOUBLE, ndim, tot_quad);
+    *weights = gkyl_array_new(GKYL_DOUBLE, 1, tot_quad);
+  }
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &qrange);
+
+  while (gkyl_range_iter_next(&iter)) {
+    int node = gkyl_range_idx(&qrange, iter.idx);
+
+    // set ordinates
+    double *ord = gkyl_array_fetch(ordinates_ho, node);
+    for (int i=0; i<ndim; ++i)
+      ord[i] = ordinates1[iter.idx[i]-qrange.lower[i]];
+
+    // set weights
+    double *wgt = gkyl_array_fetch(weights_ho, node);
+    wgt[0] = 1.0;
+    for (int i=0; i<qrange.ndim; ++i)
+      wgt[0] *= weights1[iter.idx[i]-qrange.lower[i]];
+  }
+
+  // pre-compute basis functions at ordinates
+  struct gkyl_array *basis_at_ords_ho = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
+  if (use_gpu)
+    *basis_at_ords = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
+  else
+    *basis_at_ords = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
+  for (int n=0; n<tot_quad; ++n)
+    basis->eval(gkyl_array_fetch(ordinates_ho, n), gkyl_array_fetch(basis_at_ords_ho, n));
+
+  // copy host array to device array
+  gkyl_array_copy(*ordinates, ordinates_ho);
+  gkyl_array_copy(*weights, weights_ho);
+  gkyl_array_copy(*basis_at_ords, basis_at_ords_ho);
+
+  gkyl_array_release(ordinates_ho);
+  gkyl_array_release(weights_ho);
+  gkyl_array_release(basis_at_ords_ho);
+
+  return tot_quad;
+}
+
+gkyl_spitzer_coll_freq*
+gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis, int num_quad, bool use_gpu)
+{
+  gkyl_spitzer_coll_freq *up = gkyl_malloc(sizeof(gkyl_spitzer_coll_freq));
+
+  up->ndim = basis->ndim;
+  up->num_quad = num_quad;
+  up->num_basis = basis->num_basis;
+  up->use_gpu = use_gpu;
+
+  // MF 2022/10/01: device kernel has arrays hard-coded to 3x p=2 for now.
+  if (use_gpu) assert(basis->poly_order<3);
+
+  // initialize data needed for quadrature
+  up->tot_quad = init_quad_values(basis, num_quad, &up->ordinates, &up->weights,
+    &up->basis_at_ords, use_gpu);
+
+  if (up->use_gpu)
+    up->fun_at_ords = NULL;
+  else
+    up->fun_at_ords = gkyl_array_new(GKYL_DOUBLE, 1, up->tot_quad); // Only used in CPU implementation.
+
+  return up;
+}
+
+static void
+proj_on_basis(const gkyl_spitzer_coll_freq *up, const struct gkyl_array *fun_at_ords, double* f)
+{
+  int num_basis = up->num_basis;
+  int tot_quad = up->tot_quad;
+
+  const double* GKYL_RESTRICT weights = up->weights->data;
+  const double* GKYL_RESTRICT basis_at_ords = up->basis_at_ords->data;
+  const double* GKYL_RESTRICT func_at_ords = fun_at_ords->data;
+
+  for (int k=0; k<num_basis; ++k) f[k] = 0.0;
+
+  for (int imu=0; imu<tot_quad; ++imu) {
+    double tmp = weights[imu]*func_at_ords[imu];
+    for (int k=0; k<num_basis; ++k)
+      f[k] += tmp*basis_at_ords[k+num_basis*imu];
+  }
+}
+
+void
+gkyl_spitzer_coll_freq_advance_normnu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *vtSqSelf,
+  const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  double normNu, struct gkyl_array *nuOut)
+{
+  // Scale project normNu*n_r/(v_ts^2+v_tr^2)^(3/2) onto the basis using
+  // quadrature.
+
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    return gkyl_spitzer_coll_freq_advance_normnu_cu(up, range, vtSqSelf, 
+      m0Other, vtSqOther, normNu, nuOut);
+#endif
+
+  // Create range to loop over quadrature points.
+  struct gkyl_range qrange = get_qrange(up->ndim, up->num_quad);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  while (gkyl_range_iter_next(&iter)) {
+    long linidx = gkyl_range_idx(range, iter.idx);
+
+    const double *vtSqSelf_d = gkyl_array_cfetch(vtSqSelf, linidx);
+    const double *m0Other_d = gkyl_array_cfetch(m0Other, linidx);
+    const double *vtSqOther_d = gkyl_array_cfetch(vtSqOther, linidx);
+
+    struct gkyl_range_iter qiter;
+    gkyl_range_iter_init(&qiter, &qrange);
+    while (gkyl_range_iter_next(&qiter)) {
+      
+      int qidx = gkyl_range_idx(&qrange, qiter.idx);
+
+      // Evaluate densities and thermal speeds (squared) at quad point.
+      const double *b_ord = gkyl_array_cfetch(up->basis_at_ords, qidx);
+      double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
+      for (int k=0; k<up->num_basis; ++k) {
+        vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
+        m0Other_q += m0Other_d[k]*b_ord[k];
+        vtSqOther_q += vtSqOther_d[k]*b_ord[k];
+      }
+
+      double *fq = gkyl_array_fetch(up->fun_at_ords, qidx);
+
+      if ((m0Other_q>0.) && (vtSqSelf_q>0.) && (vtSqOther_q>0.))
+        fq[0] = normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+      else
+        fq[0] = 1.e-40;
+    }
+
+    // compute expansion coefficients of Maxwellian on basis
+    proj_on_basis(up, up->fun_at_ords, gkyl_array_fetch(nuOut, linidx));
+  }
+
+}
+
+void
+gkyl_spitzer_coll_freq_release(gkyl_spitzer_coll_freq* up)
+{
+  gkyl_array_release(up->ordinates);
+  gkyl_array_release(up->weights);
+  gkyl_array_release(up->basis_at_ords);
+  gkyl_array_release(up->fun_at_ords);
+  gkyl_free(up);
+}

--- a/zero/spitzer_coll_freq_cu.cu
+++ b/zero/spitzer_coll_freq_cu.cu
@@ -48,7 +48,8 @@ gkyl_spitzer_coll_freq_advance_normnu_cu_ker(int num_quad,
         vtSqOther_q += vtSqOther_d[k]*b_ord[k];
       }
 
-      double nu_o = normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+      double nu_o = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
+        1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
 
       double tmp = w_d[n]*nu_o;
       for (int k=0; k<num_basis; ++k)

--- a/zero/spitzer_coll_freq_cu.cu
+++ b/zero/spitzer_coll_freq_cu.cu
@@ -1,0 +1,72 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_spitzer_coll_freq.h>
+#include <gkyl_spitzer_coll_freq_priv.h>
+#include <gkyl_const.h>
+#include <gkyl_range.h>
+}
+
+__global__ static void
+gkyl_spitzer_coll_freq_advance_normnu_cu_ker(int num_quad, 
+  const struct gkyl_range range, const struct gkyl_array* GKYL_RESTRICT basis_at_ords,
+  const struct gkyl_array* GKYL_RESTRICT weights, const struct gkyl_array* GKYL_RESTRICT vtSqSelf,
+  const struct gkyl_array* GKYL_RESTRICT m0Other, const struct gkyl_array* GKYL_RESTRICT vtSqOther,
+  double normNu, struct gkyl_array* GKYL_RESTRICT nuOut)
+{
+  int num_basis = basis_at_ords->ncomp;
+  int tot_quad = basis_at_ords->size;
+
+  int idx[3];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < range.volume; tid += blockDim.x*gridDim.x) {
+
+    gkyl_sub_range_inv_idx(&range, tid, idx);
+    long linidx = gkyl_range_idx(&range, idx);
+
+    const double *vtSqSelf_d = (const double *) gkyl_array_cfetch(vtSqSelf, linidx);
+    const double *m0Other_d = (const double *) gkyl_array_cfetch(m0Other, linidx);
+    const double *vtSqOther_d = (const double *) gkyl_array_cfetch(vtSqOther, linidx);
+
+    double *nuOut_d = (double *) gkyl_array_fetch(nuOut, linidx);
+    for (int k=0; k<num_basis; ++k) nuOut_d[k] = 0.0;
+
+    // Compute expansion coefficients of nuOut using quadrature.
+    const double *w_d = (const double *) weights->data;
+    const double *bo_d = (const double *) basis_at_ords->data;
+
+    for (int n=0; n<tot_quad; ++n) {
+
+      const double *b_ord = (const double *) gkyl_array_cfetch(basis_at_ords, n);
+
+      // Evaluate densities and thermal speeds (squared) at quad point.
+      double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
+      for (int k=0; k<num_basis; ++k) {
+        vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
+        m0Other_q += m0Other_d[k]*b_ord[k];
+        vtSqOther_q += vtSqOther_d[k]*b_ord[k];
+      }
+
+      double nu_o = normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+
+      double tmp = w_d[n]*nu_o;
+      for (int k=0; k<num_basis; ++k)
+        nuOut_d[k] += tmp*bo_d[k+num_basis*n];
+    }
+
+  }
+}
+
+void
+gkyl_spitzer_coll_freq_advance_normnu_cu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *vtSqSelf,
+  const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  double normNu, struct gkyl_array *nuOut)
+{
+  int nblocks = range->nblocks, nthreads = range->nthreads;
+  gkyl_spitzer_coll_freq_advance_normnu_cu_ker<<<nblocks, nthreads>>>
+    (up->num_quad, *range, up->basis_at_ords->on_dev,
+     up->weights->on_dev, vtSqSelf->on_dev,
+     m0Other->on_dev, vtSqOther->on_dev, normNu, nuOut->on_dev);
+}


### PR DESCRIPTION
Implement updaters that compute the Spitzer collision frequency and pow(sqrt(f),q) using Gaussian quadrature.

Spitzer_coll_freq currently only has the normNu option, since I think that's the most useful right now.

Unit tests pass on the CPU and GPU. However valgrind is giving errors on the ```qrange``` function in these updaters, but that is the exact same function as in proj_maxwellian_on_basis, so I don't know if it's a true error. Maybe reviewers can check in another (non-stellar) computer.