### PR TITLE
Makefile fixes and some FV mods 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,12 @@ ifeq ($(CC), nvcc)
 endif
 
 # Build directory
+ifndef BUILD_DIR
 ifdef USING_NVCC
 	BUILD_DIR ?= cuda-build
 else
 	BUILD_DIR ?= build
+endif
 endif
 
 # On OSX we should use Accelerate framework

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,16 @@
-#
-# You can set parameters on the command line:
-#
-# make CC=nvcc -j
-#
-# Or run the configure script to set various parameters. Usually
-# defaults are all you need, specially if the dependencies are in
-# $HOME/gkylsoft and you are using standard compilers (not building on
-# GPUs)
+# -*- makefile-gmake -*-
 
-# these flags may be overwritten by the configure script
-ARCH_FLAGS = -march=native
-CUDA_ARCH = 70
+# Type make help to see help for this Makefile
+
+ARCH_FLAGS ?= -march=native
+CUDA_ARCH ?= 70
 # Warning flags: -Wall -Wno-unused-variable -Wno-unused-function -Wno-missing-braces
-CFLAGS = -O3 -g -ffast-math -fPIC -MMD -MP
-LDFLAGS =
-
-# Install prefix
-PREFIX = ${HOME}/gkylsoft
+CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP
+LDFLAGS = 
+PREFIX ?= ${HOME}/gkylsoft
 
 # determine OS we are running on
 UNAME = $(shell uname)
-
-# Directories containing source code
-SRC_DIRS := minus zero apps kernels
 
 # Default lapack include and libraries: we prefer linking to static library
 LAPACK_INC = ${HOME}/gkylsoft/OpenBLAS/include
@@ -38,10 +26,6 @@ else
 	SUPERLU_LIB_DIR = ${HOME}/gkylsoft/superlu/lib
 	SUPERLU_LIB = ${HOME}/gkylsoft/superlu/lib/libsuperlu.a
 endif
-
-# list of includes from kernels
-KERN_INC_DIRS = $(shell find $(SRC_DIRS) -type d)
-KERN_INCLUDES = $(addprefix -I,$(KERN_INC_DIRS))
 
 # Include config.mak file (if it exists) to overide defaults above
 -include config.mak
@@ -64,12 +48,10 @@ ifeq ($(CC), nvcc)
 endif
 
 # Build directory
-ifndef BUILD_DIR
 ifdef USING_NVCC
 	BUILD_DIR ?= cuda-build
-else
+else	
 	BUILD_DIR ?= build
-endif
 endif
 
 # On OSX we should use Accelerate framework
@@ -82,18 +64,56 @@ else
 	SHFLAGS += -shared
 endif
 
+# Header files
+HEADERS := $(wildcard minus/*.h) $(wildcard zero/*.h) $(wildcard apps/*.h) $(wildcard kernels/*/*.h)
+# Headers to install
+INSTALL_HEADERS := $(shell ls apps/gkyl_*.h zero/gkyl_*.h | grep -v "priv" | sort)
+INSTALL_HEADERS += $(shell ls minus/*.h)
+
 # all includes
 INCLUDES = -Iminus -Iminus/STC/include -Izero -Iapps -Iregression -I${BUILD_DIR} ${KERN_INCLUDES} -I${LAPACK_INC} -I${SUPERLU_INC}
+
+# Directories containing source code
+SRC_DIRS := minus zero apps kernels
+
+# List of regression and unit tests
+REGS := $(patsubst %.c,${BUILD_DIR}/%,$(wildcard regression/rt_*.c))
+UNITS := $(patsubst %.c,${BUILD_DIR}/%,$(wildcard unit/ctest_*.c))
+
+# list of includes from kernels
+KERN_INC_DIRS = $(shell find $(SRC_DIRS) -type d)
+KERN_INCLUDES = $(addprefix -I,$(KERN_INC_DIRS))
+
+# List of link directories and libraries for unit and regression tests
+EXEC_LIB_DIRS = -L${SUPERLU_LIB_DIR} -L${LAPACK_LIB_DIR} -L${BUILD_DIR}
+EXEC_EXT_LIBS = -lsuperlu -lopenblas ${CUDA_LIBS} -lm -lpthread
+EXEC_LIBS = -lgkylzero ${EXEC_EXT_LIBS}
+EXEC_RPATH = -Wl,-rpath,${BUILD_DIR}
+
+# Build commands for C source
+$(BUILD_DIR)/%.c.o: %.c
+	$(MKDIR_P) $(dir $@)
+	$(CC) $(CFLAGS) $(ARCH_FLAGS) $(INCLUDES) -c $< -o $@
 
 # Build commands for CUDA source
 $(BUILD_DIR)/%.cu.o: %.cu
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCLUDES) -c $< -o $@
 
-# Build commands for C source
-$(BUILD_DIR)/%.c.o: %.c
-	$(MKDIR_P) $(dir $@)
-	$(CC) $(CFLAGS) $(ARCH_FLAGS) $(INCLUDES) -c $< -o $@
+# Unit tests
+${BUILD_DIR}/unit/%: unit/%.c ${ZERO_SH_LIB} ${UNIT_CU_OBJS} ${UNIT_CU_SRCS}
+	$(MKDIR_P) ${BUILD_DIR}/unit
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${EXEC_LIB_DIRS} ${EXEC_RPATH} ${EXEC_LIBS}
+
+# Regression tests
+${BUILD_DIR}/regression/%: regression/%.c ${ZERO_SH_LIB}
+	$(MKDIR_P) ${BUILD_DIR}/regression
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${EXEC_LIB_DIRS} ${EXEC_RPATH} ${EXEC_LIBS}
+
+# Amalgamated header file
+${BUILD_DIR}/gkylzero.h:
+	$(MKDIR_P) ${BUILD_DIR}
+	./minus/gengkylzeroh.sh > ${BUILD_DIR}/gkylzero.h
 
 # Specialized build commands for kernels when using nvcc
 ifdef USING_NVCC
@@ -144,123 +164,78 @@ $(BUILD_DIR)/kernels/fem_parproj/%.c.o : kernels/fem_parproj/%.c
 
 endif
 
-# List of source files
+## GkylZero Library 
+ZERO := libgkylzero
 SRCS := $(shell find $(SRC_DIRS) -name *.c)
 ifdef USING_NVCC
 	SRCS += $(shell find zero -name *.cu)
 endif
-
-# List of object files that will be built
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
-# List of dependencies
 DEPS := $(OBJS:.o=.d)
 
-# List of regression and unit tests
-REGS := $(patsubst %.c,${BUILD_DIR}/%,$(wildcard regression/rt_*.c))
-UNITS := $(patsubst %.c,${BUILD_DIR}/%,$(wildcard unit/ctest_*.c))
+ZERO_SH_LIB := $(BUILD_DIR)/$(ZERO).so
+$(ZERO_SH_LIB): $(OBJS)
+	$(MKDIR_P) $(dir $@)
+	${CC} ${SHFLAGS} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@
 
-# We need to build CUDA unit-test objects
-UNIT_CU_SRCS =
-UNIT_CU_OBJS =
-ifdef USING_NVCC
-	UNIT_CU_SRCS = $(shell find unit -name *.cu)
-	UNIT_CU_OBJS = $(UNIT_CU_SRCS:%=$(BUILD_DIR)/%.o)
-endif
+## All libraries build targets completed at this point
 
-# Header files
-HEADERS := $(wildcard minus/*.h) $(wildcard zero/*.h) $(wildcard apps/*.h) $(wildcard kernels/*/*.h)
-# Headers to install
-INSTALL_HEADERS := $(shell ls apps/gkyl_*.h zero/gkyl_*.h | grep -v "priv" | sort)
-INSTALL_HEADERS += $(shell ls minus/*.h)
+all: ${BUILD_DIR}/gkylzero.h ${ZERO_SH_LIB} ## Build libraries and amalgamated header
 
-# Library name
-ifeq ($(CC), nvcc)
-	G0LIB = gkylzero
-else
-	G0LIB = gkylzero
-endif
+# Explicit targets to build unit and regression tests
+unit: ${UNITS} ## Build unit tests
+regression: ${REGS} ## Build regression tests
 
-# Object files to compile in library
-LIBOBJS = ${OBJS}
-
-# names of libraries to build
-G0STLIB = lib${G0LIB}.a
-G0SHLIB = lib${G0LIB}.so
-
-# Make targets: libraries, regression tests and unit tests
-all: ${BUILD_DIR}/gkylzero.h ${BUILD_DIR}/${G0STLIB} ${BUILD_DIR}/${G0SHLIB}
-
-# Amalgamated header file
-${BUILD_DIR}/gkylzero.h:
-	$(MKDIR_P) ${BUILD_DIR}
-	./minus/gengkylzeroh.sh > ${BUILD_DIR}/gkylzero.h
-
-# Library archive
-${BUILD_DIR}/${G0STLIB}: ${LIBOBJS}
-	ar -crs $@ ${LIBOBJS}
-
-# Dynamic (shared) library
-${BUILD_DIR}/${G0SHLIB}: ${LIBOBJS}
-	${CC} ${SHFLAGS} ${LDFLAGS} ${LIBOBJS} ${SUPERLU_LIB} ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread -o $@
-
-# Regression tests
-${BUILD_DIR}/regression/%: regression/%.c ${BUILD_DIR}/${G0STLIB} regression/rt_arg_parse.h
-	$(MKDIR_P) ${BUILD_DIR}/regression
-	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${BUILD_DIR}/${G0STLIB} ${SUPERLU_LIB} ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread
-
-# Unit tests
-${BUILD_DIR}/unit/%: unit/%.c ${BUILD_DIR}/${G0STLIB} ${UNIT_CU_OBJS} ${UNIT_CU_SRCS}
-	$(MKDIR_P) ${BUILD_DIR}/unit
-	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $< -I. $(INCLUDES) ${UNIT_CU_OBJS} ${BUILD_DIR}/${G0STLIB} ${SUPERLU_LIB} ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread
-
-.PHONY: check clean partclean install
-
+.PHONY: check
 # Run all unit tests
-check: ${UNITS}
+check: ${UNITS} ## Build (if needed) and run all unit tests
 	$(foreach unit,${UNITS},echo $(unit); $(unit) -E;)
 
-unit: ${UNITS}
-
-regression: ${REGS}
-
-install: all
+install: all ## Install library and headers
+# Construct install directories
 	$(MKDIR_P) ${PREFIX}/gkylzero/include
 	${MKDIR_P} ${PREFIX}/gkylzero/lib
 	${MKDIR_P} ${PREFIX}/gkylzero/bin
 	${MKDIR_P} ${PREFIX}/gkylzero/share
 	${MKDIR_P} ${PREFIX}/gkylzero/scripts
+# Headers
 	cp ${INSTALL_HEADERS} ${PREFIX}/gkylzero/include
 	./minus/gengkylzeroh.sh > ${PREFIX}/gkylzero/include/gkylzero.h
-	cp -f ${BUILD_DIR}/${G0STLIB} ${PREFIX}/gkylzero/lib
-	cp -f ${BUILD_DIR}/${G0SHLIB} ${PREFIX}/gkylzero/lib
+# libraries
+	cp -f ${ZERO_SH_LIB} ${PREFIX}/gkylzero/lib
+# Examples
 	cp -f Makefile.sample ${PREFIX}/gkylzero/share/Makefile
 	cp -f regression/rt_arg_parse.h ${PREFIX}/gkylzero/share/rt_arg_parse.h
 	cp -f regression/rt_twostream.c ${PREFIX}/gkylzero/share/rt_twostream.c
-#	cp -f ${BUILD_DIR}/regression/rt_vlasov_kerntm ${PREFIX}/gkylzero/bin/
+# Lua wrappers
 	cp -f inf/Vlasov.lua ${PREFIX}/gkylzero/lib/
 	cp -f inf/Moments.lua ${PREFIX}/gkylzero/lib/
+# Misc scripts
 	cp -f scripts/*.sh ${PREFIX}/gkylzero/scripts
 
-libinstall: ${BUILD_DIR}/${G0STLIB} ${BUILD_DIR}/${G0SHLIB}
-	$(MKDIR_P) ${PREFIX}/gkylzero/include
-	${MKDIR_P} ${PREFIX}/gkylzero/lib
-	${MKDIR_P} ${PREFIX}/gkylzero/bin
-	${MKDIR_P} ${PREFIX}/gkylzero/share
-	cp ${HEADERS} ${PREFIX}/gkylzero/include
-	cp -f ${BUILD_DIR}/${G0STLIB} ${PREFIX}/gkylzero/lib
-	cp -f ${BUILD_DIR}/${G0SHLIB} ${PREFIX}/gkylzero/lib
-
-clean:
+.PHONY: clean
+clean: ## Clean build output
 	rm -rf ${BUILD_DIR}
-
-# partclean does not delete the kernel object files as they do not
-# always need to be rebuilt and are very expensive to build when using
-# nvcc
-partclean:
-	rm -rf ${BUILD_DIR}/${G0STLIB} ${BUILD_DIR}/${G0SHLIB} ${BUILD_DIR}/zero ${BUILD_DIR}/app ${BUILD_DIR}/regression ${BUILD_DIR}/unit
 
 # include dependencies
 -include $(DEPS)
 
 # command to make dir
-MKDIR_P ?= mkdir -p	
+MKDIR_P ?= mkdir -p
+
+# From: https://www.client9.com/self-documenting-makefiles/
+.PHONY: help
+help: ## Show help
+	@echo "GkylZero Makefile help. You can set parameters on the command line:"
+	@echo ""
+	@echo "make CC=nvcc -j"
+	@echo ""
+	@echo "Or run the configure script to set various parameters. Usually"
+	@echo "defaults are all you need, specially if the dependencies are in"
+	@echo "${HOME}/gkylsoft and you are using standard compilers (not building on GPUs)"
+	@echo ""
+	@echo "See ./configure --help for usage of configure script"
+	@echo ""
+	@awk -F ':|##' '/^[^\t].+?:.*?##/ {\
+        printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
+        }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ endif
 
 # On OSX we should use Accelerate framework
 ifeq ($(UNAME), Darwin)
+	LAPACK_LIB_DIR = 
 	LAPACK_INC = zero # dummy
 	LAPACK_LIB = -framework Accelerate
 	CFLAGS += -DGKYL_USING_FRAMEWORK_ACCELERATE

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ UNAME = $(shell uname)
 # Default lapack include and libraries: we prefer linking to static library
 LAPACK_INC = ${HOME}/gkylsoft/OpenBLAS/include
 LAPACK_LIB_DIR = ${HOME}/gkylsoft/OpenBLAS/lib
-LAPACK_LIB = ${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a
+LAPACK_LIB = -lopenblas
 
 # SuperLU includes and librararies
 SUPERLU_INC = ${HOME}/gkylsoft/superlu/include
@@ -91,7 +91,7 @@ KERN_INCLUDES = $(addprefix -I,$(KERN_INC_DIRS))
 
 # List of link directories and libraries for unit and regression tests
 EXEC_LIB_DIRS = -L${SUPERLU_LIB_DIR} -L${LAPACK_LIB_DIR} -L${BUILD_DIR}
-EXEC_EXT_LIBS = -lsuperlu -lopenblas ${CUDA_LIBS} -lm -lpthread
+EXEC_EXT_LIBS = -lsuperlu ${LAPACK_LIB} ${CUDA_LIBS} -lm -lpthread
 EXEC_LIBS = -lgkylzero ${EXEC_EXT_LIBS}
 EXEC_RPATH = -Wl,-rpath,${BUILD_DIR}
 

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ endif
 
 # On OSX we should use Accelerate framework
 ifeq ($(UNAME), Darwin)
-	LAPACK_LIB_DIR = 
+	LAPACK_LIB_DIR = .
 	LAPACK_INC = zero # dummy
 	LAPACK_LIB = -framework Accelerate
 	CFLAGS += -DGKYL_USING_FRAMEWORK_ACCELERATE
-	SHFLAGS += -dynamiclib -install_name ${PREFIX}/gkylzero/lib/libgkylzero.so
+	SHFLAGS += -dynamiclib
 else
 	SHFLAGS += -shared
 endif

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ endif
 # Include config.mak file (if it exists) to overide defaults above
 -include config.mak
 
+# By default, build the "all" target. This builds the G0 shared
+# library only. Unit and regression tests are built with explicit
+# targets. See "make help"
+.DEFAULT_GOAL := all
+
 # CUDA flags
 USING_NVCC =
 NVCC_FLAGS = 
@@ -180,6 +185,7 @@ $(ZERO_SH_LIB): $(OBJS)
 
 ## All libraries build targets completed at this point
 
+.PHONY: all
 all: ${BUILD_DIR}/gkylzero.h ${ZERO_SH_LIB} ## Build libraries and amalgamated header
 
 # Explicit targets to build unit and regression tests

--- a/Makefile.sample
+++ b/Makefile.sample
@@ -8,14 +8,15 @@ PREFIX = ${HOME}/gkylsoft
 
 G0_INC_DIR = ${PREFIX}/gkylzero/include
 G0_LIB_DIR = ${PREFIX}/gkylzero/lib
-G0_STLIB = ${PREFIX}/gkylzero/lib/libgkylzero.a
+G0_LIB = -lgkylzero
 CUDA_LIB = 
 
 ifeq ($(CC), nvcc)
 	CUDA_LIB = -lcublas
 endif
 
-G0_LIBS = ${G0_STLIB} ${CUDA_LIB} -lm -lpthread
+G0_LIBS = ${G0_LIB} ${CUDA_LIB} -lm -lpthread
+G0_RPATH = -Wl,-rpath,${G0_LIB_DIR}
 
 # Default lapack include and libraries: we prefer linking to static library
 LAPACK_INC = ${HOME}/gkylsoft/OpenBLAS/include
@@ -41,7 +42,7 @@ INCLUDES = -I${G0_INC_DIR} -I${LAPACK_INC} -I${SUPERLU_INC}
 all: rt_twostream
 
 rt_twostream: rt_twostream.c
-	 ${CC} ${CFLAGS} ${INCLUDES} rt_twostream.c -o rt_twostream -L${G0_LIB_DIR} ${G0_LIBS} ${LAPACK_LIB} ${SUPERLU_LIB}
+	 ${CC} ${CFLAGS} ${INCLUDES} rt_twostream.c -o rt_twostream -L${G0_LIB_DIR} ${G0_RPATH} ${G0_LIBS} ${LAPACK_LIB} ${SUPERLU_LIB}
 
 clean:
 	rm -rf rt_twostream rt_twostream.dSYM

--- a/configure
+++ b/configure
@@ -15,7 +15,7 @@ LAPACK_LIB=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a
 OSTYPE=`uname -o`
 MACHINE=`uname -n`
 USER=`whoami`
-echo "OS type is $OSTYPE on $MACHINE user $USER"
+echo "# OS type is $OSTYPE on $MACHINE user $USER"
 # SuperLU includes and librararies
 SUPERLU_INC=${HOME}/gkylsoft/superlu/include
 if [ "$OSTYPE" = "linux-gnu"* ]
@@ -176,5 +176,5 @@ CUDAMATH_LIBDIR=$CUDAMATH_LIBDIR
 
 EOF1
 
-echo "# Wrote config.mak with contents"
+echo "# Wrote config.mak with contents:"
 cat config.mak

--- a/zero/wave_prop.c
+++ b/zero/wave_prop.c
@@ -237,7 +237,7 @@ gkyl_wave_prop_advance(gkyl_wave_prop *wv,
   int ndim = update_range->ndim;
   int meqn = wv->equation->num_equations;
   //  when forced to use Lax fluxes, we only have a single wave
-  int mwaves = wv->force_low_order_flux ? 1 :  wv->equation->num_waves;
+  int mwaves = wv->force_low_order_flux ? 2 :  wv->equation->num_waves;
 
   double cfla = 0.0, cfl = wv->cfl, cflm = 1.1*cfl;
 

--- a/zero/wv_euler.c
+++ b/zero/wv_euler.c
@@ -97,13 +97,22 @@ wave_lax(const struct gkyl_wv_eqn *eqn,
   double ul = ql[1]/ql[0], ur = qr[1]/qr[0];
   double pl = gkyl_euler_pressure(gas_gamma, ql), pr = gkyl_euler_pressure(gas_gamma, qr);
   double sl = fabs(ul) + sqrt(gas_gamma*pl/rhol), sr = fabs(ur) + sqrt(gas_gamma*pr/rhor);
+  double amax = fmax(sl, sr);
 
-  double *wv = &waves[0]; // single wave
-  for (int i=0; i<5; ++i)  wv[i] = delta[i];
+  double fl[5], fr[5];
+  gkyl_euler_flux(gas_gamma, ql, fl);
+  gkyl_euler_flux(gas_gamma, qr, fr);
 
-  s[0] = 0.5*(sl+sr);
+  double *w0 = &waves[0], *w1 = &waves[5];
+  for (int i=0; i<5; ++i) {
+    w0[i] = 0.5*((qr[i]-ql[i]) - (fr[i]-fl[i])/amax);
+    w1[i] = 0.5*((qr[i]-ql[i]) + (fr[i]-fl[i])/amax);
+  }
+
+  s[0] = -amax;
+  s[1] = amax;
   
-  return s[0];
+  return s[1];
 }
 
 static void
@@ -111,22 +120,13 @@ qfluct_lax(const struct gkyl_wv_eqn *eqn,
   const double *ql, const double *qr, const double *waves, const double *s,
   double *amdq, double *apdq)
 {
-  const struct wv_euler *euler = container_of(eqn, struct wv_euler, eqn);
-  double gas_gamma = euler->gas_gamma;
-
-  double rhol = ql[0], rhor = qr[0];
-  double ul = ql[1]/ql[0], ur = qr[1]/qr[0];
-  double pl = gkyl_euler_pressure(gas_gamma, ql), pr = gkyl_euler_pressure(gas_gamma, qr);
-  double sl = fabs(ul) + sqrt(gas_gamma*pl/rhol), sr = fabs(ur) + sqrt(gas_gamma*pr/rhor);
-  double amax = fmax(sl, sr);
-
-  double fl[5], fr[5];
-  gkyl_euler_flux(gas_gamma, ql, fl);
-  gkyl_euler_flux(gas_gamma, qr, fr);
+  const double *w0 = &waves[0], *w1 = &waves[5];
+  double s0m = fmin(0.0, s[0]), s1m = fmin(0.0, s[1]);
+  double s0p = fmax(0.0, s[0]), s1p = fmax(0.0, s[1]);
 
   for (int i=0; i<5; ++i) {
-    amdq[i] = 0.5*(fr[i]-fl[i] - amax*(qr[i]-ql[i]));
-    apdq[i] = 0.5*(fr[i]-fl[i] + amax*(qr[i]-ql[i]));
+    amdq[i] = s0m*w0[i] + s1m*w1[i];
+    apdq[i] = s0p*w0[i] + s1p*w1[i];
   }
 }
 
@@ -456,7 +456,7 @@ gkyl_wv_euler_inew(const struct gkyl_wv_euler_inp *inp)
       break;
       
     case WV_EULER_RP_LAX:
-      euler->eqn.num_waves = 1;
+      euler->eqn.num_waves = 2;
       euler->eqn.waves_func = wave_lax_l;
       euler->eqn.qfluct_func = qfluct_lax_l;
       break;      


### PR DESCRIPTION
This branch has two unrelated work:

- Makefile mods to only build shared library. So static lib is not build any more. All unit and regression tests use shared libs only. Leads to dramatic reduction in disk space: 10 GB -> 8 MB for nvcc builds. Of course, builds are still taking long.
- Liang's fixed to Euler Lax solver to use two waves rather than 1. Added consistency to the speeds used in the Lax fluxes which were previously unscaled.