### PR TITLE
Makefile: allow setting BUILD_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,12 @@ ifeq ($(CC), nvcc)
 endif
 
 # Build directory
+ifndef BUILD_DIR
 ifdef USING_NVCC
 	BUILD_DIR ?= cuda-build
 else
 	BUILD_DIR ?= build
+endif
 endif
 
 # On OSX we should use Accelerate framework


### PR DESCRIPTION
e.g., `make BUILD_DIR=build002` will make `build002/libgkylzero.so`

Then one may create multiple builds under the same `gkylzero` folder.