### PR TITLE
Change Makefile so /regression and /unit executables are not built by

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,19 +43,22 @@ endif
 KERN_INC_DIRS = $(shell find $(SRC_DIRS) -type d)
 KERN_INCLUDES = $(addprefix -I,$(KERN_INC_DIRS))
 
+# Location of CUDA math libraries
+CUDAMATH_LIBDIR = 
+
 # Include config.mak file (if it exists) to overide defaults above
 -include config.mak
 
 # CUDA flags
 USING_NVCC =
 NVCC_FLAGS = 
-CUDA_LIBS =
+CUDA_LIBS = -L${CUDAMATH_LIBDIR}
 ifeq ($(CC), nvcc)
        USING_NVCC = yes
        CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC
        NVCC_FLAGS = -x cu -dc -arch=sm_${CUDA_ARCH} --compiler-options="-fPIC"
        LDFLAGS += -arch=sm_${CUDA_ARCH}
-       CUDA_LIBS = -lcublas -lcusparse -lcusolver
+       CUDA_LIBS = -L${CUDAMATH_LIBDIR} -lcublas -lcusparse -lcusolver
 endif
 
 # Build directory
@@ -181,7 +184,7 @@ G0STLIB = lib${G0LIB}.a
 G0SHLIB = lib${G0LIB}.so
 
 # Make targets: libraries, regression tests and unit tests
-all: ${BUILD_DIR}/gkylzero.h ${BUILD_DIR}/${G0STLIB} ${BUILD_DIR}/${G0SHLIB} ${REGS} ${UNITS}
+all: ${BUILD_DIR}/gkylzero.h ${BUILD_DIR}/${G0STLIB} ${BUILD_DIR}/${G0SHLIB}
 
 # Amalgamated header file
 ${BUILD_DIR}/gkylzero.h:
@@ -212,6 +215,16 @@ ${BUILD_DIR}/unit/%: unit/%.c ${BUILD_DIR}/${G0STLIB} ${UNIT_CU_OBJS} ${UNIT_CU_
 check: ${UNITS}
 	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
 
+unit: unit/%.c ${BUILD_DIR}/${G0STLIB} ${UNIT_CU_OBJS} ${UNIT_CU_SRCS}
+	# Unit tests
+	$(MKDIR_P) ${BUILD_DIR}/unit
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${UNIT_CU_OBJS} ${BUILD_DIR}/${G0STLIB} ${SUPERLU_LIB} ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread
+
+regression: regression/%.c ${BUILD_DIR}/${G0STLIB} regression/rt_arg_parse.h
+	# Regression tests
+	$(MKDIR_P) ${BUILD_DIR}/regression
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${BUILD_DIR}/${G0STLIB} ${SUPERLU_LIB} ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread
+
 install: all
 	$(MKDIR_P) ${PREFIX}/gkylzero/include
 	${MKDIR_P} ${PREFIX}/gkylzero/lib
@@ -225,7 +238,7 @@ install: all
 	cp -f Makefile.sample ${PREFIX}/gkylzero/share/Makefile
 	cp -f regression/rt_arg_parse.h ${PREFIX}/gkylzero/share/rt_arg_parse.h
 	cp -f regression/rt_twostream.c ${PREFIX}/gkylzero/share/rt_twostream.c
-	cp -f ${BUILD_DIR}/regression/rt_vlasov_kerntm ${PREFIX}/gkylzero/bin/
+#	cp -f ${BUILD_DIR}/regression/rt_vlasov_kerntm ${PREFIX}/gkylzero/bin/
 	cp -f inf/Vlasov.lua ${PREFIX}/gkylzero/lib/
 	cp -f inf/Moments.lua ${PREFIX}/gkylzero/lib/
 	cp -f scripts/*.sh ${PREFIX}/gkylzero/scripts

--- a/configure
+++ b/configure
@@ -25,6 +25,9 @@ else
     SUPERLU_LIB=${HOME}/gkylsoft/superlu/lib/libsuperlu.a;
 fi
 
+# Location of CUDA math libraries
+CUDAMATH_LIBS=
+
 # ----------------------------------------------------------------------------
 # Function definitions
 # ----------------------------------------------------------------------------
@@ -58,6 +61,8 @@ Library Includes and Locations
 
 --superlu-inc              Location of SuperLU headers
 --superlu-lib              Full path to SuperLU static library
+
+--cudamath-libdir          Full path to CUDA math libraries
 
 EOF
 }
@@ -138,6 +143,10 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       SUPERLU_LIB="$value"
       ;;   
+   --cudamath-libdir)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      CUDAMATH_LIBDIR="$value"
+      ;;   
    *)
       die "Error: Unknown flag: $1"
       ;;
@@ -162,6 +171,8 @@ LAPACK_LIB=$LAPACK_LIB
 
 SUPERLU_INC=$SUPERLU_INC
 SUPERLU_LIB=$SUPERLU_LIB
+
+CUDAMATH_LIBDIR=$CUDAMATH_LIBDIR
 
 EOF1
 

--- a/install-deps/build-openblas.sh
+++ b/install-deps/build-openblas.sh
@@ -24,8 +24,8 @@ then
     gunzip -f OpenBLAS-0.3.15.tar.gz
     tar xvf OpenBLAS-0.3.15.tar
     cd OpenBLAS-0.3.15
-    make USE_OPENMP=0 NUM_THREADS=1 FC=$FC -j
-    make USE_OPENMP=0 NUM_THREADS=1 install PREFIX=$PREFIX -j
+    make USE_OPENMP=0 NUM_THREADS=1 FC=$FC -j 32
+    make USE_OPENMP=0 NUM_THREADS=1 install PREFIX=$PREFIX -j 32
 
     # soft-link 
     ln -sfn $PREFIX $GKYLSOFT/OpenBLAS

--- a/install-deps/build-superlu.sh
+++ b/install-deps/build-superlu.sh
@@ -32,7 +32,7 @@ then
     cmake .. -DCMAKE_C_FLAGS="-g -O3 -fPIC" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib -Denable_tests=NO -Denable_internal_blaslib=NO -DXSDK_ENABLE_Fortran=NO
 
     # build and install
-    make -j VERBOSE=1
+    make -j 32 VERBOSE=1
     make install
 
     # soft-link 

--- a/machines/configure.perlmutter.dev.sh
+++ b/machines/configure.perlmutter.dev.sh
@@ -1,3 +1,5 @@
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft --lapack-inc=${HOME}/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft/superlu/include --superlu-lib=${HOME}/gkylsoft/superlu/lib/libsuperlu.a;
+module load cudatoolkit/11.7
+module unload darshan
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft --lapack-inc=${HOME}/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft/superlu/include --superlu-lib=${HOME}/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/math_libs/11.7/lib64;
 
 

--- a/machines/mkdeps.perlmutter.dev.sh
+++ b/machines/mkdeps.perlmutter.dev.sh
@@ -1,3 +1,4 @@
 module load cudatoolkit/11.7
+module unload darshan
 cd install-deps
 ./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$HOME/gkylsoft/

--- a/zero/array_ops.c
+++ b/zero/array_ops.c
@@ -9,6 +9,7 @@
 #include <gkyl_array_ops.h>
 #include <gkyl_array_ops_priv.h>
 #include <gkyl_array_reduce.h>
+#include <gkyl_alloc_flags_priv.h>
 
 bool
 gkyl_array_copy_func_is_cu_dev(const struct gkyl_array_copy_func *bc)

--- a/zero/bc_basic.c
+++ b/zero/bc_basic.c
@@ -1,6 +1,7 @@
 #include <gkyl_bc_basic.h>
 #include <gkyl_bc_basic_priv.h>
 #include <gkyl_alloc.h>
+#include <gkyl_alloc_flags_priv.h>
 
 // Private function to create a pointer to the function that applies the BC,
 // i.e., the array_copy_func applied to expansion coefficients in ghost cell.

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <gkyl_alloc_flags_priv.h>
 #include <gkyl_array.h>
 #include <gkyl_evalf_def.h>
 #include <gkyl_range.h>

--- a/zero/prim_lbo_cross_calc.c
+++ b/zero/prim_lbo_cross_calc.c
@@ -1,6 +1,6 @@
 #include "gkyl_prim_lbo_type.h"
 #include <gkyl_alloc.h>
-//#include <gkyl_alloc_flags_priv.h>
+#include <gkyl_alloc_flags_priv.h>
 #include <gkyl_array_ops.h>
 #include <gkyl_prim_lbo_cross_calc.h>
 #include <gkyl_prim_lbo_cross_calc_priv.h>


### PR DESCRIPTION
default. That's because currently those executables take way too much space and if you have other stuff in your $HOME, your diskspace can easily fill up and crash the build. Now one has to build these on demand with, for example,

make cuda-build/regression
make cuda-build/unit

or specific tests with

make cuda-build/regression/rt_weibel_4d
make cuda-build/unit/ctest_dg_bin_ops

Additionally, change ```-j``` in scripts that build dependencies to
```-j 32``` because Stellar and Perlmutter admins don't like that we hog
all the cores on the login node.

Adapt config and make files to allow passing location of cuda math
libraries, because on Perlmutter they are in some other nonstandard
location. Update Perlmutter machine files with this (also had to unload
darshan module for some reason, recommended by admins).