### PR TITLE
Gyrokinetic updater and additions to Spitzer collisionality updater

### DIFF
--- a/unit/ctest_mom_gyrokinetic.c
+++ b/unit/ctest_mom_gyrokinetic.c
@@ -64,10 +64,15 @@ mkarr(long nc, long size)
 }
 // allocate cu_dev array
 static struct gkyl_array*
-mkarr_cu(long nc, long size)
+mkarr_cu(long nc, long size, bool use_gpu)
 {
-  struct gkyl_array* a = gkyl_array_cu_dev_new(GKYL_DOUBLE, nc, size);
-  return a;
+  if (use_gpu) {
+    struct gkyl_array* a = gkyl_array_cu_dev_new(GKYL_DOUBLE, nc, size);
+    return a;
+  } else {
+    struct gkyl_array* a = gkyl_array_new(GKYL_DOUBLE, nc, size);
+    return a;
+  }
 }
 
 struct skin_ghost_ranges {
@@ -127,7 +132,7 @@ void distf_2x2v(double t, const double *xn, double* restrict fout, void *ctx)
 }
 
 void
-test_1x1v(int polyOrder)
+test_1x1v(int polyOrder, bool use_gpu)
 {
   double mass = 1.;
   int poly_order = 1;
@@ -168,48 +173,78 @@ test_1x1v(int polyOrder)
   skin_ghost_ranges_init(&skin_ghost, &local_ext, ghost);
 
   // create distribution function array and project distribution function on basis
-  struct gkyl_array *distf;
-  distf = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *distf_ho, *distf;
+  distf_ho = mkarr(basis.num_basis, local_ext.volume);
+  distf = mkarr_cu(basis.num_basis, local_ext.volume, use_gpu);
   gkyl_proj_on_basis *projDistf = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, distf_1x1v, NULL);
-  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf);
-//  gkyl_grid_sub_array_write(&grid, &local, distf, "ctest_mom_gyrokinetic_1x1v_p1_distf.gkyl");
+  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf_ho);
+  gkyl_array_copy(distf, distf_ho);
+//  gkyl_grid_sub_array_write(&grid, &local, distf_ho, "ctest_mom_gyrokinetic_1x1v_p1_distf.gkyl");
 
   // create bmag array and project magnetic field amplitude function on basis
-  struct gkyl_array *bmag;
-  bmag = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *bmag_ho, *bmag;
+  bmag_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  bmag = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
   gkyl_proj_on_basis *projbmag = gkyl_proj_on_basis_new(&confGrid, &confBasis,
     poly_order+1, 1, bmag_1x, NULL);
-  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag);
-//  gkyl_grid_sub_array_write(&confGrid, &confLocal, bmag, "ctest_mom_gyrokinetic_1x1v_p1_bmag.gkyl");
+  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag_ho);
+  gkyl_array_copy(bmag, bmag_ho);
+//  gkyl_grid_sub_array_write(&confGrid, &confLocal, bmag_ho, "ctest_mom_gyrokinetic_1x1v_p1_bmag.gkyl");
 
-  struct gkyl_mom_type *M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
-  struct gkyl_mom_type *M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
-  struct gkyl_mom_type *M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  struct gkyl_mom_type *M0_t, *M1_t, *M2_t;
+  if (use_gpu) {
+    M0_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M2");
+  } else {
+    M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  }
   gkyl_gyrokinetic_set_bmag(M0_t, bmag);
   gkyl_gyrokinetic_set_bmag(M1_t, bmag);
   gkyl_gyrokinetic_set_bmag(M2_t, bmag);
-  gkyl_mom_calc *m0calc = gkyl_mom_calc_new(&grid, M0_t);
-  gkyl_mom_calc *m1calc = gkyl_mom_calc_new(&grid, M1_t);
-  gkyl_mom_calc *m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  gkyl_mom_calc *m0calc, *m1calc, *m2calc;
+  if (use_gpu) {
+    m0calc = gkyl_mom_calc_cu_dev_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_cu_dev_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_cu_dev_new(&grid, M2_t);
+  } else {
+    m0calc = gkyl_mom_calc_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  }
 
   // create moment arrays
-  struct gkyl_array *m0, *m1, *m2;
-  m0 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m1 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m2 = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *m0_ho, *m1_ho, *m2_ho, *m0, *m1, *m2;
+  m0_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m1_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m2_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m0 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m1 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m2 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
 
   // compute the moments
-  gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
-  gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
-  gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  if (use_gpu) {
+    gkyl_mom_calc_advance_cu(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance_cu(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance_cu(m2calc, &local, &confLocal, distf, m2);
+  } else {
+    gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  }
+  gkyl_array_copy(m0_ho, m0);
+  gkyl_array_copy(m1_ho, m1);
+  gkyl_array_copy(m2_ho, m2);
 
-  double *m00 = gkyl_array_fetch(m0, 0+confGhost[0]); double *m01 = gkyl_array_fetch(m0, 1+confGhost[0]);
-  double *m02 = gkyl_array_fetch(m0, 2+confGhost[0]); double *m03 = gkyl_array_fetch(m0, 3+confGhost[0]);
-  double *m10 = gkyl_array_fetch(m1, 0+confGhost[0]); double *m11 = gkyl_array_fetch(m1, 1+confGhost[0]);
-  double *m12 = gkyl_array_fetch(m1, 2+confGhost[0]); double *m13 = gkyl_array_fetch(m1, 3+confGhost[0]);
-  double *m20 = gkyl_array_fetch(m2, 0+confGhost[0]); double *m21 = gkyl_array_fetch(m2, 1+confGhost[0]);
-  double *m22 = gkyl_array_fetch(m2, 2+confGhost[0]); double *m23 = gkyl_array_fetch(m2, 3+confGhost[0]);
+  double *m00 = gkyl_array_fetch(m0_ho, 0+confGhost[0]); double *m01 = gkyl_array_fetch(m0_ho, 1+confGhost[0]);
+  double *m02 = gkyl_array_fetch(m0_ho, 2+confGhost[0]); double *m03 = gkyl_array_fetch(m0_ho, 3+confGhost[0]);
+  double *m10 = gkyl_array_fetch(m1_ho, 0+confGhost[0]); double *m11 = gkyl_array_fetch(m1_ho, 1+confGhost[0]);
+  double *m12 = gkyl_array_fetch(m1_ho, 2+confGhost[0]); double *m13 = gkyl_array_fetch(m1_ho, 3+confGhost[0]);
+  double *m20 = gkyl_array_fetch(m2_ho, 0+confGhost[0]); double *m21 = gkyl_array_fetch(m2_ho, 1+confGhost[0]);
+  double *m22 = gkyl_array_fetch(m2_ho, 2+confGhost[0]); double *m23 = gkyl_array_fetch(m2_ho, 3+confGhost[0]);
 
   if (poly_order==1) {
     // Check M0.
@@ -305,15 +340,17 @@ test_1x1v(int polyOrder)
 
   // release memory for moment data object
   gkyl_array_release(m0); gkyl_array_release(m1); gkyl_array_release(m2);
+  gkyl_array_release(m0_ho); gkyl_array_release(m1_ho); gkyl_array_release(m2_ho);
   gkyl_mom_calc_release(m0calc); gkyl_mom_calc_release(m1calc); gkyl_mom_calc_release(m2calc);
   gkyl_mom_type_release(M0_t); gkyl_mom_type_release(M1_t); gkyl_mom_type_release(M2_t);
 
   gkyl_proj_on_basis_release(projDistf);
-  gkyl_array_release(distf);
+  gkyl_array_release(distf); gkyl_array_release(distf_ho);
+  gkyl_array_release(bmag); gkyl_array_release(bmag_ho);
 }
 
 void
-test_1x2v(int poly_order)
+test_1x2v(int poly_order, bool use_gpu)
 {
   double mass = 1.;
   double lower[] = {-M_PI, -2.0, 0.0}, upper[] = {M_PI, 2.0, 2.0};
@@ -353,47 +390,77 @@ test_1x2v(int poly_order)
   skin_ghost_ranges_init(&skin_ghost, &local_ext, ghost);
 
   // create distribution function array and project distribution function on basis
-  struct gkyl_array *distf;
-  distf = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *distf_ho, *distf;
+  distf_ho = mkarr(basis.num_basis, local_ext.volume);
+  distf = mkarr_cu(basis.num_basis, local_ext.volume, use_gpu);
   gkyl_proj_on_basis *projDistf = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, distf_1x2v, NULL);
-  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf_ho);
+  gkyl_array_copy(distf, distf_ho);
 
   // create bmag array and project magnetic field amplitude function on basis
-  struct gkyl_array *bmag;
-  bmag = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *bmag_ho, *bmag;
+  bmag_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  bmag = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
   gkyl_proj_on_basis *projbmag = gkyl_proj_on_basis_new(&confGrid, &confBasis,
     poly_order+1, 1, bmag_1x, NULL);
-  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag);
+  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag_ho);
+  gkyl_array_copy(bmag, bmag_ho);
 
-  struct gkyl_mom_type *M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
-  struct gkyl_mom_type *M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
-  struct gkyl_mom_type *M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  struct gkyl_mom_type *M0_t, *M1_t, *M2_t;
+  if (use_gpu) {
+    M0_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M2");
+  } else {
+    M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  }
   gkyl_gyrokinetic_set_bmag(M0_t, bmag);
   gkyl_gyrokinetic_set_bmag(M1_t, bmag);
   gkyl_gyrokinetic_set_bmag(M2_t, bmag);
-  gkyl_mom_calc *m0calc = gkyl_mom_calc_new(&grid, M0_t);
-  gkyl_mom_calc *m1calc = gkyl_mom_calc_new(&grid, M1_t);
-  gkyl_mom_calc *m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  gkyl_mom_calc *m0calc, *m1calc, *m2calc;
+  if (use_gpu) {
+    m0calc = gkyl_mom_calc_cu_dev_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_cu_dev_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_cu_dev_new(&grid, M2_t);
+  } else {
+    m0calc = gkyl_mom_calc_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  }
 
   // create moment arrays
-  struct gkyl_array *m0, *m1, *m2;
-  m0 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m1 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m2 = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *m0_ho, *m1_ho, *m2_ho, *m0, *m1, *m2;
+  m0_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m1_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m2_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m0 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m1 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m2 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
 
   // compute the moments
-  gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
-  gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
-  gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  if (use_gpu) {
+    gkyl_mom_calc_advance_cu(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance_cu(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance_cu(m2calc, &local, &confLocal, distf, m2);
+  } else {
+    gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  }
+  gkyl_array_copy(m0_ho, m0);
+  gkyl_array_copy(m1_ho, m1);
+  gkyl_array_copy(m2_ho, m2);
 
-  double *m00 = gkyl_array_fetch(m0, gkyl_range_idx(&confLocal, &(int) {0+confGhost[0]})); 
-  double *m01 = gkyl_array_fetch(m0, gkyl_range_idx(&confLocal, &(int) {1+confGhost[0]}));
-  double *m02 = gkyl_array_fetch(m0, 2+confGhost[0]); double *m03 = gkyl_array_fetch(m0, 3+confGhost[0]);
-  double *m10 = gkyl_array_fetch(m1, 0+confGhost[0]); double *m11 = gkyl_array_fetch(m1, 1+confGhost[0]);
-  double *m12 = gkyl_array_fetch(m1, 2+confGhost[0]); double *m13 = gkyl_array_fetch(m1, 3+confGhost[0]);
-  double *m20 = gkyl_array_fetch(m2, 0+confGhost[0]); double *m21 = gkyl_array_fetch(m2, 1+confGhost[0]);
-  double *m22 = gkyl_array_fetch(m2, 2+confGhost[0]); double *m23 = gkyl_array_fetch(m2, 3+confGhost[0]);
+  double *m00 = gkyl_array_fetch(m0_ho, gkyl_range_idx(&confLocal, &(int) {0+confGhost[0]})); 
+  double *m01 = gkyl_array_fetch(m0_ho, gkyl_range_idx(&confLocal, &(int) {1+confGhost[0]}));
+  double *m02 = gkyl_array_fetch(m0_ho, 2+confGhost[0]); double *m03 = gkyl_array_fetch(m0_ho, 3+confGhost[0]);
+  double *m10 = gkyl_array_fetch(m1_ho, 0+confGhost[0]); double *m11 = gkyl_array_fetch(m1_ho, 1+confGhost[0]);
+  double *m12 = gkyl_array_fetch(m1_ho, 2+confGhost[0]); double *m13 = gkyl_array_fetch(m1_ho, 3+confGhost[0]);
+  double *m20 = gkyl_array_fetch(m2_ho, 0+confGhost[0]); double *m21 = gkyl_array_fetch(m2_ho, 1+confGhost[0]);
+  double *m22 = gkyl_array_fetch(m2_ho, 2+confGhost[0]); double *m23 = gkyl_array_fetch(m2_ho, 3+confGhost[0]);
   if (poly_order==1) {
     // Check M0.
     TEST_CHECK( gkyl_compare(  191.6841953662915, m00[0], 1e-12) );
@@ -470,15 +537,17 @@ test_1x2v(int poly_order)
 
   // release memory for moment data object
   gkyl_array_release(m0); gkyl_array_release(m1); gkyl_array_release(m2);
+  gkyl_array_release(m0_ho); gkyl_array_release(m1_ho); gkyl_array_release(m2_ho);
   gkyl_mom_calc_release(m0calc); gkyl_mom_calc_release(m1calc); gkyl_mom_calc_release(m2calc);
   gkyl_mom_type_release(M0_t); gkyl_mom_type_release(M1_t); gkyl_mom_type_release(M2_t);
 
   gkyl_proj_on_basis_release(projDistf);
-  gkyl_array_release(distf);
+  gkyl_array_release(distf); gkyl_array_release(distf_ho);
+  gkyl_array_release(bmag); gkyl_array_release(bmag_ho);
 }
 
 void
-test_2x2v(int poly_order)
+test_2x2v(int poly_order, bool use_gpu)
 {
   double mass = 1.;
   double lower[] = {-M_PI, -M_PI, -2.0, 0.0}, upper[] = {M_PI, M_PI, 2.0, 2.0};
@@ -518,39 +587,69 @@ test_2x2v(int poly_order)
   skin_ghost_ranges_init(&skin_ghost, &local_ext, ghost);
 
   // create distribution function array and project distribution function on basis
-  struct gkyl_array *distf;
-  distf = mkarr(basis.num_basis, local_ext.volume);
+  struct gkyl_array *distf_ho, *distf;
+  distf_ho = mkarr(basis.num_basis, local_ext.volume);
+  distf = mkarr_cu(basis.num_basis, local_ext.volume, use_gpu);
   gkyl_proj_on_basis *projDistf = gkyl_proj_on_basis_new(&grid, &basis,
     poly_order+1, 1, distf_2x2v, NULL);
-  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projDistf, 0.0, &local, distf_ho);
+  gkyl_array_copy(distf, distf_ho);
 
   // create bmag array and project magnetic field amplitude function on basis
-  struct gkyl_array *bmag;
-  bmag = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *bmag_ho, *bmag;
+  bmag_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  bmag = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
   gkyl_proj_on_basis *projbmag = gkyl_proj_on_basis_new(&confGrid, &confBasis,
     poly_order+1, 1, bmag_2x, NULL);
-  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag);
+  gkyl_proj_on_basis_advance(projbmag, 0.0, &confLocal, bmag_ho);
+  gkyl_array_copy(bmag, bmag_ho);
 
-  struct gkyl_mom_type *M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
-  struct gkyl_mom_type *M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
-  struct gkyl_mom_type *M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  struct gkyl_mom_type *M0_t, *M1_t, *M2_t;
+  if (use_gpu) {
+    M0_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_cu_dev_new(&confBasis, &basis, &confLocal, mass, "M2");
+  } else {
+    M0_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M0");
+    M1_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M1");
+    M2_t = gkyl_mom_gyrokinetic_new(&confBasis, &basis, &confLocal, mass, "M2");
+  }
   gkyl_gyrokinetic_set_bmag(M0_t, bmag);
   gkyl_gyrokinetic_set_bmag(M1_t, bmag);
   gkyl_gyrokinetic_set_bmag(M2_t, bmag);
-  gkyl_mom_calc *m0calc = gkyl_mom_calc_new(&grid, M0_t);
-  gkyl_mom_calc *m1calc = gkyl_mom_calc_new(&grid, M1_t);
-  gkyl_mom_calc *m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  gkyl_mom_calc *m0calc, *m1calc, *m2calc;
+  if (use_gpu) {
+    m0calc = gkyl_mom_calc_cu_dev_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_cu_dev_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_cu_dev_new(&grid, M2_t);
+  } else {
+    m0calc = gkyl_mom_calc_new(&grid, M0_t);
+    m1calc = gkyl_mom_calc_new(&grid, M1_t);
+    m2calc = gkyl_mom_calc_new(&grid, M2_t);
+  }
 
   // create moment arrays
-  struct gkyl_array *m0, *m1, *m2;
-  m0 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m1 = mkarr(confBasis.num_basis, confLocal_ext.volume);
-  m2 = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *m0_ho, *m1_ho, *m2_ho, *m0, *m1, *m2;
+  m0_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m1_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m2_ho = mkarr(confBasis.num_basis, confLocal_ext.volume);
+  m0 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m1 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
+  m2 = mkarr_cu(confBasis.num_basis, confLocal_ext.volume, use_gpu);
 
   // compute the moments
-  gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
-  gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
-  gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  if (use_gpu) {
+    gkyl_mom_calc_advance_cu(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance_cu(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance_cu(m2calc, &local, &confLocal, distf, m2);
+  } else {
+    gkyl_mom_calc_advance(m0calc, &local, &confLocal, distf, m0);
+    gkyl_mom_calc_advance(m1calc, &local, &confLocal, distf, m1);
+    gkyl_mom_calc_advance(m2calc, &local, &confLocal, distf, m2);
+  }
+  gkyl_array_copy(m0_ho, m0);
+  gkyl_array_copy(m1_ho, m1);
+  gkyl_array_copy(m2_ho, m2);
 
   if (poly_order==1) {
     double m0Correct[] = {
@@ -611,15 +710,15 @@ test_2x2v(int poly_order)
       for (int j=0; j<cells[1]; j++) {
         int idx[] = {i+confGhost[0], j+confGhost[1]};
         // Check M0.
-        double *m0ptr = gkyl_array_fetch(m0, gkyl_range_idx(&confLocal, idx)); 
+        double *m0ptr = gkyl_array_fetch(m0_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m0Correct[(i*cells[1]+j)*confBasis.num_basis+k], m0ptr[k], 1e-12) );
         // Check M1.
-        double *m1ptr = gkyl_array_fetch(m1, gkyl_range_idx(&confLocal, idx)); 
+        double *m1ptr = gkyl_array_fetch(m1_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m1Correct[(i*cells[1]+j)*confBasis.num_basis+k], m1ptr[k], 1e-12) );
         // Check M2.
-        double *m2ptr = gkyl_array_fetch(m2, gkyl_range_idx(&confLocal, idx)); 
+        double *m2ptr = gkyl_array_fetch(m2_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m2Correct[(i*cells[1]+j)*confBasis.num_basis+k], m2ptr[k], 1e-12) );
       }
@@ -703,15 +802,15 @@ test_2x2v(int poly_order)
       for (int j=0; j<cells[1]; j++) {
         int idx[] = {i+confGhost[0], j+confGhost[1]};
         // Check M0.
-        double *m0ptr = gkyl_array_fetch(m0, gkyl_range_idx(&confLocal, idx)); 
+        double *m0ptr = gkyl_array_fetch(m0_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m0Correct[(i*cells[1]+j)*confBasis.num_basis+k], m0ptr[k], 1e-12) );
         // Check M1.
-        double *m1ptr = gkyl_array_fetch(m1, gkyl_range_idx(&confLocal, idx)); 
+        double *m1ptr = gkyl_array_fetch(m1_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m1Correct[(i*cells[1]+j)*confBasis.num_basis+k], m1ptr[k], 1e-12) );
         // Check M2.
-        double *m2ptr = gkyl_array_fetch(m2, gkyl_range_idx(&confLocal, idx)); 
+        double *m2ptr = gkyl_array_fetch(m2_ho, gkyl_range_idx(&confLocal, idx)); 
         for (int k=0; k<confBasis.num_basis; k++)
           TEST_CHECK( gkyl_compare( m2Correct[(i*cells[1]+j)*confBasis.num_basis+k], m2ptr[k], 1e-12) );
       }
@@ -720,19 +819,30 @@ test_2x2v(int poly_order)
 
   // release memory for moment data object
   gkyl_array_release(m0); gkyl_array_release(m1); gkyl_array_release(m2);
+  gkyl_array_release(m0_ho); gkyl_array_release(m1_ho); gkyl_array_release(m2_ho);
   gkyl_mom_calc_release(m0calc); gkyl_mom_calc_release(m1calc); gkyl_mom_calc_release(m2calc);
   gkyl_mom_type_release(M0_t); gkyl_mom_type_release(M1_t); gkyl_mom_type_release(M2_t);
 
   gkyl_proj_on_basis_release(projDistf);
-  gkyl_array_release(distf);
+  gkyl_array_release(distf); gkyl_array_release(distf_ho);
+  gkyl_array_release(bmag); gkyl_array_release(bmag_ho);
 }
 
-void test_1x1v_p1() { test_1x1v(1); } 
-void test_1x1v_p2() { test_1x1v(2); } 
-void test_1x2v_p1() { test_1x2v(1); } 
-void test_1x2v_p2() { test_1x2v(2); } 
-void test_2x2v_p1() { test_2x2v(1); } 
-void test_2x2v_p2() { test_2x2v(2); } 
+void test_1x1v_p1() { test_1x1v(1, false); } 
+void test_1x1v_p2() { test_1x1v(2, false); } 
+void test_1x2v_p1() { test_1x2v(1, false); } 
+void test_1x2v_p2() { test_1x2v(2, false); } 
+void test_2x2v_p1() { test_2x2v(1, false); } 
+void test_2x2v_p2() { test_2x2v(2, false); } 
+
+#ifdef GKYL_HAVE_CUDA
+void test_1x1v_p1_cu() { test_1x1v(1, true); } 
+void test_1x1v_p2_cu() { test_1x1v(2, true); } 
+void test_1x2v_p1_cu() { test_1x2v(1, true); } 
+void test_1x2v_p2_cu() { test_1x2v(2, true); } 
+void test_2x2v_p1_cu() { test_2x2v(1, true); } 
+void test_2x2v_p2_cu() { test_2x2v(2, true); } 
+#endif
 
 TEST_LIST = {
   { "mom_gyrokinetic", test_mom_gyrokinetic },
@@ -745,9 +855,12 @@ TEST_LIST = {
 //  { "test_3x2v_p1", test_3x2v_p1 },
 #ifdef GKYL_HAVE_CUDA
 //  { "cu_mom_gyrokinetic", test_cu_mom_gyrokinetic },
-//  { "test_1x1v_p1_cu", test_1x1v_p1_cu },
-//  { "test_1x2v_p1_cu", test_1x2v_p1_cu },
-//  { "test_2x2v_p1_cu", test_2x2v_p1_cu },
+  { "test_1x1v_p1_cu", test_1x1v_p1_cu },
+  { "test_1x1v_p2_cu", test_1x1v_p2_cu },
+  { "test_1x2v_p1_cu", test_1x2v_p1_cu },
+  { "test_1x2v_p2_cu", test_1x2v_p2_cu },
+  { "test_2x2v_p1_cu", test_2x2v_p1_cu },
+  { "test_2x2v_p2_cu", test_2x2v_p2_cu },
 //  { "test_3x2v_p1_cu", test_3x2v_p1_cu },
 #endif
   { NULL, NULL },

--- a/unit/ctest_spitzer_coll_freq.c
+++ b/unit/ctest_spitzer_coll_freq.c
@@ -120,7 +120,8 @@ test_1x(int poly_order, bool use_gpu)
     nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
 
   // Create Spitzer collision frequency updater.
-  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+  double nufrac = 1., epsilon_0 = 1., hbar = 1.;
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, nufrac, epsilon_0, hbar, use_gpu);
 
   if (use_gpu) {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);
@@ -266,7 +267,8 @@ test_2x(int poly_order, bool use_gpu)
     nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
 
   // Create Spitzer collision frequency updater.
-  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+  double nufrac = 1., epsilon_0 = 1., hbar = 1.;
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, nufrac, epsilon_0, hbar, use_gpu);
 
   if (use_gpu) {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);
@@ -414,7 +416,8 @@ test_3x(int poly_order, bool use_gpu)
     nu_cu = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis.num_basis, local_ext.volume);
 
   // Create Spitzer collision frequency updater.
-  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, use_gpu);
+  double nufrac = 1., epsilon_0 = 1., hbar = 1.;
+  gkyl_spitzer_coll_freq *spitz_up = gkyl_spitzer_coll_freq_new(&basis, poly_order+1, nufrac, epsilon_0, hbar, use_gpu);
 
   if (use_gpu) {
     gkyl_spitzer_coll_freq_advance_normnu(spitz_up, &local, vtsqs_cu, m0r_cu, vtsqr_cu, norm_nu, nu_cu);

--- a/zero/dg_updater_gyrokinetic.c
+++ b/zero/dg_updater_gyrokinetic.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <math.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_dg_eqn.h>
+#include <gkyl_dg_gyrokinetic.h>
+#include <gkyl_dg_updater_gyrokinetic.h>
+#include <gkyl_dg_updater_gyrokinetic_priv.h>
+#include <gkyl_hyper_dg.h>
+#include <gkyl_util.h>
+
+struct gkyl_dg_eqn*
+gkyl_dg_updater_gyrokinetic_acquire_eqn(const gkyl_dg_updater_gyrokinetic* gyrokinetic)
+{
+  return gkyl_dg_eqn_acquire(gyrokinetic->dgeqn);
+}
+
+gkyl_dg_updater_gyrokinetic*
+gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
+  const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
+  const struct gkyl_range *conf_range, const struct gkyl_range *vel_range,
+  enum gkyl_gkeqn_id eqn_id, double charge, double mass, bool use_gpu)
+{
+  gkyl_dg_updater_gyrokinetic *up = gkyl_malloc(sizeof(gkyl_dg_updater_gyrokinetic));
+
+  up->eqn_id = eqn_id;
+  if (eqn_id == GKYL_GK_DEFAULT)
+    up->dgeqn = gkyl_dg_gyrokinetic_new(cbasis, pbasis, conf_range, charge, mass, use_gpu);
+//  else if (eqn_id == GKYL_GK_SOFTMIRROR)
+//    up->dgeqn = gkyl_dg_gyrokinetic_softmirror_new(cbasis, pbasis, conf_range, charge, mass, use_gpu);
+
+  int cdim = cbasis->ndim, pdim = pbasis->ndim;
+  int vdim = pdim-cdim;
+  int up_dirs[GKYL_MAX_DIM] = {0};
+  int num_up_dirs = cdim+1;
+  for (int d=0; d<num_up_dirs; ++d) up_dirs[d] = d;
+
+  int zero_flux_flags[GKYL_MAX_DIM] = {0};
+  for (int d=cdim; d<pdim; ++d)
+    zero_flux_flags[d] = 1; // zero-flux BCs in vel-space
+
+  up->hyperdg = gkyl_hyper_dg_new(grid, pbasis, up->dgeqn,
+    num_up_dirs, up_dirs, zero_flux_flags, 1, use_gpu);
+
+  return up;
+}
+
+void
+gkyl_dg_updater_gyrokinetic_advance(gkyl_dg_updater_gyrokinetic *up,
+  const struct gkyl_range *update_rng,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacobtot_inv,
+  const struct gkyl_array *cmag, const struct gkyl_array *b_i,
+  const struct gkyl_array *phi, const struct gkyl_array *apar,
+  const struct gkyl_array *apardot, const struct gkyl_array* GKYL_RESTRICT fIn,
+  struct gkyl_array* GKYL_RESTRICT cflrate, struct gkyl_array* GKYL_RESTRICT rhs)
+{
+  // Set arrays needed.
+  if (up->eqn_id == GKYL_GK_DEFAULT)
+    gkyl_gyrokinetic_set_auxfields(up->dgeqn, 
+      (struct gkyl_dg_gyrokinetic_auxfields) { .bmag = bmag, .jacobtot_inv = jacobtot_inv,
+        .cmag = cmag, .b_i = b_i, .phi = phi, .apar = apar, .apardot = apardot });
+
+#ifdef GKYL_HAVE_CUDA
+  gkyl_hyper_dg_advance_cu(up->hyperdg, update_rng, fIn, cflrate, rhs);
+#else
+  gkyl_hyper_dg_advance(up->hyperdg, update_rng, fIn, cflrate, rhs);
+#endif
+}
+
+void
+gkyl_dg_updater_gyrokinetic_release(gkyl_dg_updater_gyrokinetic* up)
+{
+  gkyl_dg_eqn_release(up->dgeqn);
+  gkyl_hyper_dg_release(up->hyperdg);
+  gkyl_free(up);
+}

--- a/zero/dg_updater_gyrokinetic.c
+++ b/zero/dg_updater_gyrokinetic.c
@@ -23,6 +23,8 @@ gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid,
 {
   gkyl_dg_updater_gyrokinetic *up = gkyl_malloc(sizeof(gkyl_dg_updater_gyrokinetic));
 
+  up->use_gpu = use_gpu;
+
   up->eqn_id = eqn_id;
   if (eqn_id == GKYL_GK_DEFAULT)
     up->dgeqn = gkyl_dg_gyrokinetic_new(cbasis, pbasis, conf_range, charge, mass, use_gpu);
@@ -61,7 +63,10 @@ gkyl_dg_updater_gyrokinetic_advance(gkyl_dg_updater_gyrokinetic *up,
         .cmag = cmag, .b_i = b_i, .phi = phi, .apar = apar, .apardot = apardot });
 
 #ifdef GKYL_HAVE_CUDA
-  gkyl_hyper_dg_advance_cu(up->hyperdg, update_rng, fIn, cflrate, rhs);
+  if (up->use_gpu)
+    gkyl_hyper_dg_advance_cu(up->hyperdg, update_rng, fIn, cflrate, rhs);
+  else
+    gkyl_hyper_dg_advance(up->hyperdg, update_rng, fIn, cflrate, rhs);
 #else
   gkyl_hyper_dg_advance(up->hyperdg, update_rng, fIn, cflrate, rhs);
 #endif

--- a/zero/gkyl_dg_updater_gyrokinetic.h
+++ b/zero/gkyl_dg_updater_gyrokinetic.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_eqn_type.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
+
+// Object type
+typedef struct gkyl_dg_updater_gyrokinetic gkyl_dg_updater_gyrokinetic;
+
+// Boundary condition types.
+enum gkyl_gkeqn_id {
+  GKYL_GK_DEFAULT=0,    // Default GK equation (kernels).
+//  GKYL_GK_SOFTMIRROR,
+};
+
+/**
+ * Create new updater to update gyrokinetic equations using hyper dg.
+ *
+ * @param grid Grid object
+ * @param cbasis Configuration space basis functions
+ * @param pbasis Phase-space basis function
+ * @param conf_range Config space range
+ * @param vel_range Velocity space range
+ * @param field_id Enum identifier for field type (see gkyl_eqn_type.h)
+ * 
+ * @return New gyrokinetic updater object
+ */
+gkyl_dg_updater_gyrokinetic* gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
+  const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
+  const struct gkyl_range *conf_range, const struct gkyl_range *vel_range,
+  enum gkyl_gkeqn_id eqn_id, double charge, double mass, bool use_gpu);
+
+/**
+ * Acquire gyrokinetic equation object
+ *
+ * @param up gyrokinetic updater object
+ * 
+ * @return gyrokinetic equation object
+ */
+struct gkyl_dg_eqn* 
+gkyl_dg_updater_gyrokinetic_acquire_eqn(const gkyl_dg_updater_gyrokinetic* up);
+
+/**
+ * Compute RHS of DG update. The update_rng MUST be a sub-range of the
+ * range on which the array is defined. That is, it must be either the
+ * same range as the array range, or one created using the
+ * gkyl_sub_range_init method.
+ *
+ * @param up gyrokinetic updater object
+ * @param field_id Enum identifier for field type (see gkyl_eqn_type.h)
+ * @param update_rng Range on which to compute.
+ * @param bmag Magnetic field magnitude.
+ * @param jacobtot_inv Reciprocal of the total (conf * guiding center) Jacobian.
+ * @param cmag Multiplicative factor in Clebsch-like form of the magnetic field.
+ * @param b_i Covariant components of hat{b}.
+ * @param phi Electrostatic potential.
+ * @param apar Parallel component of magnetic vector potential.
+ * @param apardot Time rate of change of apar.
+ * @param fIn Input to updater
+ * @param cflrate CFL scalar rate (frequency) array (units of 1/[T])
+ * @param rhs RHS output
+ */
+void gkyl_dg_updater_gyrokinetic_advance(gkyl_dg_updater_gyrokinetic *up,
+  const struct gkyl_range *update_rng,
+  const struct gkyl_array *bmag, const struct gkyl_array *jacobtot_inv,
+  const struct gkyl_array *cmag, const struct gkyl_array *b_i,
+  const struct gkyl_array *phi, const struct gkyl_array *apar,
+  const struct gkyl_array *apardot, const struct gkyl_array* GKYL_RESTRICT fIn,
+  struct gkyl_array* GKYL_RESTRICT cflrate, struct gkyl_array* GKYL_RESTRICT rhs);
+
+/**
+ * Delete updater.
+ *
+ * @param up Updater to delete.
+ */
+void gkyl_dg_updater_gyrokinetic_release(gkyl_dg_updater_gyrokinetic* up);

--- a/zero/gkyl_dg_updater_gyrokinetic_priv.h
+++ b/zero/gkyl_dg_updater_gyrokinetic_priv.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gkyl_hyper_dg.h>
+#include <gkyl_dg_eqn.h>
+#include <gkyl_dg_updater_gyrokinetic.h>
+
+struct gkyl_dg_updater_gyrokinetic {
+  struct gkyl_dg_eqn *dgeqn; // Equation object
+  struct gkyl_hyper_dg *hyperdg; // solvers for specific gyrokinetic equation
+
+  enum gkyl_gkeqn_id eqn_id;  // ID to distinguish the equation type.
+
+  bool use_gpu;
+};

--- a/zero/gkyl_spitzer_coll_freq.h
+++ b/zero/gkyl_spitzer_coll_freq.h
@@ -14,18 +14,21 @@ typedef struct gkyl_spitzer_coll_freq gkyl_spitzer_coll_freq;
  *
  * @param basis Basis object (configuration space).
  * @param num_quad Number of quadrature nodes.
- * @param use_gpu boolean indicating whether to use the GPU.
+ * @param use_gpu Boolean indicating whether to use the GPU.
+ * @param nufrac Fraction to multiply the collision frequency by.
+ * @param eps0 Permittivity of vacuum.
+ * @param hbar Planck's constant divided by 2*pi.
  * @return New updater pointer.
  */
-gkyl_spitzer_coll_freq* gkyl_spitzer_coll_freq_new(
-  const struct gkyl_basis *basis, int num_quad, bool use_gpu);
+gkyl_spitzer_coll_freq* gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis,
+  int num_quad, double nufrac, double eps0, double hbar, bool use_gpu);
 
 /**
  * Scale the normalized collision frequency, normNu, by
  * n_r/(v_ts^2+v_tr^2)^(3/2) and project it on to the basis.
  *
  * @param up Spizer collision frequency updater object.
- * @param range Config-space range
+ * @param range Config-space rang.e
  * @param vtSqSelf Thermal speed squared of this species. 
  * @param m0Other Thermal speed squared of the other species. 
  * @param vtSqOther Thermal speed squared of the other species. 
@@ -42,7 +45,8 @@ void gkyl_spitzer_coll_freq_advance_normnu(const gkyl_spitzer_coll_freq *up,
  * is computed using cell averaged values.
  *
  * @param up Spizer collision frequency updater object.
- * @param range Config-space range
+ * @param range Config-space range.
+ * @param bmag Magnetic field magnitude.
  * @param qSelf Charge of this species.
  * @param mSelf Mass of this species.
  * @param m0Self Thermal speed squared of the other species. 
@@ -54,7 +58,7 @@ void gkyl_spitzer_coll_freq_advance_normnu(const gkyl_spitzer_coll_freq *up,
  * @param nuOut Output collision frequency.
  */
 void gkyl_spitzer_coll_freq_advance(const gkyl_spitzer_coll_freq *up,
-  const struct gkyl_range *range,
+  const struct gkyl_range *range, const struct gkyl_array *bmag,
   double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
   double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
   struct gkyl_array *nuOut);

--- a/zero/gkyl_spitzer_coll_freq_priv.h
+++ b/zero/gkyl_spitzer_coll_freq_priv.h
@@ -15,6 +15,10 @@ struct gkyl_spitzer_coll_freq {
 
   struct gkyl_array *fun_at_ords; // function (Maxwellian) evaluated at
                                   // ordinates in a cell.
+
+  // Time independent factors that can be precomputed.
+  double hbar_fac, r4pieps0_fac, nufraceps0_fac, cellav_fac;
+  double eps0;
 };
 
 void
@@ -25,7 +29,7 @@ gkyl_spitzer_coll_freq_advance_normnu_cu(const gkyl_spitzer_coll_freq *up,
 
 void
 gkyl_spitzer_coll_freq_advance_cu(const gkyl_spitzer_coll_freq *up,
-  const struct gkyl_range *range,
+  const struct gkyl_range *range, const struct gkyl_array *bmag,
   double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
   double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
   struct gkyl_array *nuOut);

--- a/zero/spitzer_coll_freq.c
+++ b/zero/spitzer_coll_freq.c
@@ -32,8 +32,7 @@ init_quad_values(const struct gkyl_basis *basis, int num_quad,
     // than computing them on the fly)
     memcpy(ordinates1, gkyl_gauss_ordinates[num_quad], sizeof(double[num_quad]));
     memcpy(weights1, gkyl_gauss_weights[num_quad], sizeof(double[num_quad]));
-  }
-  else {
+  } else {
     gkyl_gauleg(-1, 1, ordinates1, weights1, num_quad);
   }
 
@@ -70,12 +69,13 @@ init_quad_values(const struct gkyl_basis *basis, int num_quad,
 
   // pre-compute basis functions at ordinates
   struct gkyl_array *basis_at_ords_ho = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
+  for (int n=0; n<tot_quad; ++n)
+    basis->eval(gkyl_array_fetch(ordinates_ho, n), gkyl_array_fetch(basis_at_ords_ho, n));
+
   if (use_gpu)
     *basis_at_ords = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
   else
     *basis_at_ords = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, tot_quad);
-  for (int n=0; n<tot_quad; ++n)
-    basis->eval(gkyl_array_fetch(ordinates_ho, n), gkyl_array_fetch(basis_at_ords_ho, n));
 
   // copy host array to device array
   gkyl_array_copy(*weights, weights_ho);
@@ -161,8 +161,8 @@ calc_nu(const gkyl_spitzer_coll_freq *up, struct gkyl_range qrange, const double
 
     double *fq = gkyl_array_fetch(up->fun_at_ords, qidx);
 
-    fq[0] = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
-      1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+    fq[0] = ((m0Other_q>0.) && (vtSqSelf_q>0.) && (vtSqOther_q>0.)) ?
+      normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3) : 1.e-14;
   }
 
   // compute expansion coefficients of Maxwellian on basis

--- a/zero/spitzer_coll_freq.c
+++ b/zero/spitzer_coll_freq.c
@@ -89,7 +89,8 @@ init_quad_values(const struct gkyl_basis *basis, int num_quad,
 }
 
 gkyl_spitzer_coll_freq*
-gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis, int num_quad, bool use_gpu)
+gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis, int num_quad,
+  double nufrac, double eps0, double hbar, bool use_gpu)
 {
   gkyl_spitzer_coll_freq *up = gkyl_malloc(sizeof(gkyl_spitzer_coll_freq));
 
@@ -107,6 +108,14 @@ gkyl_spitzer_coll_freq_new(const struct gkyl_basis *basis, int num_quad, bool us
   else
     up->fun_at_ords = gkyl_array_new(GKYL_DOUBLE, 1, up->tot_quad); // Only used in CPU implementation.
 
+  up->eps0 = eps0;
+  // Pre-compute time-independent factors for the case in which we calculate
+  // the collision frequency from scratch (instead of normnu).
+  up->hbar_fac = hbar/(2.0*exp(0.5));
+  up->r4pieps0_fac = 1./(4.*M_PI*eps0);
+  up->nufraceps0_fac = nufrac/(3.*sqrt(pow(2.*M_PI,3))*pow(eps0,2));
+  up->cellav_fac = 1./pow(sqrt(2.),up->ndim);
+  
   return up;
 }
 
@@ -127,6 +136,37 @@ proj_on_basis(const gkyl_spitzer_coll_freq *up, const struct gkyl_array *fun_at_
     for (int k=0; k<num_basis; ++k)
       f[k] += tmp*basis_at_ords[k+num_basis*imu];
   }
+}
+
+void
+calc_nu(const gkyl_spitzer_coll_freq *up, struct gkyl_range qrange, const double *vtSqSelf_d,
+  const double *m0Other_d, const double *vtSqOther_d, double normNu, long linidx, struct gkyl_array *nuOut)
+{
+  // Perform the multiplication of normNu*n_r/(v_ts^2+v_tr^2)^(3/2) via
+  // quadrature in one cell.
+  struct gkyl_range_iter qiter;
+  gkyl_range_iter_init(&qiter, &qrange);
+  while (gkyl_range_iter_next(&qiter)) {
+    
+    int qidx = gkyl_range_idx(&qrange, qiter.idx);
+
+    // Evaluate densities and thermal speeds (squared) at quad point.
+    const double *b_ord = gkyl_array_cfetch(up->basis_at_ords, qidx);
+    double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
+    for (int k=0; k<up->num_basis; ++k) {
+      vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
+      m0Other_q += m0Other_d[k]*b_ord[k];
+      vtSqOther_q += vtSqOther_d[k]*b_ord[k];
+    }
+
+    double *fq = gkyl_array_fetch(up->fun_at_ords, qidx);
+
+    fq[0] = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
+      1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+  }
+
+  // compute expansion coefficients of Maxwellian on basis
+  proj_on_basis(up, up->fun_at_ords, gkyl_array_fetch(nuOut, linidx));
 }
 
 void
@@ -156,29 +196,73 @@ gkyl_spitzer_coll_freq_advance_normnu(const gkyl_spitzer_coll_freq *up,
     const double *m0Other_d = gkyl_array_cfetch(m0Other, linidx);
     const double *vtSqOther_d = gkyl_array_cfetch(vtSqOther, linidx);
 
-    struct gkyl_range_iter qiter;
-    gkyl_range_iter_init(&qiter, &qrange);
-    while (gkyl_range_iter_next(&qiter)) {
-      
-      int qidx = gkyl_range_idx(&qrange, qiter.idx);
+    calc_nu(up, qrange, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut);
+  }
 
-      // Evaluate densities and thermal speeds (squared) at quad point.
-      const double *b_ord = gkyl_array_cfetch(up->basis_at_ords, qidx);
-      double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
-      for (int k=0; k<up->num_basis; ++k) {
-        vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
-        m0Other_q += m0Other_d[k]*b_ord[k];
-        vtSqOther_q += vtSqOther_d[k]*b_ord[k];
-      }
+}
 
-      double *fq = gkyl_array_fetch(up->fun_at_ords, qidx);
+void
+gkyl_spitzer_coll_freq_advance(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *bmag,  
+  double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  struct gkyl_array *nuOut)
+{
+  // Compute the Spitzer-like collision frequency
+  //   nu_sr = nu_frac * (n_r/m_s)*(1/m_s+1/m_r)
+  //     * (q_s^2*q_r^2*log(Lambda_sr)/(3*(2*pi)^(3/2)*epsilon_0^2))
+  //     * (1/(v_ts^2+v_tr^2)^(3/2))
+  // where log(Lambda_sr) is the Coulomb logarithm (see Gkeyll docs).
 
-      fq[0] = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
-        1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
-    }
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    return gkyl_spitzer_coll_freq_advance_cu(up, range, bmag, qSelf, mSelf, m0Self, vtSqSelf, 
+      qOther, mOther, m0Other, vtSqOther, nuOut);
+#endif
 
-    // compute expansion coefficients of Maxwellian on basis
-    proj_on_basis(up, up->fun_at_ords, gkyl_array_fetch(nuOut, linidx));
+  double mReduced = 1./(1./mSelf+1./mOther);
+  double timeConstFac = up->nufraceps0_fac*pow(qSelf*qOther,2)/(mSelf*mReduced);
+
+  // Create range to loop over quadrature points.
+  struct gkyl_range qrange = get_qrange(up->ndim, up->num_quad);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  while (gkyl_range_iter_next(&iter)) {
+    long linidx = gkyl_range_idx(range, iter.idx);
+
+    const double *bmag_d = gkyl_array_cfetch(bmag, linidx);
+    const double *m0Self_d = gkyl_array_cfetch(m0Self, linidx);
+    const double *vtSqSelf_d = gkyl_array_cfetch(vtSqSelf, linidx);
+    const double *m0Other_d = gkyl_array_cfetch(m0Other, linidx);
+    const double *vtSqOther_d = gkyl_array_cfetch(vtSqOther, linidx);
+
+    // Compute the Coulomb logarithm using cell-average values.
+    double bmagAv = bmag_d[0]*up->cellav_fac;
+    double m0SelfAv = m0Self_d[0]*up->cellav_fac;
+    double vtSqSelfAv = vtSqSelf_d[0]*up->cellav_fac;
+    double m0OtherAv = m0Other_d[0]*up->cellav_fac;
+    double vtSqOtherAv = vtSqOther_d[0]*up->cellav_fac;
+
+    double omegaSqSumSelf  = m0SelfAv*pow(qSelf,2)/(up->eps0*mSelf)+pow(qSelf*bmagAv/mSelf,2);
+    double omegaSqSumOther = m0OtherAv*pow(qOther,2)/(up->eps0*mOther)+pow(qOther*bmagAv/mOther,2);
+
+    double rmaxSumSelf = omegaSqSumSelf/(vtSqSelfAv+3.*vtSqSelfAv)+omegaSqSumOther/(vtSqOtherAv+3.*vtSqSelfAv);
+    double rmaxSumOther = omegaSqSumSelf/(vtSqSelfAv+3.*vtSqOtherAv)+omegaSqSumOther/(vtSqOtherAv+3.*vtSqOtherAv);
+
+    double rmaxSelf = 1./sqrt(rmaxSumSelf);
+    double rmaxOther = 1./sqrt(rmaxSumOther);
+
+    double uRelSq = 3.*(vtSqOtherAv+vtSqSelfAv);
+
+    double rMin = GKYL_MAX(fabs(qSelf*qOther)*up->r4pieps0_fac/(mReduced*uRelSq), up->hbar_fac/(mReduced*sqrt(uRelSq)));
+
+    double logLambda = 0.5*(0.5*log(1.+pow(rmaxSelf/rMin,2))+0.5*log(1.+pow(rmaxOther/rMin,2)));
+
+    // Normalized nu (nu missing density and temperature factors).
+    double normNu = timeConstFac*logLambda;
+
+    calc_nu(up, qrange, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut);
   }
 
 }

--- a/zero/spitzer_coll_freq_cu.cu
+++ b/zero/spitzer_coll_freq_cu.cu
@@ -7,18 +7,53 @@ extern "C" {
 #include <gkyl_range.h>
 }
 
-__global__ static void
-gkyl_spitzer_coll_freq_advance_normnu_cu_ker(int num_quad, 
-  const struct gkyl_range range, const struct gkyl_array* GKYL_RESTRICT basis_at_ords,
-  const struct gkyl_array* GKYL_RESTRICT weights, const struct gkyl_array* GKYL_RESTRICT vtSqSelf,
-  const struct gkyl_array* GKYL_RESTRICT m0Other, const struct gkyl_array* GKYL_RESTRICT vtSqOther,
-  double normNu, struct gkyl_array* GKYL_RESTRICT nuOut)
+GKYL_CU_D static inline void
+calc_nu_cu(const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
+  const struct gkyl_array* GKYL_RESTRICT vtSqSelf_d, const struct gkyl_array* GKYL_RESTRICT m0Other_d,
+  const struct gkyl_array* GKYL_RESTRICT vtSqOther_d, double normNu, long linidx,
+  struct gkyl_array* GKYL_RESTRICT nuOut_d)
 {
+  // Perform the multiplication of normNu*n_r/(v_ts^2+v_tr^2)^(3/2) via
+  // quadrature in one cell.
   int num_basis = basis_at_ords->ncomp;
   int tot_quad = basis_at_ords->size;
 
-  int idx[3];
+  double *nuOut_d = (double *) gkyl_array_fetch(nuOut, linidx);
+  for (int k=0; k<num_basis; ++k) nuOut_d[k] = 0.0;
 
+  // Compute expansion coefficients of nuOut using quadrature.
+  const double *w_d = (const double *) weights->data;
+  const double *bo_d = (const double *) basis_at_ords->data;
+
+  for (int n=0; n<tot_quad; ++n) {
+
+    const double *b_ord = (const double *) gkyl_array_cfetch(basis_at_ords, n);
+
+    // Evaluate densities and thermal speeds (squared) at quad point.
+    double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
+    for (int k=0; k<num_basis; ++k) {
+      vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
+      m0Other_q += m0Other_d[k]*b_ord[k];
+      vtSqOther_q += vtSqOther_d[k]*b_ord[k];
+    }
+
+    double nu_o = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
+      1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+
+    double tmp = w_d[n]*nu_o;
+    for (int k=0; k<num_basis; ++k)
+      nuOut_d[k] += tmp*bo_d[k+num_basis*n];
+  }
+}
+
+
+__global__ static void
+gkyl_spitzer_coll_freq_advance_normnu_cu_ker(const struct gkyl_range range,
+  const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
+  const struct gkyl_array* GKYL_RESTRICT vtSqSelf, const struct gkyl_array* GKYL_RESTRICT m0Other,
+  const struct gkyl_array* GKYL_RESTRICT vtSqOther, double normNu, struct gkyl_array* GKYL_RESTRICT nuOut)
+{
+  int idx[3];
   for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
       tid < range.volume; tid += blockDim.x*gridDim.x) {
 
@@ -29,33 +64,61 @@ gkyl_spitzer_coll_freq_advance_normnu_cu_ker(int num_quad,
     const double *m0Other_d = (const double *) gkyl_array_cfetch(m0Other, linidx);
     const double *vtSqOther_d = (const double *) gkyl_array_cfetch(vtSqOther, linidx);
 
-    double *nuOut_d = (double *) gkyl_array_fetch(nuOut, linidx);
-    for (int k=0; k<num_basis; ++k) nuOut_d[k] = 0.0;
+    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut_d);
+  }
+}
 
-    // Compute expansion coefficients of nuOut using quadrature.
-    const double *w_d = (const double *) weights->data;
-    const double *bo_d = (const double *) basis_at_ords->data;
+__global__ static void
+gkyl_spitzer_coll_freq_advance_cu_ker(const struct gkyl_range range,
+  const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
+  double nufraceps0_fac, double cellav_fac, double r4pieps0_fac, double hbar_fac, double eps0,
+  const struct gkyl_array* GKYL_RESTRICT bmag,
+  double qSelf, double mSelf, const struct gkyl_array* GKYL_RESTRICT m0Self, const struct gkyl_array* GKYL_RESTRICT vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array* GKYL_RESTRICT m0Other, const struct gkyl_array* GKYL_RESTRICT vtSqOther,
+  struct gkyl_array* GKYL_RESTRICT nuOut)
+{
+  double mReduced = 1./(1./mSelf+1./mOther);
+  double timeConstFac = nufraceps0_fac*pow(qSelf*qOther,2)/(mSelf*mReduced);
 
-    for (int n=0; n<tot_quad; ++n) {
+  int idx[3];
+  for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
+      tid < range.volume; tid += blockDim.x*gridDim.x) {
 
-      const double *b_ord = (const double *) gkyl_array_cfetch(basis_at_ords, n);
+    gkyl_sub_range_inv_idx(&range, tid, idx);
+    long linidx = gkyl_range_idx(&range, idx);
 
-      // Evaluate densities and thermal speeds (squared) at quad point.
-      double vtSqSelf_q=0., m0Other_q=0., vtSqOther_q=0.;
-      for (int k=0; k<num_basis; ++k) {
-        vtSqSelf_q += vtSqSelf_d[k]*b_ord[k];
-        m0Other_q += m0Other_d[k]*b_ord[k];
-        vtSqOther_q += vtSqOther_d[k]*b_ord[k];
-      }
+    const double *bmag_d = gkyl_array_cfetch(bmag, linidx);
+    const double *m0Self_d = gkyl_array_cfetch(m0Self, linidx);
+    const double *vtSqSelf_d = (const double *) gkyl_array_cfetch(vtSqSelf, linidx);
+    const double *m0Other_d = (const double *) gkyl_array_cfetch(m0Other, linidx);
+    const double *vtSqOther_d = (const double *) gkyl_array_cfetch(vtSqOther, linidx);
 
-      double nu_o = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
-        1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+    // Compute the Coulomb logarithm using cell-average values.
+    double bmagAv = bmag_d[0]*cellav_fac;
+    double m0SelfAv = m0Self_d[0]*cellav_fac;
+    double vtSqSelfAv = vtSqSelf_d[0]*cellav_fac;
+    double m0OtherAv = m0Other_d[0]*cellav_fac;
+    double vtSqOtherAv = vtSqOther_d[0]*cellav_fac;
 
-      double tmp = w_d[n]*nu_o;
-      for (int k=0; k<num_basis; ++k)
-        nuOut_d[k] += tmp*bo_d[k+num_basis*n];
-    }
+    double omegaSqSumSelf  = m0SelfAv*pow(qSelf,2)/(eps0*mSelf)+pow(qSelf*bmagAv/mSelf,2);
+    double omegaSqSumOther = m0OtherAv*pow(qOther,2)/(eps0*mOther)+pow(qOther*bmagAv/mOther,2);
 
+    double rmaxSumSelf = omegaSqSumSelf/(vtSqSelfAv+3.*vtSqSelfAv)+omegaSqSumOther/(vtSqOtherAv+3.*vtSqSelfAv);
+    double rmaxSumOther = omegaSqSumSelf/(vtSqSelfAv+3.*vtSqOtherAv)+omegaSqSumOther/(vtSqOtherAv+3.*vtSqOtherAv);
+
+    double rmaxSelf = 1./sqrt(rmaxSumSelf);
+    double rmaxOther = 1./sqrt(rmaxSumOther);
+
+    double uRelSq = 3.*(vtSqOtherAv+vtSqSelfAv);
+
+    double rMin = GKYL_MAX(fabs(qSelf*qOther)*r4pieps0_fac/(mReduced*uRelSq), hbar_fac/(mReduced*sqrt(uRelSq)));
+
+    double logLambda = 0.5*(0.5*log(1.+pow(rmaxSelf/rMin,2))+0.5*log(1.+pow(rmaxOther/rMin,2)));
+
+    // Normalized nu (nu missing density and temperature factors).
+    double normNu = timeConstFac*logLambda;
+
+    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut_d);
   }
 }
 
@@ -67,7 +130,23 @@ gkyl_spitzer_coll_freq_advance_normnu_cu(const gkyl_spitzer_coll_freq *up,
 {
   int nblocks = range->nblocks, nthreads = range->nthreads;
   gkyl_spitzer_coll_freq_advance_normnu_cu_ker<<<nblocks, nthreads>>>
-    (up->num_quad, *range, up->basis_at_ords->on_dev,
+    (*range, up->basis_at_ords->on_dev,
      up->weights->on_dev, vtSqSelf->on_dev,
      m0Other->on_dev, vtSqOther->on_dev, normNu, nuOut->on_dev);
+}
+
+void
+gkyl_spitzer_coll_freq_advance_cu(const gkyl_spitzer_coll_freq *up,
+  const struct gkyl_range *range, const struct gkyl_array *bmag,
+  double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
+  struct gkyl_array *nuOut);
+{
+  int nblocks = range->nblocks, nthreads = range->nthreads;
+  gkyl_spitzer_coll_freq_advance_cu_ker<<<nblocks, nthreads>>>
+    (*range, up->basis_at_ords->on_dev, up->weights->on_dev,
+     up->nufraceps0_fac, up->cellav_fac, up->r4pieps0_fac, up->hbar_fac, up->eps0,
+     bmag->on_dev,
+     qSelf, mSelf, m0Self->on_dev, vtSqSelf->on_dev,
+     qOther, mOther, m0Other->on_dev, vtSqOther->on_dev, nuOut->on_dev);
 }

--- a/zero/spitzer_coll_freq_cu.cu
+++ b/zero/spitzer_coll_freq_cu.cu
@@ -7,11 +7,10 @@ extern "C" {
 #include <gkyl_range.h>
 }
 
-GKYL_CU_D static inline void
+GKYL_CU_D void
 calc_nu_cu(const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
-  const struct gkyl_array* GKYL_RESTRICT vtSqSelf_d, const struct gkyl_array* GKYL_RESTRICT m0Other_d,
-  const struct gkyl_array* GKYL_RESTRICT vtSqOther_d, double normNu, long linidx,
-  struct gkyl_array* GKYL_RESTRICT nuOut_d)
+  const double* vtSqSelf_d, const double* GKYL_RESTRICT m0Other_d, const double* vtSqOther_d, double normNu, long linidx,
+  struct gkyl_array* GKYL_RESTRICT nuOut)
 {
   // Perform the multiplication of normNu*n_r/(v_ts^2+v_tr^2)^(3/2) via
   // quadrature in one cell.
@@ -37,8 +36,8 @@ calc_nu_cu(const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gk
       vtSqOther_q += vtSqOther_d[k]*b_ord[k];
     }
 
-    double nu_o = ((m0Other_q<0.) || (vtSqSelf_q<0.) || (vtSqOther_q<0.)) ?
-      1.e-40 : normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3);
+    double nu_o = ((m0Other_q>0.) && (vtSqSelf_q>0.) && (vtSqOther_q>0.)) ?
+      normNu*m0Other_q/pow(sqrt(vtSqSelf_q+vtSqOther_q),3) : 1.e-14;
 
     double tmp = w_d[n]*nu_o;
     for (int k=0; k<num_basis; ++k)
@@ -50,8 +49,8 @@ calc_nu_cu(const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gk
 __global__ static void
 gkyl_spitzer_coll_freq_advance_normnu_cu_ker(const struct gkyl_range range,
   const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
-  const struct gkyl_array* GKYL_RESTRICT vtSqSelf, const struct gkyl_array* GKYL_RESTRICT m0Other,
-  const struct gkyl_array* GKYL_RESTRICT vtSqOther, double normNu, struct gkyl_array* GKYL_RESTRICT nuOut)
+  const struct gkyl_array* vtSqSelf, const struct gkyl_array* GKYL_RESTRICT m0Other,
+  const struct gkyl_array* vtSqOther, double normNu, struct gkyl_array* GKYL_RESTRICT nuOut)
 {
   int idx[3];
   for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
@@ -64,7 +63,7 @@ gkyl_spitzer_coll_freq_advance_normnu_cu_ker(const struct gkyl_range range,
     const double *m0Other_d = (const double *) gkyl_array_cfetch(m0Other, linidx);
     const double *vtSqOther_d = (const double *) gkyl_array_cfetch(vtSqOther, linidx);
 
-    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut_d);
+    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut);
   }
 }
 
@@ -73,8 +72,8 @@ gkyl_spitzer_coll_freq_advance_cu_ker(const struct gkyl_range range,
   const struct gkyl_array* GKYL_RESTRICT basis_at_ords, const struct gkyl_array* GKYL_RESTRICT weights,
   double nufraceps0_fac, double cellav_fac, double r4pieps0_fac, double hbar_fac, double eps0,
   const struct gkyl_array* GKYL_RESTRICT bmag,
-  double qSelf, double mSelf, const struct gkyl_array* GKYL_RESTRICT m0Self, const struct gkyl_array* GKYL_RESTRICT vtSqSelf,
-  double qOther, double mOther, const struct gkyl_array* GKYL_RESTRICT m0Other, const struct gkyl_array* GKYL_RESTRICT vtSqOther,
+  double qSelf, double mSelf, const struct gkyl_array* m0Self, const struct gkyl_array* vtSqSelf,
+  double qOther, double mOther, const struct gkyl_array* m0Other, const struct gkyl_array* vtSqOther,
   struct gkyl_array* GKYL_RESTRICT nuOut)
 {
   double mReduced = 1./(1./mSelf+1./mOther);
@@ -87,8 +86,8 @@ gkyl_spitzer_coll_freq_advance_cu_ker(const struct gkyl_range range,
     gkyl_sub_range_inv_idx(&range, tid, idx);
     long linidx = gkyl_range_idx(&range, idx);
 
-    const double *bmag_d = gkyl_array_cfetch(bmag, linidx);
-    const double *m0Self_d = gkyl_array_cfetch(m0Self, linidx);
+    const double *bmag_d = (const double *) gkyl_array_cfetch(bmag, linidx);
+    const double *m0Self_d = (const double *) gkyl_array_cfetch(m0Self, linidx);
     const double *vtSqSelf_d = (const double *) gkyl_array_cfetch(vtSqSelf, linidx);
     const double *m0Other_d = (const double *) gkyl_array_cfetch(m0Other, linidx);
     const double *vtSqOther_d = (const double *) gkyl_array_cfetch(vtSqOther, linidx);
@@ -118,7 +117,7 @@ gkyl_spitzer_coll_freq_advance_cu_ker(const struct gkyl_range range,
     // Normalized nu (nu missing density and temperature factors).
     double normNu = timeConstFac*logLambda;
 
-    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut_d);
+    calc_nu_cu(basis_at_ords, weights, vtSqSelf_d, m0Other_d, vtSqOther_d, normNu, linidx, nuOut);
   }
 }
 
@@ -130,9 +129,8 @@ gkyl_spitzer_coll_freq_advance_normnu_cu(const gkyl_spitzer_coll_freq *up,
 {
   int nblocks = range->nblocks, nthreads = range->nthreads;
   gkyl_spitzer_coll_freq_advance_normnu_cu_ker<<<nblocks, nthreads>>>
-    (*range, up->basis_at_ords->on_dev,
-     up->weights->on_dev, vtSqSelf->on_dev,
-     m0Other->on_dev, vtSqOther->on_dev, normNu, nuOut->on_dev);
+    (*range, up->basis_at_ords->on_dev, up->weights->on_dev,
+     vtSqSelf->on_dev, m0Other->on_dev, vtSqOther->on_dev, normNu, nuOut->on_dev);
 }
 
 void
@@ -140,7 +138,7 @@ gkyl_spitzer_coll_freq_advance_cu(const gkyl_spitzer_coll_freq *up,
   const struct gkyl_range *range, const struct gkyl_array *bmag,
   double qSelf, double mSelf, const struct gkyl_array *m0Self, const struct gkyl_array *vtSqSelf,
   double qOther, double mOther, const struct gkyl_array *m0Other, const struct gkyl_array *vtSqOther,
-  struct gkyl_array *nuOut);
+  struct gkyl_array *nuOut)
 {
   int nblocks = range->nblocks, nthreads = range->nthreads;
   gkyl_spitzer_coll_freq_advance_cu_ker<<<nblocks, nthreads>>>


### PR DESCRIPTION
- Create a gyrokinetic updater which wraps hyper_dg and the GK equation object. Tested via g2.
- Implement option in the Spitzer collisionality updater to build the collision frequency from scratch (not normNu), and make other minor changes to normNu.

At first I tried to run the GK 1x2v-p1 sheath test with normNu, and I encountered issues of variable results on the GPU or GPU results that don't match the CPU results. This is still the case. However at higher resolution (2X in all dimensions) those problems go away. I don't understand why the coarse grid behavior is so erratic. It improves if moments and primitive are computed on the CPU. I implemented GPU unit tests for GK moments and didn't find errors though.

Somewhat unsatisfactory but I'm afraid this will have to do for now.