### PR TITLE
Cross BGK prim moms (+ some edits for LBO too)

### DIFF
--- a/zero/gkyl_prim_bgk_cross_calc.h
+++ b/zero/gkyl_prim_bgk_cross_calc.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+
+/**
+ * Calculate the cross primitive moments, u_{sr,i} and v_{tsr}^2,
+ * for cross-species collisions with the BGK operator.
+ *
+ *   u_sr = u_si-0.5*delta_s*(beta+1)*(u_si - u_ri)
+ *
+ *   v_tsr^2 = v_ts^2-(u_sri-u_ri).(u_sri-u_si)/vdim_phys
+ *     -(delta_s*(beta+1)/(m_s+m_r))*
+ *      (m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+ *
+ * @param basis Basis object (configuration space).
+ * @param vdim_phys Physical number of velocity dimensions represented.
+ * @param m0sdeltas Prefactor m_0s*delta_s*(beta+1) (and m_0s should be 1 here).
+ * @param massself Mass of this species.
+ * @param primsself Primitive moments of this species, u_s and v_ts^2.
+ * @param massother Mass of the other species.
+ * @param primsother Primitive moments of the other species, u_r and v_tr^2.
+ * @param range Range in which we'll compute m0_s*delta_s.
+ * @return crossprims Cross primitive moments, u_sri and v_tsr^2.
+ */
+void gkyl_prim_bgk_cross_calc_advance(struct gkyl_basis basis,
+  int vdim_phys, const struct gkyl_array* m0sdeltas,
+  double massself, const struct gkyl_array* primsself,
+  double massother, const struct gkyl_array* primsother,
+  const struct gkyl_range *range, struct gkyl_array* crossprims);
+
+void gkyl_prim_bgk_cross_calc_advance_cu(struct gkyl_basis basis,
+  int vdim_phys, const struct gkyl_array* m0sdeltas,
+  double massself, const struct gkyl_array* primsself,
+  double massother, const struct gkyl_array* primsother,
+  const struct gkyl_range *range, struct gkyl_array* crossprims);

--- a/zero/gkyl_prim_cross_m0deltas.h
+++ b/zero/gkyl_prim_cross_m0deltas.h
@@ -8,10 +8,10 @@
 typedef struct gkyl_prim_cross_m0deltas gkyl_prim_cross_m0deltas;
 
 /**
- * Create a new updater that computes the m0_s*delta_s prefactor
+ * Create a new updater that computes the m0_s*delta_s*(beta+1) prefactor
  * in the calculation of cross-primitive moments for LBO and BGK
  * collisions. That is:
- *   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
+ *   m0_s*delta_s*(beta+1) = m0_s*2*m_r*m0_r*nu_rs*(beta+1)/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
  *
  * @param basis Basis object (configuration space).
  * @param range Range in which we'll compute m0_s*delta_s.
@@ -34,14 +34,15 @@ gkyl_prim_cross_m0deltas* gkyl_prim_cross_m0deltas_new(
  * @param massother Mass of the other species, m_r.
  * @param m0other Number density of the other species, m0_r.
  * @param nuother Cross collision frequency of the other species, nu_rs.
+ * @param prem0s Prefactor, M_0s for LBO, 1 for BGK.
  * @param range Range in which we'll compute m0_s*delta_s.
  * @param out Output array.
  * @return New updater pointer.
  */
 void gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
-  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
-  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
-  const struct gkyl_range *range, struct gkyl_array* out);
+  double massself, const struct gkyl_array* m0self, const struct gkyl_array* nuself,
+  double massother, const struct gkyl_array* m0other, const struct gkyl_array* nuother,
+  const struct gkyl_array* prem0s, const struct gkyl_range *range, struct gkyl_array* out);
 
 /**
  * Delete updater.

--- a/zero/gkyl_prim_cross_m0deltas_priv.h
+++ b/zero/gkyl_prim_cross_m0deltas_priv.h
@@ -9,6 +9,6 @@ struct gkyl_prim_cross_m0deltas {
 
 void
 gkyl_prim_cross_m0deltas_advance_cu(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
-  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
-  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
-  const struct gkyl_range *range, struct gkyl_array* out);
+  double massself, const struct gkyl_array* m0self, const struct gkyl_array* nuself,
+  double massother, const struct gkyl_array* m0other, const struct gkyl_array* nuother,
+  const struct gkyl_array* prem0s, const struct gkyl_range *range, struct gkyl_array* out);

--- a/zero/prim_bgk_cross_calc.c
+++ b/zero/prim_bgk_cross_calc.c
@@ -1,0 +1,92 @@
+#include <gkyl_dg_bin_ops.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_array_ops_priv.h>
+#include <gkyl_alloc.h>
+#include <gkyl_prim_bgk_cross_calc.h>
+
+void
+gkyl_prim_bgk_cross_calc_advance(struct gkyl_basis basis,
+  int vdim_phys, const struct gkyl_array* m0sdeltas,
+  double massself, const struct gkyl_array* primsself,
+  double massother, const struct gkyl_array* primsother,
+  const struct gkyl_range *range, struct gkyl_array* crossprims)
+{
+  unsigned num_basis = basis.num_basis;
+  assert(num_basis <= 20); // MF 2022/11/20: Hardcoded to a max of 3x p2 ser.
+  unsigned ndim = basis.ndim;
+  unsigned poly_order = basis.poly_order;
+  mul_op_t mul_op = choose_ser_mul_kern(ndim, poly_order);
+
+  unsigned udim = primsself->ncomp/num_basis-1;
+  unsigned u_num_basis = udim*num_basis;
+  double massDiff = 0.5*(massself-massother)/vdim_phys;
+  double massSum = massself+massother;
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  while (gkyl_range_iter_next(&iter)) {
+    long loc = gkyl_range_idx(range, iter.idx);
+
+    const double *m0sdeltas_d = gkyl_array_cfetch(m0sdeltas, loc);
+    const double *primsself_d = gkyl_array_cfetch(primsself, loc);
+    const double *primsother_d = gkyl_array_cfetch(primsother, loc);
+
+    double *crossprims_d = gkyl_array_fetch(crossprims, loc);
+
+    // Pointers to each primitive moment (for simplicity).
+    const double *uself = primsself_d;
+    const double *vtsqself = &primsself_d[u_num_basis];
+    const double *uother = primsother_d;
+    const double *vtsqother = &primsother_d[u_num_basis];
+    double *ucross = crossprims_d;
+    double *vtsqcross = &crossprims_d[u_num_basis];
+
+    // u_sr = u_si - u_ri:
+    array_set1(u_num_basis, ucross, 1., uself);
+    array_acc1(u_num_basis, ucross,-1., uother);
+
+    // v_tsr^2 = (u_si-u_ri)^2 = (u_si-u_ri) . (u_si-u_ri)
+    double vbuf[20*3]; // MF 2022/11/20: Hardcoded to 3x p2 ser (3 components).
+    for (int k=0; k<num_basis; k++) vtsqcross[k] = 0.;
+    for (int d=0; d<udim; d++) {
+      mul_op(ucross+d*num_basis, ucross+d*num_basis, vbuf);
+      for (int k=0; k<num_basis; k++) vtsqcross[k] += vbuf[k];
+    }
+
+    // v_tsr^2 = m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] = massDiff*vtsqcross[k]+massself*vtsqself[k]-massother*vtsqother[k];;
+
+    // vbuf = -0.5*delta_s*(beta+1)*(u_si - u_ri) = u_sri - u_si:
+    for (int d=0; d<udim; d++) {
+      mul_op(m0sdeltas_d, ucross+d*num_basis, vbuf+d*num_basis);
+      for (int k=d*num_basis; k<(d+1)*num_basis; k++)
+        vbuf[k] *= -0.5;
+    }
+    // v_tsr^2 = -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    mul_op(m0sdeltas_d, vtsqcross, vtsqcross);
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] = -vtsqcross[k]/massSum;
+
+    // u_sr = u_si-0.5*delta_s*(beta+1)*(u_si - u_ri) = u_si + vbuf:
+    for (int k=0; k<u_num_basis; k++)
+      ucross[k] = uself[k]+vbuf[k];
+
+    // v_tsr^2 = -(u_sri-u_ri).(u_sri-u_si)/vdim_phys
+    //   -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    // Need the dot product (u_sri-u_ri).(u_sri-u_si):
+    for (int d=0; d<udim; d++) {
+      double compbuf[20]; // MF 2022/11/20: Hardcoded to 3x p2 ser.
+      for (int k=0; k<num_basis; k++)
+        compbuf[k] = ucross[d*num_basis+k]-uother[d*num_basis+k];
+      mul_op(compbuf, vbuf+d*num_basis, compbuf);
+      for (int k=0; k<num_basis; k++)
+        vtsqcross[k] += -compbuf[k]/vdim_phys;
+    }
+
+    // v_tsr^2 = v_ts^2-(u_sri-u_ri).(u_sri-u_si)/vdim_phys
+    //   -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] += vtsqself[k];
+  }
+}

--- a/zero/prim_bgk_cross_calc_cu.cu
+++ b/zero/prim_bgk_cross_calc_cu.cu
@@ -1,0 +1,120 @@
+/* -*- c++ -*- */
+
+extern "C" {
+#include <gkyl_dg_bin_ops.h>
+#include <gkyl_dg_bin_ops_priv.h>
+#include <gkyl_array_ops_priv.h>
+#include <gkyl_alloc.h>
+#include <gkyl_prim_bgk_cross_calc.h>
+}
+
+__global__ void
+gkyl_prim_bgk_cross_calc_advance_cu_kernel(struct gkyl_basis basis,
+  int vdim_phys, const struct gkyl_array* m0sdeltas,
+  double massself, const struct gkyl_array* primsself,
+  double massother, const struct gkyl_array* primsother,
+  struct gkyl_range range, struct gkyl_array* crossprims)
+{
+  unsigned num_basis = basis.num_basis;
+  unsigned ndim = basis.ndim;
+  unsigned poly_order = basis.poly_order;
+  mul_op_t mul_op = choose_ser_mul_kern(ndim, poly_order);
+
+  unsigned udim = primsself->ncomp/num_basis-1;
+  unsigned u_num_basis = udim*num_basis;
+  double massDiff = 0.5*(massself-massother)/vdim_phys;
+  double massSum = massself+massother;
+
+  int idx[GKYL_MAX_DIM];
+
+  for (unsigned long linc1 = threadIdx.x + blockIdx.x*blockDim.x;
+      linc1 < range.volume;
+      linc1 += gridDim.x*blockDim.x)
+  {
+    // inverse index from linc1 to idx
+    // must use gkyl_sub_range_inv_idx so that linc1=0 maps to idx={1,1,...}
+    // since update_range is a subrange
+    gkyl_sub_range_inv_idx(&range, linc1, idx);
+
+    // convert back to a linear index on the super-range (with ghost cells)
+    // linc will have jumps in it to jump over ghost cells
+    long start = gkyl_range_idx(&range, idx);
+
+    const double *m0sdeltas_d =  (const double *) gkyl_array_cfetch(m0sdeltas, start);
+    const double *primsself_d =  (const double *) gkyl_array_cfetch(primsself, start);
+    const double *primsother_d = (const double *) gkyl_array_cfetch(primsother, start);
+
+    double *crossprims_d = (double *) gkyl_array_fetch(crossprims, start);
+
+    // Pointers to each primitive moment (for simplicity).
+    const double *uself = primsself_d;
+    const double *vtsqself = &primsself_d[u_num_basis];
+    const double *uother = primsother_d;
+    const double *vtsqother = &primsother_d[u_num_basis];
+    double *ucross = crossprims_d;
+    double *vtsqcross = &crossprims_d[u_num_basis];
+
+    // u_sr = u_si - u_ri:
+    array_set1(u_num_basis, ucross, 1., uself);
+    array_acc1(u_num_basis, ucross,-1., uother);
+
+    // v_tsr^2 = (u_si-u_ri)^2 = (u_si-u_ri) . (u_si-u_ri)
+    double vbuf[20*3]; // MF 2022/11/20: Hardcoded to 3x p2 ser (3 components).
+    for (int k=0; k<num_basis; k++) vtsqcross[k] = 0.;
+    for (int d=0; d<udim; d++) {
+      mul_op(ucross+d*num_basis, ucross+d*num_basis, vbuf);
+      for (int k=0; k<num_basis; k++) vtsqcross[k] += vbuf[k];
+    }
+
+    // v_tsr^2 = m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] = massDiff*vtsqcross[k]+massself*vtsqself[k]-massother*vtsqother[k];;
+
+    // vbuf = -0.5*delta_s*(beta+1)*(u_si - u_ri) = u_sri - u_si:
+    for (int d=0; d<udim; d++) {
+      mul_op(m0sdeltas_d, ucross+d*num_basis, vbuf+d*num_basis);
+      for (int k=d*num_basis; k<(d+1)*num_basis; k++)
+        vbuf[k] *= -0.5;
+    }
+    // v_tsr^2 = -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    mul_op(m0sdeltas_d, vtsqcross, vtsqcross);
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] = -vtsqcross[k]/massSum;
+
+    // u_sr = u_si-0.5*delta_s*(beta+1)*(u_si - u_ri) = u_si + vbuf:
+    for (int k=0; k<u_num_basis; k++)
+      ucross[k] = uself[k]+vbuf[k];
+
+    // v_tsr^2 = -(u_sri-u_ri).(u_sri-u_si)/vdim_phys
+    //   -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    // Need the dot product (u_sri-u_ri).(u_sri-u_si):
+    for (int d=0; d<udim; d++) {
+      double compbuf[20]; // MF 2022/11/20: Hardcoded to 3x p2 ser.
+      for (int k=0; k<num_basis; k++)
+        compbuf[k] = ucross[d*num_basis+k]-uother[d*num_basis+k];
+      mul_op(compbuf, vbuf+d*num_basis, compbuf);
+      for (int k=0; k<num_basis; k++)
+        vtsqcross[k] += -compbuf[k]/vdim_phys;
+    }
+
+    // v_tsr^2 = v_ts^2-(u_sri-u_ri).(u_sri-u_si)/vdim_phys
+    //   -(delta_s*(beta+1)/(m_s+m_r))*(m_s*v_ts^2-m_r*v_tr^2+((m_s-m_r)/(2*vdim_phys))*(u_si-u_ri)^2)
+    for (int k=0; k<num_basis; k++)
+      vtsqcross[k] += vtsqself[k];
+  }
+}
+
+void
+gkyl_prim_bgk_cross_calc_advance_cu(struct gkyl_basis basis,
+  int vdim_phys, const struct gkyl_array* m0sdeltas,
+  double massself, const struct gkyl_array* primsself,
+  double massother, const struct gkyl_array* primsother,
+  const struct gkyl_range *range, struct gkyl_array* crossprims)
+{
+  int nblocks = range->nblocks;
+  int nthreads = range->nthreads;
+
+  gkyl_prim_bgk_cross_calc_advance_cu_kernel<<<nblocks, nthreads>>>(basis,
+    vdim_phys, m0sdeltas->on_dev, massself, primsself->on_dev, 
+    massother, primsother->on_dev, *range, crossprims->on_dev);
+}

--- a/zero/prim_cross_m0deltas.c
+++ b/zero/prim_cross_m0deltas.c
@@ -26,9 +26,9 @@ gkyl_prim_cross_m0deltas_new(const struct gkyl_basis *basis, const struct gkyl_r
 
 void
 gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis basis,
-  double massself, struct gkyl_array* m0self, struct gkyl_array* nuself,
-  double massother, struct gkyl_array* m0other, struct gkyl_array* nuother,
-  const struct gkyl_range *range, struct gkyl_array* out)
+  double massself, const struct gkyl_array* m0self, const struct gkyl_array* nuself,
+  double massother, const struct gkyl_array* m0other, const struct gkyl_array* nuother,
+  const struct gkyl_array* prem0s, const struct gkyl_range *range, struct gkyl_array* out)
 {
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu)
@@ -58,6 +58,7 @@ gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis
     const double *nuself_d = gkyl_array_cfetch(nuself, loc);
     const double *m0other_d = gkyl_array_cfetch(m0other, loc);
     const double *nuother_d = gkyl_array_cfetch(nuother, loc);
+    const double *prem0s_d = gkyl_array_cfetch(prem0s, loc);
 
     // compute the numerator and denominator in:
     //   m0_s*delta_s = m0_s*2*m_r*m0_r*nu_rs/(m_s*m0_s*nu_sr+m_r*m0_r*nu_rs)
@@ -72,7 +73,7 @@ gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis
 
     array_acc1(num_basis, denom, 0.5/up->betap1, numer);
 
-    mul_op(m0self_d, numer, numer);
+    mul_op(prem0s_d, numer, numer);
 
     struct gkyl_mat A = gkyl_nmat_get(As, count);
     struct gkyl_mat x = gkyl_nmat_get(xs, count);

--- a/zero/prim_cross_m0deltas.c
+++ b/zero/prim_cross_m0deltas.c
@@ -33,7 +33,8 @@ gkyl_prim_cross_m0deltas_advance(gkyl_prim_cross_m0deltas *up, struct gkyl_basis
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu)
     return gkyl_prim_cross_m0deltas_advance_cu(up, basis, massself, m0self, nuself,
-                                               massother, m0other, nuother, range, out);
+      massother, m0other, nuother, prem0s, range, out);
+
 #endif
 
   int num_basis = basis.num_basis;

--- a/zero/proj_maxwellian_on_basis.c
+++ b/zero/proj_maxwellian_on_basis.c
@@ -494,7 +494,7 @@ gkyl_proj_gkmaxwellian_on_basis_lab_mom(const gkyl_proj_maxwellian_on_basis *up,
 
         double efact = 0.0;        
         // vpar term.
-        efact += (xmu[cdim]-upar[cqidx])*(xmu[cdim]-upar[cqidx]);
+        efact += pow(xmu[cdim]-upar[cqidx],2);
         // mu term (only for 2v, vdim_phys=3).
         efact += (vdim_phys-1)*xmu[cdim+1]*bfield[cqidx]/mass;
 
@@ -600,7 +600,7 @@ gkyl_proj_gkmaxwellian_on_basis_prim_mom(const gkyl_proj_maxwellian_on_basis *up
 
         double efact = 0.0;        
         // vpar term.
-        efact += (xmu[cdim]-upar_o[cqidx])*(xmu[cdim]-upar_o[cqidx]);
+        efact += pow(xmu[cdim]-upar_o[cqidx],2);
         // mu term (only for 2v, vdim_phys=3).
         efact += (vdim_phys-1)*xmu[cdim+1]*bmag_o[cqidx]/mass;
 


### PR DESCRIPTION
(continuation of pull request #123 )

Change the signature of the updater that computes the m0_s*delta_s prefactor for LBO cross-species collisions so it works with BGK as well (i.e. only compute delta_s for BGK).

Implement a function to compute BGK cross-primitive moments, CPU and GPU.

Tested via g2. Cross BGK reg tests pass on CPU (compared to results created with g2's old CrossPrimMom for BGK). Also,  cross BGK now runs on GPU and produces identical (to machine precision) results to those on CPU.