### PR TITLE
Remove gkyl_alloc_flags_priv.h from cusolver public header. I think i…

### DIFF
--- a/zero/gkyl_cusolver_ops.h
+++ b/zero/gkyl_cusolver_ops.h
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <stdbool.h>
-#include "gkyl_alloc_flags_priv.h"
 
 #include <gkyl_alloc.h>
 #include <gkyl_mat_triples.h>


### PR DESCRIPTION
…t's not needed, and it worked this way on Perlmutter.

I forgotten to commit/push this as part of pull request #108 