### PR TITLE
Project maxwellian, BGK and LBO cross prim mom prefactor

### DIFF
--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -72,32 +72,6 @@ void eval_vtsq_1v(double t, const double *xn, double* restrict fout, void *ctx)
   fout[0] = vtsq;
 }
 
-void eval_M1i_2v(double t, const double *xn, double* restrict fout, void *ctx)
-{
-  double x = xn[0];
-  fout[0] = 0.5; fout[1] = 0.25;
-}
-
-void eval_M2_2v(double t, const double *xn, double* restrict fout, void *ctx)
-{
-  double n = 1.0, vth2 = 1.0, ux = 0.5, uy = 0.25;
-  double x = xn[0];
-  fout[0] = 2*n*vth2 + n*(ux*ux+uy*uy);
-}
-
-void eval_udrift_2v(double t, const double *xn, double* restrict fout, void *ctx)
-{
-  double x = xn[0];
-  fout[0] = 0.5; fout[1] = 0.25;
-}
-
-void eval_vtsq_2v(double t, const double *xn, double* restrict fout, void *ctx)
-{
-  double x = xn[0];
-  double vtsq = 1.0;
-  fout[0] = vtsq;
-}
-
 void
 test_1x1v(int poly_order, bool use_gpu)
 {
@@ -117,7 +91,10 @@ test_1x1v(int poly_order, bool use_gpu)
 
   // basis functions
   struct gkyl_basis basis, confBasis;
-  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+  if (poly_order == 1) 
+    gkyl_cart_modal_hybrid(&basis, cdim, vdim);
+  else
+    gkyl_cart_modal_serendip(&basis, ndim, poly_order);
   gkyl_cart_modal_serendip(&confBasis, cdim, poly_order);
 
   int confGhost[] = { 1 };
@@ -181,8 +158,7 @@ test_1x1v(int poly_order, bool use_gpu)
   }
 
   // values to compare  at index (1, 17) [remember, lower-left index is (1,1)]
-  double p1_vals[] = {  7.5585421616306459e-01, -2.1688605007995894e-17,  2.5560131294504802e-02,
-    0.0000000000000000e+00 };
+  double p1_vals[] = {  7.5586260555876306e-01, 0.0000000000000000e+00, 2.5444480361615229e-02, 0.0000000000000000e+00, -3.5764626824659473e-03, 0.0000000000000000e+00 };
   double p2_vals[] = {  7.5586260555876306e-01,  3.3461741853476639e-17,  2.5444480361615243e-02,
     9.2374888136351991e-18, 3.6409663532636887e-16, -3.5764626824658884e-03,
     5.2417618568471655e-17, -3.0935326627861718e-18 };
@@ -289,6 +265,32 @@ test_1x1v(int poly_order, bool use_gpu)
   gkyl_proj_maxwellian_on_basis_release(proj_max);
 }
 
+void eval_M1i_2v(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  fout[0] = 0.5; fout[1] = 0.25;
+}
+
+void eval_M2_2v(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double n = 1.0, vth2 = 1.0, ux = 0.5, uy = 0.25;
+  double x = xn[0];
+  fout[0] = 2*n*vth2 + n*(ux*ux+uy*uy);
+}
+
+void eval_udrift_2v(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  fout[0] = 0.5; fout[1] = 0.25;
+}
+
+void eval_vtsq_2v(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double vtsq = 1.0;
+  fout[0] = vtsq;
+}
+
 void
 test_1x2v(int poly_order, bool use_gpu)
 {
@@ -308,7 +310,10 @@ test_1x2v(int poly_order, bool use_gpu)
 
   // basis functions
   struct gkyl_basis basis, confBasis;
-  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+  if (poly_order == 1) 
+    gkyl_cart_modal_hybrid(&basis, cdim, vdim);
+  else
+    gkyl_cart_modal_serendip(&basis, ndim, poly_order);
   gkyl_cart_modal_serendip(&confBasis, cdim, poly_order);
 
   int confGhost[] = { 1 };
@@ -372,9 +377,10 @@ test_1x2v(int poly_order, bool use_gpu)
   }
 
   // values to compare  at index (1, 9, 9) [remember, lower-left index is (1,1,1)]
-  double p1_vals[] = {  4.2319425948079414e-01,  1.2894963939286889e-17,  1.1450235276582092e-02,
-    -1.1450235276582088e-02, -9.8282386852756766e-19, -9.8282386852756766e-19,
-    -3.0980544974766697e-04, -9.8282386852756766e-19 };
+  double p1_vals[] = {  
+    4.2337474137655012e-01, 0.0000000000000000e+00, 1.1241037221784697e-02, -1.1241037221784659e-02, 0.0000000000000000e+00, 0.0000000000000000e+00,
+    -2.9846116329636935e-04, 0.0000000000000000e+00, -8.7555592875305493e-03, 0.0000000000000000e+00, 2.3246915375411265e-04, 0.0000000000000000e+00,
+    -8.7555592875305354e-03, 0.0000000000000000e+00, -2.3246915375410571e-04, 0.0000000000000000e+00 };
   double p2_vals[] = { 4.2337474137655023e-01,  5.0502880544733958e-17,  1.1241037221784692e-02,
     -1.1241037221784697e-02, -4.7391077427032355e-18,  2.1997861612039929e-18,
     -2.9846116329638447e-04,  1.7051554382338028e-16, -8.7555592875305649e-03,
@@ -472,10 +478,10 @@ test_1x2v(int poly_order, bool use_gpu)
       TEST_CHECK( gkyl_compare_double(p3_vals[i], fv[i], 1e-10) );
   }
 
-//  // write distribution function to file
-//  char fname[1024];
-//  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x1v_p%d.gkyl", poly_order);
-//  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
+  // write distribution function to file
+  char fname[1024];
+  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x2v_p%d.gkyl", poly_order);
+  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
 
   gkyl_array_release(m0); gkyl_array_release(udrift); gkyl_array_release(vtsq);
   if (use_gpu) {

--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -714,10 +714,10 @@ test_1x2v_gk(int poly_order, bool use_gpu)
       TEST_CHECK( gkyl_compare_double(p2_vals[i], fv[i], 1e-12) );
   }
 
-  // write distribution function to file
-  char fname[1024];
-  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x2v_p%d.gkyl", poly_order);
-  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
+//  // write distribution function to file
+//  char fname[1024];
+//  sprintf(fname, "ctest_proj_maxwellian_on_basis_test_1x2v_p%d.gkyl", poly_order);
+//  gkyl_grid_sub_array_write(&grid, &local, distf, fname);
 
   gkyl_array_release(m0); gkyl_array_release(udrift); gkyl_array_release(vtsq);
   gkyl_array_release(bmag); gkyl_array_release(jacob_tot);
@@ -759,6 +759,9 @@ void test_1x2v_p0_gpu() { test_1x2v(0, true); }
 void test_1x2v_p1_gpu() { test_1x2v(1, true); }
 void test_1x2v_p2_gpu() { test_1x2v(2, true); }
 void test_1x2v_p3_gpu() { test_1x2v(3, true); }
+
+void test_1x2v_p1_gk_gpu() { test_1x2v_gk(1, true); }
+void test_1x2v_p2_gk_gpu() { test_1x2v_gk(2, true); }
 #endif
 
 TEST_LIST = {
@@ -786,6 +789,9 @@ TEST_LIST = {
   { "test_1x2v_p1_gpu", test_1x2v_p1_gpu },
   { "test_1x2v_p2_gpu", test_1x2v_p2_gpu },
   { "test_1x2v_p3_gpu", test_1x2v_p3_gpu },
+
+  { "test_1x2v_p1_gk_gpu", test_1x2v_p1_gk_gpu },
+  { "test_1x2v_p2_gk_gpu", test_1x2v_p2_gk_gpu },
 #endif
   { NULL, NULL },
 };

--- a/unit/ctest_proj_maxwellian_on_basis.c
+++ b/unit/ctest_proj_maxwellian_on_basis.c
@@ -775,6 +775,7 @@ TEST_LIST = {
 // MF 2022/11/17: not ready. Need new updater.
   { "test_1x2v_p1_gk", test_1x2v_p1_gk },
   { "test_1x2v_p2_gk", test_1x2v_p2_gk },
+
 #ifdef GKYL_HAVE_CUDA
   { "test_1x1v_p0_gpu", test_1x1v_p0_gpu },
   { "test_1x1v_p1_gpu", test_1x1v_p1_gpu },

--- a/zero/bgk_collisions.c
+++ b/zero/bgk_collisions.c
@@ -1,0 +1,73 @@
+#include <gkyl_bgk_collisions.h>
+#include <gkyl_bgk_collisions_priv.h>
+#include <gkyl_alloc.h>
+#include <gkyl_array.h>
+#include <gkyl_range.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_array_ops_priv.h>
+
+gkyl_bgk_collisions*
+gkyl_bgk_collisions_new(const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis,
+  bool use_gpu)
+{
+  gkyl_bgk_collisions *up = gkyl_malloc(sizeof(gkyl_bgk_collisions));
+
+  up->cdim = cbasis->ndim;
+  up->pdim = pbasis->ndim;
+  up->cnum_basis = cbasis->num_basis;
+  up->pnum_basis = pbasis->num_basis;
+  up->use_gpu = use_gpu;
+  assert(up->pnum_basis > up->cnum_basis);
+  assert(up->pnum_basis <= 160); // MF 2022/11/18: hardcode to 3x3v p=1 hybrid.
+
+  int vdim = up->pdim-up->cdim;
+  int poly_order = cbasis->poly_order;
+  enum gkyl_basis_type b_type = pbasis->b_type;
+  up->mul_op = choose_mul_conf_phase_kern(b_type, up->cdim, vdim, poly_order);
+
+  return up;
+}
+
+void
+gkyl_bgk_collisions_advance(const gkyl_bgk_collisions *up,
+  const struct gkyl_range *crange, const struct gkyl_range *prange,
+  const struct gkyl_array *nu, const struct gkyl_array *nufM, const struct gkyl_array *fin,
+  struct gkyl_array *out, struct gkyl_array *cflfreq)
+{
+  // Compute nu*f_M - nu*f, and its contribution to the CFL rate.
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    return gkyl_bgk_collisions_advance_cu(up, crange, prange, nu, nufM, fin, out, cflrate);
+#endif
+
+  struct gkyl_range_iter piter;
+  gkyl_range_iter_init(&piter, prange);
+  while (gkyl_range_iter_next(&piter)) {
+    long ploc = gkyl_range_idx(prange, piter.idx);
+
+    int cidx[3];
+    for (int d=0; d<up->cdim; d++) cidx[d] = piter.idx[d];
+    long cloc = gkyl_range_idx(crange, cidx);
+
+    const double *nu_d = gkyl_array_cfetch(nu, cloc);
+    double *out_d = gkyl_array_fetch(out, ploc);
+
+    // Calculate -nu*f.
+    double incr[160]; // mul_op assigns, but need increment, so use a buffer.
+    up->mul_op(nu_d, gkyl_array_cfetch(fin, ploc), incr);
+    for (int i=0; i<up->pnum_basis; i++) out_d[i] += -incr[i];
+
+    // Add nu*f_M.
+    array_acc1(up->pnum_basis, out_d, 1., gkyl_array_cfetch(nufM, ploc));
+
+    // Add contribution to CFL frequency.
+    double *cflfreq_d = gkyl_array_fetch(cflfreq, ploc);
+    cflfreq_d[0] += nu_d[0]*sqrt(pow(2,up->pdim)) ;
+  }
+}
+
+void
+gkyl_bgk_collisions_release(gkyl_bgk_collisions* up)
+{
+  gkyl_free(up);
+}

--- a/zero/bgk_collisions.c
+++ b/zero/bgk_collisions.c
@@ -26,6 +26,8 @@ gkyl_bgk_collisions_new(const struct gkyl_basis *cbasis, const struct gkyl_basis
   if (!up->use_gpu)
     up->mul_op = choose_mul_conf_phase_kern(up->pb_type, up->cdim, up->vdim, poly_order);
 
+  up->cellav_fac = 1./sqrt(pow(2,up->cdim));
+
   return up;
 }
 
@@ -40,8 +42,6 @@ gkyl_bgk_collisions_advance(const gkyl_bgk_collisions *up,
   if (up->use_gpu)
     return gkyl_bgk_collisions_advance_cu(up, crange, prange, nu, nufM, fin, out, cflfreq);
 #endif
-
-  unsigned pdim = up->cdim+up->vdim;
 
   struct gkyl_range_iter piter;
   gkyl_range_iter_init(&piter, prange);
@@ -65,7 +65,7 @@ gkyl_bgk_collisions_advance(const gkyl_bgk_collisions *up,
 
     // Add contribution to CFL frequency.
     double *cflfreq_d = gkyl_array_fetch(cflfreq, ploc);
-    cflfreq_d[0] += nu_d[0]*sqrt(pow(2,pdim)) ;
+    cflfreq_d[0] += nu_d[0]*up->cellav_fac;
   }
 }
 

--- a/zero/bgk_collisions_cu.cu
+++ b/zero/bgk_collisions_cu.cu
@@ -1,0 +1,70 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_alloc.h>
+#include <gkyl_array_ops_priv.h>
+#include <gkyl_dg_bin_ops.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_util.h>
+#include <gkyl_bgk_collisions_priv.h>
+}
+
+__global__ void
+gkyl_bgk_collisions_advance_cu_kernel(unsigned cdim, unsigned vdim, unsigned poly_order,
+  unsigned pnum_basis, enum gkyl_basis_type b_type, struct gkyl_range crange, struct gkyl_range prange,
+  const struct gkyl_array* nu, const struct gkyl_array* nufM, const struct gkyl_array* fin,
+  struct gkyl_array* out, struct gkyl_array* cflfreq)
+{
+  mul_op_t mul_op = choose_mul_conf_phase_kern(b_type, cdim, vdim, poly_order);
+
+  int pidx[GKYL_MAX_DIM];
+  unsigned pdim = cdim+vdim;
+
+  for (unsigned long linc1 = threadIdx.x + blockIdx.x*blockDim.x;
+      linc1 < prange.volume;
+      linc1 += gridDim.x*blockDim.x)
+  {
+    // inverse index from linc1 to idx
+    // must use gkyl_sub_range_inv_idx so that linc1=0 maps to idx={1,1,...}
+    // since update_range is a subrange
+    gkyl_sub_range_inv_idx(&prange, linc1, pidx);
+
+    // convert back to a linear index on the super-range (with ghost cells)
+    // linc will have jumps in it to jump over ghost cells
+    long pstart = gkyl_range_idx(&prange, pidx);
+
+    const double *nufM_d = (const double*) gkyl_array_cfetch(nufM, pstart);
+    const double *fin_d = (const double*) gkyl_array_cfetch(fin, pstart);
+    double *out_d = (double*) gkyl_array_fetch(out, pstart);
+
+    int cidx[3];
+    for (int d=0; d<cdim; d++) cidx[d] = pidx[d];
+    long cstart = gkyl_range_idx(&crange, cidx);
+    const double *nu_d = (const double*) gkyl_array_cfetch(nu, cstart);
+
+    // Calculate -nu*f.
+    double incr[160]; // mul_op assigns, but need increment, so use a buffer.
+    mul_op(nu_d, fin_d, incr);
+    for (int i=0; i<pnum_basis; i++) out_d[i] += -incr[i];
+
+    // Add nu*f_M.
+    array_acc1(pnum_basis, out_d, 1., nufM_d);
+
+    // Add contribution to CFL frequency.
+    double *cflfreq_d = (double *) gkyl_array_fetch(cflfreq, pstart);
+    cflfreq_d[0] += nu_d[0]*sqrt(pow(2,pdim)) ;
+  }
+}
+
+void
+gkyl_bgk_collisions_advance_cu(const gkyl_bgk_collisions *up,
+  const struct gkyl_range *crange, const struct gkyl_range *prange,
+  const struct gkyl_array *nu, const struct gkyl_array *nufM, const struct gkyl_array *fin,
+  struct gkyl_array *out, struct gkyl_array *cflfreq)
+{
+  int nblocks = prange->nblocks;
+  int nthreads = prange->nthreads;
+  gkyl_bgk_collisions_advance_cu_kernel<<<nblocks, nthreads>>>(up->cdim,
+    up->vdim, up->poly_order, up->pnum_basis, up->pb_type, *crange, *prange,
+    nu->on_dev, nufM->on_dev, fin->on_dev, out->on_dev, cflfreq->on_dev);
+}

--- a/zero/gkyl_bgk_collisions.h
+++ b/zero/gkyl_bgk_collisions.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+
+// Object type
+typedef struct gkyl_bgk_collisions gkyl_bgk_collisions;
+
+/**
+ * Create new updater to compute the increment due to a BGK
+ * collision operator
+ *   nu*f_M - nu*f)
+ * where nu*f_M=sum_r nu_sr*f_Msr and nu=sum_r nu_sr, in
+ * order to support multispecies collisions. The quantities
+ * nu*f_M and nu must be computed elsewhere.
+ *
+ * @param cbasis Basis object (configuration space).
+ * @param pbasis Basis object (phase space).
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
+gkyl_bgk_collisions* gkyl_bgk_collisions_new(const struct gkyl_basis *cbasis,
+  const struct gkyl_basis *pbasis, bool use_gpu);
+
+/**
+ * Advance BGK operator (compute the BGK contribution to df/dt).
+ *
+ * @param up Spizer collision frequency updater object.
+ * @param crange Config-space range.
+ * @param prange Phase-space range.
+ * @param nu Sum of collision frequencies.
+ * @param nufM Sum of collision frequencies times their respective Maxwellian.
+ * @param fin Input distribution function.
+ * @param out BGK contribution to df/dt.
+ * @param cflfreq Output CFL frequency.
+ */
+void gkyl_bgk_collisions_advance(const gkyl_bgk_collisions *up,
+  const struct gkyl_range *crange, const struct gkyl_range *prange,
+  const struct gkyl_array *nu, const struct gkyl_array *nufM, const struct gkyl_array *fin,
+  struct gkyl_array *out, struct gkyl_array *cflfreq);
+
+/**
+ * Delete updater.
+ *
+ * @param pob Updater to delete.
+ */
+void gkyl_bgk_collisions_release(gkyl_bgk_collisions* up);

--- a/zero/gkyl_bgk_collisions_priv.h
+++ b/zero/gkyl_bgk_collisions_priv.h
@@ -1,0 +1,19 @@
+#include <gkyl_bgk_collisions.h>
+#include <gkyl_dg_bin_ops_priv.h>
+
+struct gkyl_bgk_collisions {
+  int cdim; // Configuration-space dimension.
+  int pdim; // Phase-space dimension.
+  int cnum_basis; // Number of conf-space basis functions.
+  int pnum_basis; // Number of phase-space basis functions.
+
+  mul_op_t mul_op; // Conf*phase bin_op multiplication kernel.
+
+  bool use_gpu;
+};
+
+void
+gkyl_bgk_collisions_advance_cu(const gkyl_bgk_collisions *up,
+  const struct gkyl_range *crange, const struct gkyl_range *prange,
+  const struct gkyl_array *nu, const struct gkyl_array *nufM, const struct gkyl_array *fin,
+  struct gkyl_array *out, struct gkyl_array *cflfreq);

--- a/zero/gkyl_bgk_collisions_priv.h
+++ b/zero/gkyl_bgk_collisions_priv.h
@@ -9,6 +9,8 @@ struct gkyl_bgk_collisions {
   unsigned poly_order; // Polynomial order of the basis.
   enum gkyl_basis_type pb_type; // Phase basis type.
 
+  double cellav_fac; // Multiply 0-th DG coeff by this to get the cell avg.
+
   mul_op_t mul_op; // Conf*phase bin_op multiplication kernel.
 
   bool use_gpu;

--- a/zero/gkyl_bgk_collisions_priv.h
+++ b/zero/gkyl_bgk_collisions_priv.h
@@ -2,10 +2,12 @@
 #include <gkyl_dg_bin_ops_priv.h>
 
 struct gkyl_bgk_collisions {
-  int cdim; // Configuration-space dimension.
-  int pdim; // Phase-space dimension.
-  int cnum_basis; // Number of conf-space basis functions.
-  int pnum_basis; // Number of phase-space basis functions.
+  unsigned cdim; // Configuration-space dimension.
+  unsigned vdim; // Velocity-space dimension.
+  unsigned cnum_basis; // Number of conf-space basis functions.
+  unsigned pnum_basis; // Number of phase-space basis functions.
+  unsigned poly_order; // Polynomial order of the basis.
+  enum gkyl_basis_type pb_type; // Phase basis type.
 
   mul_op_t mul_op; // Conf*phase bin_op multiplication kernel.
 

--- a/zero/gkyl_prim_cross_m0deltas.h
+++ b/zero/gkyl_prim_cross_m0deltas.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+
+// Object type
+typedef struct gkyl_prim_cross_m0deltas gkyl_prim_cross_m0deltas;
+
+/**
+ * Create a new updater that computes the m0_s*delta_s prefactor
+ * in the calculation of cross-primitive moments for LBO and BGK
+ * collisions. That is:
+ *   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
+ *
+ * @param basis Basis object (configuration space).
+ * @param range Range in which we'll compute m0_s*delta_s.
+ * @param betap1 beta+1 parameter in Greene's formulism.
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
+gkyl_prim_cross_m0deltas* gkyl_prim_cross_m0deltas_new(
+  const struct gkyl_basis *basis, const struct gkyl_range *range,
+  double betap1, bool use_gpu);
+
+/**
+ * Compute m0_s*delta_s.
+ *
+ * @param up Struct defining this updater..
+ * @param basis Basis object (configuration space).
+ * @param massself Mass of this species, m_s.
+ * @param m0self Number density of this species, m0_s.
+ * @param nuself Cross collision frequency of this species, nu_sr.
+ * @param massother Mass of the other species, m_r.
+ * @param m0other Number density of the other species, m0_r.
+ * @param nuother Cross collision frequency of the other species, nu_rs.
+ * @param range Range in which we'll compute m0_s*delta_s.
+ * @param out Output array.
+ * @return New updater pointer.
+ */
+void gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
+  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
+  const struct gkyl_range *range, struct gkyl_array* out);
+
+/**
+ * Delete updater.
+ *
+ * @param pob Updater to delete.
+ */
+void gkyl_prim_cross_m0deltas_release(gkyl_prim_cross_m0deltas* up);

--- a/zero/gkyl_prim_cross_m0deltas_priv.h
+++ b/zero/gkyl_prim_cross_m0deltas_priv.h
@@ -1,0 +1,14 @@
+#include <gkyl_prim_cross_m0deltas.h>
+#include <gkyl_dg_bin_ops_priv.h>
+
+struct gkyl_prim_cross_m0deltas {
+  struct gkyl_dg_bin_op_mem *mem;
+  double betap1;
+  bool use_gpu;
+};
+
+void
+gkyl_prim_cross_m0deltas_advance_cu(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
+  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
+  const struct gkyl_range *range, struct gkyl_array* out);

--- a/zero/gkyl_proj_maxwellian_on_basis.h
+++ b/zero/gkyl_proj_maxwellian_on_basis.h
@@ -15,7 +15,7 @@ typedef struct gkyl_proj_maxwellian_on_basis gkyl_proj_maxwellian_on_basis;
  * @param grid Grid object
  * @param conf_basis Conf-space basis functions
  * @param phase_basis Phase-space basis functions
- * @param num_quad Number of quadrature nodes
+ * @param num_quad Number of quadrature nodes (in 1D).
  * @param use_gpu boolean indicating whether to use the GPU.
  * @return New updater pointer.
  */

--- a/zero/gkyl_proj_maxwellian_on_basis.h
+++ b/zero/gkyl_proj_maxwellian_on_basis.h
@@ -61,6 +61,50 @@ void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis 
   struct gkyl_array *fmax);
 
 /**
+ * Compute projection of a gyrokinetic Maxwellian on basis.
+ * This method takes lab-frame moments to compute the projection
+ * of Maxwellian on basis functions.
+ *
+ * @param pob Project on basis updater to run
+ * @param phase_rng Phase-space range
+ * @param conf_rng Config-space range
+ * @param m0 Number density moment
+ * @param m1 Momentum in lab-frame
+ * @param m2 Energy in lab-frame
+ * @param bmag Magnetic field magnitude.
+ * @param jacob_tot Total jacobian (conf * guiding center jacobian). 
+ * @param mass Species mass.
+ * @param fmax Output Maxwellian
+ */
+void gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
+  const struct gkyl_array *M0, const struct gkyl_array *M1, const struct gkyl_array *M2,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
+  struct gkyl_array *fmax);
+
+/**
+ * Compute projection of a gyrokinetic Maxwellian on basis. This
+ * method takes primitive (fluid-frame) moments to compute the
+ * projection of Maxwellian on basis functions.
+ *
+ * @param pob Project on basis updater to run
+ * @param phase_rng Phase-space range
+ * @param conf_rng Config-space range
+ * @param m0 Number density moment
+ * @param udrift Velocity vector
+ * @param vtsq Square of thermal velocity (vtsq = T/m)
+ * @param bmag Magnetic field magnitude.
+ * @param jacob_tot Total jacobian (conf * guiding center jacobian). 
+ * @param mass Species mass.
+ * @param fmax Output Maxwellian
+ */
+void gkyl_proj_gkmaxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
+  const struct gkyl_array *m0, const struct gkyl_array *upar, const struct gkyl_array *vtsq,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
+  struct gkyl_array *fmax);
+
+/**
  * Delete updater.
  *
  * @param pob Updater to delete.

--- a/zero/gkyl_proj_maxwellian_on_basis.h
+++ b/zero/gkyl_proj_maxwellian_on_basis.h
@@ -32,15 +32,12 @@ gkyl_proj_maxwellian_on_basis* gkyl_proj_maxwellian_on_basis_new(
  * @param mob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
- * @param M0 Number density moment
- * @param M1i Momentum in lab-frame
- * @param M2 Energy in lab-frame
+ * @param moms velocity moments (m0, m1i, m2)
  * @param fmax Output Maxwellian
  */
 void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *mob,
   const struct gkyl_range *phase_range, const struct gkyl_range *conf_range,
-  const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,  
-  struct gkyl_array *fmax);
+  const struct gkyl_array *moms, struct gkyl_array *fmax);
 
 /**
  * Compute projection of Maxwellian on basis. This method takes
@@ -50,15 +47,13 @@ void gkyl_proj_maxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *
  * @param pob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
- * @param m0 Number density moment
- * @param udrift Velocity vector
- * @param vtsq Square of thermal velocity (vtsq = T/m)
+ * @param moms velocity moments (m0, m1i, m2)
+ * @param prim_moms (primitive moments udrift, vtsq=T/m)
  * @param fmax Output Maxwellian
  */
 void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *mob,
   const struct gkyl_range *phase_range, const struct gkyl_range *conf_range,
-  const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,  
-  struct gkyl_array *fmax);
+  const struct gkyl_array *moms, const struct gkyl_array *prim_moms, struct gkyl_array *fmax);
 
 /**
  * Compute projection of a gyrokinetic Maxwellian on basis.
@@ -68,9 +63,7 @@ void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis 
  * @param pob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
- * @param m0 Number density moment
- * @param m1 Momentum in lab-frame
- * @param m2 Energy in lab-frame
+ * @param moms velocity moments (m0, m1i, m2)
  * @param bmag Magnetic field magnitude.
  * @param jacob_tot Total jacobian (conf * guiding center jacobian). 
  * @param mass Species mass.
@@ -78,9 +71,8 @@ void gkyl_proj_maxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis 
  */
 void gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
-  const struct gkyl_array *M0, const struct gkyl_array *M1, const struct gkyl_array *M2,
-  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
-  struct gkyl_array *fmax);
+  const struct gkyl_array *moms, const struct gkyl_array *bmag,
+  const struct gkyl_array *jacob_tot, double mass, struct gkyl_array *fmax);
 
 /**
  * Compute projection of a gyrokinetic Maxwellian on basis. This
@@ -90,9 +82,8 @@ void gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis
  * @param pob Project on basis updater to run
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
- * @param m0 Number density moment
- * @param udrift Velocity vector
- * @param vtsq Square of thermal velocity (vtsq = T/m)
+ * @param moms velocity moments (m0, m1i, m2)
+ * @param prim_moms (primitive moments upar, vtsq=T/m)
  * @param bmag Magnetic field magnitude.
  * @param jacob_tot Total jacobian (conf * guiding center jacobian). 
  * @param mass Species mass.
@@ -100,7 +91,7 @@ void gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis
  */
 void gkyl_proj_gkmaxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_rng, const struct gkyl_range *conf_rng,
-  const struct gkyl_array *m0, const struct gkyl_array *upar, const struct gkyl_array *vtsq,
+  const struct gkyl_array *moms, const struct gkyl_array *prim_moms,
   const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
   struct gkyl_array *fmax);
 

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -20,7 +20,6 @@ copy_idx_arrays(int cdim, int pdim, const int *cidx, const int *vidx, int *out)
 
 struct gkyl_proj_maxwellian_on_basis {
   struct gkyl_rect_grid grid;
-  int num_quad; // number of quadrature points to use in each direction
   int cdim; // Configuration-space dimension
   int pdim; // Phase-space dimension
 
@@ -28,6 +27,9 @@ struct gkyl_proj_maxwellian_on_basis {
   int num_phase_basis; // number of phase-space basis functions
 
   bool use_gpu;
+
+  struct gkyl_range conf_qrange; // Range of conf-space ordinates.
+  struct gkyl_range phase_qrange; // Range of phase-space ordinates.
 
   // for quadrature in phase-space
   int tot_quad; // total number of quadrature points

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -59,3 +59,17 @@ gkyl_proj_maxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *u
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
   const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,
   struct gkyl_array *fmax);
+
+void
+gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *m0, const struct gkyl_array *m1, const struct gkyl_array *m2,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
+  struct gkyl_array *fmax);
+
+void
+gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
+  const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
+  const struct gkyl_array *m0, const struct gkyl_array *upar, const struct gkyl_array *vtsq,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
+  struct gkyl_array *fmax);

--- a/zero/gkyl_proj_maxwellian_on_basis_priv.h
+++ b/zero/gkyl_proj_maxwellian_on_basis_priv.h
@@ -51,25 +51,23 @@ struct gkyl_proj_maxwellian_on_basis {
 void
 gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
-  const struct gkyl_array *M0, const struct gkyl_array *M1i, const struct gkyl_array *M2,
-  struct gkyl_array *fmax);
+  const struct gkyl_array *moms, struct gkyl_array *fmax);
 
 void
 gkyl_proj_maxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
-  const struct gkyl_array *m0, const struct gkyl_array *udrift, const struct gkyl_array *vtsq,
+  const struct gkyl_array *moms, const struct gkyl_array *prim_moms,
   struct gkyl_array *fmax);
 
 void
 gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
-  const struct gkyl_array *m0, const struct gkyl_array *m1, const struct gkyl_array *m2,
-  const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
-  struct gkyl_array *fmax);
+  const struct gkyl_array *moms, const struct gkyl_array *bmag,
+  const struct gkyl_array *jacob_tot, double mass, struct gkyl_array *fmax);
 
 void
 gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
-  const struct gkyl_array *m0, const struct gkyl_array *upar, const struct gkyl_array *vtsq,
+  const struct gkyl_array *moms, const struct gkyl_array *prim_moms,
   const struct gkyl_array *bmag, const struct gkyl_array *jacob_tot, double mass,
   struct gkyl_array *fmax);

--- a/zero/prim_cross_m0deltas.c
+++ b/zero/prim_cross_m0deltas.c
@@ -1,0 +1,106 @@
+#include <gkyl_prim_cross_m0deltas.h>
+#include <gkyl_prim_cross_m0deltas_priv.h>
+#include <gkyl_dg_bin_ops.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_array_ops_priv.h>
+#include <gkyl_alloc.h>
+
+gkyl_prim_cross_m0deltas*
+gkyl_prim_cross_m0deltas_new(const struct gkyl_basis *basis, const struct gkyl_range *range,
+  double betap1, bool use_gpu)
+{
+  gkyl_prim_cross_m0deltas *up = gkyl_malloc(sizeof(gkyl_prim_cross_m0deltas));
+
+  // MF 2022/11/19: hardcoded arrays for a max of 3x p2 Ser basis below.
+  assert(basis->num_basis <= 20);
+
+  // Preallocate memory for the weak division.
+  up->mem = gkyl_dg_bin_op_mem_new(range->volume, basis->num_basis);
+
+  up->betap1 = betap1;
+  up->use_gpu = use_gpu;
+
+  return up;
+}
+
+void
+gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
+  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
+  const struct gkyl_range *range, struct gkyl_array* out)
+{
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    return gkyl_prim_cross_m0deltas_advance_cu(up, basis, massself, m0self, nuself,
+                                               massother, m0other, nuother, range, out);
+#endif
+
+  int num_basis = basis.num_basis;
+  int ndim = basis.ndim;
+  int poly_order = basis.poly_order;
+  div_set_op_t div_set_op = choose_ser_div_set_kern(ndim, poly_order);
+  mul_op_t mul_op = choose_ser_mul_kern(ndim, poly_order);
+
+  // Allocate memory for use in kernels.
+  struct gkyl_nmat *As = up->mem->As;
+  struct gkyl_nmat *xs = up->mem->xs;
+  // MF 2022/11/19: Hardcoded to a max number of basis for 3x p2 ser.
+  double denom[20], numer[20];
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  long count = 0;
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(range, iter.idx);
+
+    const double *m0self_d = gkyl_array_cfetch(m0self, loc);
+    const double *nuself_d = gkyl_array_cfetch(nuself, loc);
+    const double *m0other_d = gkyl_array_cfetch(m0other, loc);
+    const double *nuother_d = gkyl_array_cfetch(nuother, loc);
+
+    // compute the numerator and denominator in:
+    //   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
+
+    mul_op(nuself_d, m0self_d, denom);
+    mul_op(nuother_d, m0other_d, numer);
+
+    for (int k=0; k<num_basis; k++) {
+      denom[k] *= massself;
+      numer[k] *= 2.*up->betap1*massother;
+    }
+
+    array_acc1(num_basis, denom, 0.5/up->betap1, numer);
+
+    mul_op(m0self_d, numer, numer);
+
+    struct gkyl_mat A = gkyl_nmat_get(As, count);
+    struct gkyl_mat x = gkyl_nmat_get(xs, count);
+    gkyl_mat_clear(&A, 0.0); gkyl_mat_clear(&x, 0.0);
+
+    div_set_op(&A, &x, numer, denom);
+
+    count += 1;
+  }
+
+  bool status = gkyl_nmat_linsolve_lu_pa(up->mem->lu_mem, As, xs);
+  assert(status);
+
+  gkyl_range_iter_init(&iter, range);
+  count = 0;
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(range, iter.idx);
+
+    double *out_d = gkyl_array_fetch(out, loc);
+    struct gkyl_mat x = gkyl_nmat_get(xs, count);
+    binop_div_copy_sol(&x, out_d);
+
+    count += 1;
+  }
+}
+
+void
+gkyl_prim_cross_m0deltas_release(gkyl_prim_cross_m0deltas* up)
+{
+  gkyl_dg_bin_op_mem_release(up->mem);
+  gkyl_free(up);
+}

--- a/zero/prim_cross_m0deltas.c
+++ b/zero/prim_cross_m0deltas.c
@@ -14,11 +14,12 @@ gkyl_prim_cross_m0deltas_new(const struct gkyl_basis *basis, const struct gkyl_r
   // MF 2022/11/19: hardcoded arrays for a max of 3x p2 Ser basis below.
   assert(basis->num_basis <= 20);
 
-  // Preallocate memory for the weak division.
-  up->mem = gkyl_dg_bin_op_mem_new(range->volume, basis->num_basis);
-
   up->betap1 = betap1;
   up->use_gpu = use_gpu;
+
+  // Preallocate memory for the weak division.
+  up->mem = use_gpu ? gkyl_dg_bin_op_mem_cu_dev_new(range->volume, basis->num_basis)
+	             : gkyl_dg_bin_op_mem_new(range->volume, basis->num_basis);
 
   return up;
 }

--- a/zero/prim_cross_m0deltas_cu.cu
+++ b/zero/prim_cross_m0deltas_cu.cu
@@ -1,0 +1,94 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_array_ops_priv.h>
+#include <gkyl_dg_bin_ops.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_mat.h>
+#include <gkyl_util.h>
+}
+
+__global__ void
+gkyl_prim_cross_m0deltas_set_op_range_cu_kernel(struct gkyl_nmat *As, struct gkyl_nmat *xs,
+  struct gkyl_basis basis, double betap1,
+  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother
+  struct gkyl_range range, struct gkyl_array* out)
+{
+  int num_basis = basis.num_basis;
+  int ndim = basis.ndim;
+  int poly_order = basis.poly_order;
+  div_set_op_t div_set_op = choose_ser_div_set_kern(ndim, poly_order);
+  mul_op_t mul_op = choose_ser_mul_kern(ndim, poly_order);
+
+  int idx[GKYL_MAX_DIM];
+  // MF 2022/11/19: Hardcoded to a max number of basis for 3x p2 ser.
+  double denom[20], numer[20];
+
+  for (unsigned long linc1 = threadIdx.x + blockIdx.x*blockDim.x;
+      linc1 < range.volume;
+      linc1 += gridDim.x*blockDim.x)
+  {
+    // inverse index from linc1 to idx
+    // must use gkyl_sub_range_inv_idx so that linc1=0 maps to idx={1,1,...}
+    // since update_range is a subrange
+    gkyl_sub_range_inv_idx(&range, linc1, idx);
+
+    // convert back to a linear index on the super-range (with ghost cells)
+    // linc will have jumps in it to jump over ghost cells
+    long start = gkyl_range_idx(&range, idx);
+
+    const double *m0self_d = (const double*) gkyl_array_cfetch(m0self, loc);
+    const double *nuself_d = (const double*) gkyl_array_cfetch(nuself, loc);
+    const double *m0other_d = (const double*) gkyl_array_cfetch(m0other, loc);
+    const double *nuother_d = (const double*) gkyl_array_cfetch(nuother, loc);
+
+    // compute the numerator and denominator in:
+    //   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
+
+    mul_op(nuself_d, m0self_d, denom);
+    mul_op(nuother_d, m0other_d, numer);
+
+    for (int k=0; k<num_basis; k++) {
+      denom[k] *= massself;
+      numer[k] *= 2.*up->betap1*massother;
+    }
+
+    array_acc1(num_basis, denom, 0.5/betap1, numer);
+
+    mul_op(m0self_d, numer, numer);
+
+    struct gkyl_mat A = gkyl_nmat_get(As, linc1);
+    struct gkyl_mat x = gkyl_nmat_get(xs, linc1);
+    gkyl_mat_clear(&A, 0.0); gkyl_mat_clear(&x, 0.0);
+
+    div_set_op(&A, &x, numer, denom);
+  }
+}
+
+// Host-side wrapper for range-based dg division operation
+void
+gkyl_prim_cross_m0deltas_advance_cu(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
+  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
+  const struct gkyl_range *range, struct gkyl_array* out)
+{
+  int nblocks = range->nblocks;
+  int nthreads = range->nthreads;
+  // allocate memory for use in kernels
+  struct gkyl_nmat *A_d = up->mem->As;
+  struct gkyl_nmat *x_d = up->mem->xs;
+
+  // construct matrices using CUDA kernel
+  gkyl_prim_cross_m0deltas_set_op_range_cu_kernel<<<nblocks, nthreads>>>(A_d->on_dev,
+    x_d->on_dev, basis, up->betap1, massself, m0self->on_dev, nuself->on_dev,
+    massother, m0other->on_dev, nuother->on_dev, *range, out->on_dev);
+
+  // invert all matrices in batch mode
+  bool status = gkyl_nmat_linsolve_lu_pa(up->mem->lu_mem, A_d, x_d);
+  assert(status);
+
+  // copy solution into array (also lives on the device)
+  gkyl_dg_div_copy_sol_op_range_cu_kernel<<<nblocks, nthreads>>>(x_d->on_dev,
+    basis, 0, out->on_dev, *range);
+}

--- a/zero/prim_cross_m0deltas_cu.cu
+++ b/zero/prim_cross_m0deltas_cu.cu
@@ -1,6 +1,8 @@
 /* -*- c++ -*- */
 
 extern "C" {
+#include <gkyl_prim_cross_m0deltas_priv.h>
+#include <gkyl_alloc.h>
 #include <gkyl_array_ops_priv.h>
 #include <gkyl_dg_bin_ops.h>
 #include <gkyl_dg_bin_ops_priv.h>
@@ -12,7 +14,7 @@ __global__ void
 gkyl_prim_cross_m0deltas_set_op_range_cu_kernel(struct gkyl_nmat *As, struct gkyl_nmat *xs,
   struct gkyl_basis basis, double betap1,
   double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
-  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother
+  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
   struct gkyl_range range, struct gkyl_array* out)
 {
   int num_basis = basis.num_basis;
@@ -38,10 +40,10 @@ gkyl_prim_cross_m0deltas_set_op_range_cu_kernel(struct gkyl_nmat *As, struct gky
     // linc will have jumps in it to jump over ghost cells
     long start = gkyl_range_idx(&range, idx);
 
-    const double *m0self_d = (const double*) gkyl_array_cfetch(m0self, loc);
-    const double *nuself_d = (const double*) gkyl_array_cfetch(nuself, loc);
-    const double *m0other_d = (const double*) gkyl_array_cfetch(m0other, loc);
-    const double *nuother_d = (const double*) gkyl_array_cfetch(nuother, loc);
+    const double *m0self_d = (const double*) gkyl_array_cfetch(m0self, start);
+    const double *nuself_d = (const double*) gkyl_array_cfetch(nuself, start);
+    const double *m0other_d = (const double*) gkyl_array_cfetch(m0other, start);
+    const double *nuother_d = (const double*) gkyl_array_cfetch(nuother, start);
 
     // compute the numerator and denominator in:
     //   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
@@ -51,7 +53,7 @@ gkyl_prim_cross_m0deltas_set_op_range_cu_kernel(struct gkyl_nmat *As, struct gky
 
     for (int k=0; k<num_basis; k++) {
       denom[k] *= massself;
-      numer[k] *= 2.*up->betap1*massother;
+      numer[k] *= 2.*betap1*massother;
     }
 
     array_acc1(num_basis, denom, 0.5/betap1, numer);
@@ -63,6 +65,35 @@ gkyl_prim_cross_m0deltas_set_op_range_cu_kernel(struct gkyl_nmat *As, struct gky
     gkyl_mat_clear(&A, 0.0); gkyl_mat_clear(&x, 0.0);
 
     div_set_op(&A, &x, numer, denom);
+  }
+}
+
+// Modeled after gkyl_dg_div_copy_sol_op_range_cu_kernel in dg_bin_ops_cu.cu.
+__global__ void
+gkyl_prim_cross_m0deltas_copy_sol_range_cu_kernel(struct gkyl_nmat *xs,
+  struct gkyl_basis basis,
+  struct gkyl_array* out, struct gkyl_range range)
+{
+  int idx[GKYL_MAX_DIM];
+
+  for (unsigned long linc1 = threadIdx.x + blockIdx.x*blockDim.x;
+      linc1 < range.volume;
+      linc1 += gridDim.x*blockDim.x)
+  {
+    // inverse index from linc1 to idx
+    // must use gkyl_sub_range_inv_idx so that linc1=0 maps to idx={1,1,...}
+    // since update_range is a subrange
+    gkyl_sub_range_inv_idx(&range, linc1, idx);
+
+    // convert back to a linear index on the super-range (with ghost cells)
+    // linc will have jumps in it to jump over ghost cells
+    long start = gkyl_range_idx(&range, idx);
+
+    double *out_d = (double*) gkyl_array_fetch(out, start);
+
+    struct gkyl_mat x = gkyl_nmat_get(xs, linc1);
+
+    binop_div_copy_sol(&x, out_d);
   }
 }
 
@@ -89,6 +120,6 @@ gkyl_prim_cross_m0deltas_advance_cu(gkyl_prim_cross_m0deltas *up, struct gkyl_ba
   assert(status);
 
   // copy solution into array (also lives on the device)
-  gkyl_dg_div_copy_sol_op_range_cu_kernel<<<nblocks, nthreads>>>(x_d->on_dev,
-    basis, 0, out->on_dev, *range);
+  gkyl_prim_cross_m0deltas_copy_sol_range_cu_kernel<<<nblocks, nthreads>>>(x_d->on_dev,
+    basis, out->on_dev, *range);
 }

--- a/zero/proj_maxwellian_on_basis.c
+++ b/zero/proj_maxwellian_on_basis.c
@@ -538,7 +538,7 @@ gkyl_proj_gkmaxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up
   int pidx[GKYL_MAX_DIM], rem_dir[GKYL_MAX_DIM] = { 0 };
   for (int d=0; d<conf_rng->ndim; ++d) rem_dir[d] = 1;
 
-  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM];
+  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM] = {0.};
   double expamp_o[tot_conf_quad], upar_o[tot_conf_quad], vtsq_o[tot_conf_quad];
   double bmag_o[tot_conf_quad];
   

--- a/zero/proj_maxwellian_on_basis.c
+++ b/zero/proj_maxwellian_on_basis.c
@@ -499,7 +499,7 @@ gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *up,
         efact += (vdim_phys-1)*xmu[cdim+1]*bfield[cqidx]/mass;
 
         double *fq = gkyl_array_fetch(up->fun_at_ords, pqidx);
-        fq[0] = (fJacB_floor+exp_amp[cqidx])*exp(-efact/(2.0*vtsq[cqidx]));
+        fq[0] = fJacB_floor+exp_amp[cqidx]*exp(-efact/(2.0*vtsq[cqidx]));
       }
 
       // compute expansion coefficients of Maxwellian on basis
@@ -605,7 +605,7 @@ gkyl_proj_gkmaxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up
         efact += (vdim_phys-1)*xmu[cdim+1]*bmag_o[cqidx]/mass;
 
         double *fq = gkyl_array_fetch(up->fun_at_ords, pqidx);
-        fq[0] = (fJacB_floor+expamp_o[cqidx])*exp(-efact/(2.0*vtsq_o[cqidx]));
+        fq[0] = fJacB_floor+expamp_o[cqidx]*exp(-efact/(2.0*vtsq_o[cqidx]));
       }
 
       // compute expansion coefficients of Maxwellian on basis

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -292,7 +292,7 @@ gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu_ker(const struct gkyl_rect_grid grid,
       // mu term (only for 2v, vdim_phys=3).
       efact += (vdim_phys-1)*xmu[cdim+1]*bfield[cqidx]/mass;
 
-      double fmax_o = (fJacB_floor+exp_amp[cqidx])*exp(-efact/(2.0*vtsq[cqidx]));
+      double fmax_o = fJacB_floor+exp_amp[cqidx]*exp(-efact/(2.0*vtsq[cqidx]));
 
       double tmp = phase_w[n]*fmax_o;
       for (int k=0; k<num_phase_basis; ++k)
@@ -393,7 +393,7 @@ gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu_ker(const struct gkyl_rect_grid grid
       // mu term (only for 2v, vdim_phys=3).
       efact += (vdim_phys-1)*xmu[cdim+1]*bmag_o[cqidx]/mass;
 
-      double fmax_o = (fJacB_floor+expamp_o[cqidx])*exp(-efact/(2.0*vtsq_o[cqidx]));
+      double fmax_o = fJacB_floor+expamp_o[cqidx]*exp(-efact/(2.0*vtsq_o[cqidx]));
 
       double tmp = phase_w[n]*fmax_o;
       for (int k=0; k<num_phase_basis; ++k)

--- a/zero/proj_maxwellian_on_basis_cu.cu
+++ b/zero/proj_maxwellian_on_basis_cu.cu
@@ -194,6 +194,213 @@ gkyl_proj_maxwellian_on_basis_prim_mom_cu_ker(const struct gkyl_rect_grid grid,
   }
 }
 
+__global__ static void
+gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu_ker(const struct gkyl_rect_grid grid,
+  const struct gkyl_range phase_r, const struct gkyl_range conf_r,
+  const struct gkyl_array* GKYL_RESTRICT conf_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_ordinates, 
+  const struct gkyl_array* GKYL_RESTRICT phase_weights, const int *p2c_qidx,
+  const struct gkyl_array* GKYL_RESTRICT m0, const struct gkyl_array* GKYL_RESTRICT m1,
+  const struct gkyl_array* GKYL_RESTRICT m2, const struct gkyl_array* GKYL_RESTRICT bmag,
+  const struct gkyl_array* GKYL_RESTRICT jacob_tot, double mass,
+  struct gkyl_array* GKYL_RESTRICT fmax)
+{
+  double fJacB_floor = 1.e-40;
+  int pdim = phase_r.ndim, cdim = conf_r.ndim;
+  int vdim = pdim-cdim;
+  int vdim_phys = vdim==1 ? 1 : 3;
+
+  int num_conf_basis = conf_basis_at_ords->ncomp;
+  int num_phase_basis = fmax->ncomp;
+  int tot_conf_quad = conf_basis_at_ords->size;
+  int tot_phase_quad = phase_basis_at_ords->size;
+
+  // double exp_amp[tot_conf_quad], vel[tot_conf_quad][vdim], vtsq[tot_conf_quad];
+  // MF 2022/08/09: hard-coded to 3x, vdim=3, p=2 for now.
+  double exp_amp[27], upar[27], vtsq[27], bfield[27];
+
+  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM] = {0.};
+  int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < phase_r.volume; tid += blockDim.x*gridDim.x) {
+    gkyl_sub_range_inv_idx(&phase_r, tid, pidx);
+
+    // get conf-space linear index.
+    for (unsigned int k = 0; k < conf_r.ndim; k++) cidx[k] = pidx[k];
+    long lincC = gkyl_range_idx(&conf_r, cidx);
+
+    const double *m0_d = (const double *) gkyl_array_cfetch(m0, lincC);
+    const double *m1_d = (const double *) gkyl_array_cfetch(m1, lincC);
+    const double *m2_d = (const double *) gkyl_array_cfetch(m2, lincC);
+    const double *bmag_d = (const double *) gkyl_array_cfetch(bmag, lincC);
+    const double *jactot_d = (const double *) gkyl_array_cfetch(jacob_tot, lincC);
+
+    // compute primitive moments at quadrature nodes
+    for (int n=0; n<tot_conf_quad; ++n) {
+      const double *b_ord = (const double *) gkyl_array_cfetch(conf_basis_at_ords, n);
+    
+      double den = 0.;   // number density
+      double m1_n = 0.;  // momentum density.
+      double m2_n = 0.;  // kinetic energy density.
+      double jac_n = 0.; // total jacobian (conf * guiding center jacobian).
+      bfield[n] = 0.; // magnetic field amplitude.
+      for (int k=0; k<num_conf_basis; ++k) {
+        den += m0_d[k]*b_ord[k];
+        m1_n += m1_d[k]*b_ord[k];
+        m2_n += m2_d[k]*b_ord[k];
+        jac_n += jactot_d[k]*b_ord[k];
+        bfield[n] += bmag_d[k]*b_ord[k];
+      }
+      // parallel drift speed.
+      upar[n] = m1_n/den;
+      // thermal speed squared.
+      vtsq[n] = (m2_n - den*upar[n]*upar[n])/(den*vdim_phys);
+
+      // Amplitude of the exponential.
+      if ((den > 0.) && (vtsq[n]>0.))
+        exp_amp[n] = jac_n*den/sqrt(pow(2.0*GKYL_PI*vtsq[n], vdim_phys));
+      else
+        exp_amp[n] = 0.;
+    }
+
+    gkyl_rect_grid_cell_center(&grid, pidx, xc);
+
+    long lidx = gkyl_range_idx(&phase_r, pidx);
+    double *fm = (double *) gkyl_array_fetch(fmax, lidx);
+
+    for (int k=0; k<num_phase_basis; ++k) fm[k] = 0.0;
+
+    // compute expansion coefficients of Maxwellian on basis
+    // The following is modeled after proj_on_basis in the private header.
+    const double *phase_w = (const double *) phase_weights->data;
+    const double *phaseb_o = (const double *) phase_basis_at_ords->data;
+  
+    // compute Maxwellian at phase-space quadrature nodes
+    for (int n=0; n<tot_phase_quad; ++n) {
+
+      int cqidx = p2c_qidx[n];
+
+      comp_to_phys(pdim, (const double *) gkyl_array_cfetch(phase_ordinates, n),
+        grid.dx, xc, &xmu[0]);
+
+      double efact = 0.0;
+      // vpar term.
+      efact += pow(xmu[cdim]-upar[cqidx],2);
+      // mu term (only for 2v, vdim_phys=3).
+      efact += (vdim_phys-1)*xmu[cdim+1]*bfield[cqidx]/mass;
+
+      double fmax_o = (fJacB_floor+exp_amp[cqidx])*exp(-efact/(2.0*vtsq[cqidx]));
+
+      double tmp = phase_w[n]*fmax_o;
+      for (int k=0; k<num_phase_basis; ++k)
+        fm[k] += tmp*phaseb_o[k+num_phase_basis*n];
+    }
+  }
+}
+
+__global__ static void
+gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu_ker(const struct gkyl_rect_grid grid,
+  const struct gkyl_range phase_r, const struct gkyl_range conf_r,
+  const struct gkyl_array* GKYL_RESTRICT conf_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_basis_at_ords, 
+  const struct gkyl_array* GKYL_RESTRICT phase_ordinates, 
+  const struct gkyl_array* GKYL_RESTRICT phase_weights, const int *p2c_qidx,
+  const struct gkyl_array* GKYL_RESTRICT m0, const struct gkyl_array* GKYL_RESTRICT upar,
+  const struct gkyl_array* GKYL_RESTRICT vtsq, const struct gkyl_array* GKYL_RESTRICT bmag,
+  const struct gkyl_array* GKYL_RESTRICT jacob_tot, double mass,
+  struct gkyl_array* GKYL_RESTRICT fmax)
+{
+  double fJacB_floor = 1.e-40;
+  int pdim = phase_r.ndim, cdim = conf_r.ndim;
+  int vdim = pdim-cdim;
+  int vdim_phys = vdim==1 ? 1 : 3;
+
+  int num_conf_basis = conf_basis_at_ords->ncomp;
+  int num_phase_basis = fmax->ncomp;
+  int tot_conf_quad = conf_basis_at_ords->size;
+  int tot_phase_quad = phase_basis_at_ords->size;
+
+  // double expamp_o[tot_conf_quad], upar_o[tot_conf_quad][vdim], vtsq_o[tot_conf_quad];
+  // MF 2022/08/09: hard-coded to 3x, vdim=3, p=2 for now.
+  double expamp_o[27], upar_o[27], vtsq_o[27], bmag_o[27];
+
+  double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM] = {0.};
+  int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
+
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < phase_r.volume; tid += blockDim.x*gridDim.x) {
+    gkyl_sub_range_inv_idx(&phase_r, tid, pidx);
+
+    // get conf-space linear index.
+    for (unsigned int k = 0; k < conf_r.ndim; k++) cidx[k] = pidx[k];
+    long lincC = gkyl_range_idx(&conf_r, cidx);
+
+    const double *m0_d = (const double *) gkyl_array_cfetch(m0, lincC);
+    const double *upar_d = (const double *) gkyl_array_cfetch(upar, lincC);
+    const double *vtsq_d = (const double *) gkyl_array_cfetch(vtsq, lincC);
+    const double *bmag_d = (const double *) gkyl_array_cfetch(bmag, lincC);
+    const double *jactot_d = (const double *) gkyl_array_cfetch(jacob_tot, lincC);
+
+    // compute primitive moments at quadrature nodes
+    for (int n=0; n<tot_conf_quad; ++n) {
+      const double *b_ord = (const double *) gkyl_array_cfetch(conf_basis_at_ords, n);
+
+      double m0_o = 0.0;  // number density
+      double jac_o = 0.0;  // total jacobian (conf * guiding center jacobian).
+      upar_o[n] = 0.0;
+      vtsq_o[n] = 0.0;
+      bmag_o[n] = 0.0;
+      for (int k=0; k<num_conf_basis; ++k) {
+        m0_o += m0_d[k]*b_ord[k];
+        jac_o += jactot_d[k]*b_ord[k];
+        bmag_o[n] += bmag_d[k]*b_ord[k];
+        upar_o[n] += upar_d[k]*b_ord[k];
+        vtsq_o[n] += vtsq_d[k]*b_ord[k];
+      }
+      // Amplitude of the exponential.
+      if ((m0_o > 0.) && (vtsq_o[n]>0.))
+        expamp_o[n] = jac_o*m0_o/sqrt(pow(2.0*GKYL_PI*vtsq_o[n], vdim_phys));
+      else
+        expamp_o[n] = 0.;
+    }
+
+    gkyl_rect_grid_cell_center(&grid, pidx, xc);
+
+    long lidx = gkyl_range_idx(&phase_r, pidx);
+    double *fm = (double *) gkyl_array_fetch(fmax, lidx);
+
+    for (int k=0; k<num_phase_basis; ++k) fm[k] = 0.0;
+
+    // compute expansion coefficients of Maxwellian on basis
+    // The following is modeled after proj_on_basis in the private header.
+    const double *phase_w = (const double *) phase_weights->data;
+    const double *phaseb_o = (const double *) phase_basis_at_ords->data;
+  
+    // compute Maxwellian at phase-space quadrature nodes
+    for (int n=0; n<tot_phase_quad; ++n) {
+
+      int cqidx = p2c_qidx[n];
+
+      comp_to_phys(pdim, (const double *) gkyl_array_cfetch(phase_ordinates, n),
+        grid.dx, xc, &xmu[0]);
+
+      double efact = 0.0;
+      // vpar term.
+      efact += pow(xmu[cdim]-upar_o[cqidx],2);
+      // mu term (only for 2v, vdim_phys=3).
+      efact += (vdim_phys-1)*xmu[cdim+1]*bmag_o[cqidx]/mass;
+
+      double fmax_o = (fJacB_floor+expamp_o[cqidx])*exp(-efact/(2.0*vtsq_o[cqidx]));
+
+      double tmp = phase_w[n]*fmax_o;
+      for (int k=0; k<num_phase_basis; ++k)
+        fm[k] += tmp*phaseb_o[k+num_phase_basis*n];
+    }
+  }
+}
+
 void
 gkyl_proj_maxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *up,
   const struct gkyl_range *phase_r, const struct gkyl_range *conf_r,
@@ -228,10 +435,10 @@ gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu(const gkyl_proj_maxwellian_on_basis *
   struct gkyl_array *fmax)
 {
   int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
-//  gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu_ker<<<nblocks, nthreads>>>
-//    (up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
-//     up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
-//     m0->on_dev, m1->on_dev, m2->on_dev, bmag->on_dev, jacob_tot->on_dev, mass, fmax->on_dev);
+  gkyl_proj_gkmaxwellian_on_basis_lab_mom_cu_ker<<<nblocks, nthreads>>>
+    (up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
+     up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
+     m0->on_dev, m1->on_dev, m2->on_dev, bmag->on_dev, jacob_tot->on_dev, mass, fmax->on_dev);
 }
 
 void
@@ -242,8 +449,8 @@ gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu(const gkyl_proj_maxwellian_on_basis 
   struct gkyl_array *fmax)
 {
   int nblocks = phase_r->nblocks, nthreads = phase_r->nthreads;
-//  gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu_ker<<<nblocks, nthreads>>>
-//    (up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
-//     up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
-//     m0->on_dev, upar->on_dev, vtsq->on_dev, bmag->on_dev, jacob_tot->on_dev, mass, fmax->on_dev);
+  gkyl_proj_gkmaxwellian_on_basis_prim_mom_cu_ker<<<nblocks, nthreads>>>
+    (up->grid, *phase_r, *conf_r, up->conf_basis_at_ords->on_dev, up->basis_at_ords->on_dev,
+     up->ordinates->on_dev, up->weights->on_dev, up->p2c_qidx,
+     m0->on_dev, upar->on_dev, vtsq->on_dev, bmag->on_dev, jacob_tot->on_dev, mass, fmax->on_dev);
 }


### PR DESCRIPTION
Primarily implement three things:
1. Projection of a GK Maxwellian onto the basis using quadrature, lab_mom and prim_mom versions. This is used during initialization, BGK collisions and neutral interactions.
2. BGK operator.
3. An updater which computes the prefactor M_0s*delta_s appearing in cross primitive moments (previously we did it with a series of binOps).

All are implemented for GPUs too, and all are wrapped and tested via g2.