### PR TITLE
Merge grad closure

### DIFF
--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -12,6 +12,7 @@
 struct gkyl_moment_species {
   char name[128]; // species name
   double charge, mass; // charge and mass
+  bool has_grad_closure; // has gradient-based closure (only for 10 moment)
   enum gkyl_wave_limiter limiter; // limiter to use
   struct gkyl_wv_eqn *equation; // equation object
 

--- a/apps/gkyl_moment_priv.h
+++ b/apps/gkyl_moment_priv.h
@@ -139,10 +139,15 @@ struct moment_field {
 
 // Source data
 struct moment_coupling {
-  gkyl_moment_em_coupling *slvr; // source solver function
+  struct gkyl_rect_grid non_ideal_grid; // grid for braginskii variables (braginskii variables located at cell nodes)
+  struct gkyl_range non_ideal_local, non_ideal_local_ext; // local, local-ext ranges for braginskii variables (loop over nodes)
+
   gkyl_ten_moment_grad_closure *grad_closure_slvr[GKYL_MAX_SPECIES]; // Gradient-based closure solver (if present)
-  struct gkyl_array *cflrate; // array for stable time-step from non-ideal terms
-  struct gkyl_array *rhs[GKYL_MAX_SPECIES]; // array for storing RHS of each species from non-ideal term updates (Braginskii/Gradient-based closure)
+  struct gkyl_array *non_ideal_cflrate[GKYL_MAX_SPECIES]; // array for stable time-step from non-ideal terms
+  struct gkyl_array *non_ideal_vars[GKYL_MAX_SPECIES]; // array for non-ideal variables (heat-flux tensor)
+  struct gkyl_array *rhs[GKYL_MAX_SPECIES]; // array for storing RHS of each species from non-ideal term updates (Gradient-based closure)
+
+  gkyl_moment_em_coupling *slvr; // source solver function
 };
 
 struct mhd_src {

--- a/apps/mom_coupling.c
+++ b/apps/mom_coupling.c
@@ -17,11 +17,28 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
       .type = app->species[i].eqn_type,
       .charge = app->species[i].charge,
       .mass = app->species[i].mass,
-      .k0 = app->species[i].k0
+      .k0 = app->species[i].has_grad_closure ? 0.0 : app->species[i].k0,
     };
 
   // create updater to solve for sources
   src->slvr = gkyl_moment_em_coupling_new(src_inp);
+
+  for (int n=0; n<app->num_species; ++n) {
+    int meqn = app->species[n].num_equations;
+    src->rhs[n] = mkarr(false, meqn, app->local_ext.volume);
+  }
+  src->cflrate = mkarr(false, 1, app->local_ext.volume); 
+
+  // check if gradient-closure is present
+  for (int i=0; i<app->num_species; ++i) {
+    if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure) {
+      struct gkyl_ten_moment_grad_closure_inp grad_closure_inp = {
+        .grid = &app->grid,
+        .k0 = app->species[i].k0,
+      };
+      src->grad_closure_slvr[i] = gkyl_ten_moment_grad_closure_new(grad_closure_inp);      
+    }
+  }
 }
 
 // update sources: 'nstrang' is 0 for the first Strang step and 1 for
@@ -33,13 +50,20 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
   int sidx[] = { 0, app->ndim };
   struct gkyl_array *fluids[GKYL_MAX_SPECIES];
   const struct gkyl_array *app_accels[GKYL_MAX_SPECIES];
+  const struct gkyl_array *rhs_const[GKYL_MAX_SPECIES];
   
   for (int i=0; i<app->num_species; ++i) {
     fluids[i] = app->species[i].f[sidx[nstrang]];
-    
+
     if (app->species[i].proj_app_accel)
       gkyl_fv_proj_advance(app->species[i].proj_app_accel, tcurr, &app->local, app->species[i].app_accel);
     app_accels[i] = app->species[i].app_accel;
+
+    if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure) {
+      gkyl_ten_moment_grad_closure_advance(src->grad_closure_slvr[i], &app->local, 
+        app->species[i].f[sidx[nstrang]], app->field.f[sidx[nstrang]], 
+        src->cflrate, src->rhs[i]);
+    }
   }
   
   if (app->field.proj_app_current)
@@ -56,8 +80,12 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
       app->field.was_ext_em_computed = false;
   }
 
+  // Get the RHS pointer for accumulation during source update
+  for (int i=0; i<app->num_species; ++i)
+    rhs_const[i] = src->rhs[i];
+
   gkyl_moment_em_coupling_advance(src->slvr, dt, &app->local,
-    fluids, app_accels,
+    fluids, app_accels, rhs_const, 
     app->field.f[sidx[nstrang]], app->field.app_current, app->field.ext_em);
 
   for (int i=0; i<app->num_species; ++i)
@@ -68,8 +96,14 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
 
 // free sources
 void
-moment_coupling_release(const struct moment_coupling *src)
+moment_coupling_release(const struct gkyl_moment_app *app, const struct moment_coupling *src)
 {
   gkyl_moment_em_coupling_release(src->slvr);
+  for (int i=0; i<app->num_species; ++i) {
+    gkyl_array_release(src->rhs[i]);
+    if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure)
+      gkyl_ten_moment_grad_closure_release(src->grad_closure_slvr[i]);
+  }
+  gkyl_array_release(src->cflrate);
 }
 

--- a/apps/mom_priv.c
+++ b/apps/mom_priv.c
@@ -48,6 +48,47 @@ moment_apply_periodic_bc(const gkyl_moment_app *app, struct gkyl_array *bc_buffe
   gkyl_array_copy_from_buffer(f, bc_buffer->data, app->skin_ghost.lower_ghost[dir]);
 }
 
+void
+moment_apply_periodic_corner_sync_2d(const gkyl_moment_app *app, struct gkyl_array *f)
+{
+  long idx_src, idx_dest;
+  double *out;
+  const double *inp;
+  if (app->ndim == 2) {
+    // LL skin cell -> UU ghost cell
+    idx_src = gkyl_range_idx(&app->local, (int[]) {app->local.lower[0],app->local.lower[1]});
+    idx_dest = gkyl_range_idx(&app->local, (int[]) {app->local.upper[0]+1,app->local.upper[1]+1});
+    
+    out = (double*) gkyl_array_fetch(f, idx_dest);
+    inp = (const double*) gkyl_array_cfetch(f, idx_src);
+    gkyl_copy_double_arr(f->ncomp, inp, out);
+
+    // LU skin cell -> UL ghost cell
+    idx_src = gkyl_range_idx(&app->local, (int[]) {app->local.lower[0],app->local.upper[1]});
+    idx_dest = gkyl_range_idx(&app->local_ext, (int[]) {app->local.upper[0]+1,app->local.lower[1]-1});
+    
+    out = (double*) gkyl_array_fetch(f, idx_dest);
+    inp = (const double*) gkyl_array_cfetch(f, idx_src);
+    gkyl_copy_double_arr(f->ncomp, inp, out);
+
+    // UL skin cell -> LU ghost cell
+    idx_src = gkyl_range_idx(&app->local, (int[]) {app->local.upper[0],app->local.lower[1]});
+    idx_dest = gkyl_range_idx(&app->local_ext, (int[]) {app->local.lower[0]-1,app->local.upper[1]+1});
+    
+    out = (double*) gkyl_array_fetch(f, idx_dest);
+    inp = (const double*) gkyl_array_cfetch(f, idx_src);
+    gkyl_copy_double_arr(f->ncomp, inp, out);
+
+    // UU skin cell -> LL ghost cell
+    idx_src = gkyl_range_idx(&app->local, (int[]) {app->local.upper[0],app->local.upper[1]});
+    idx_dest = gkyl_range_idx(&app->local_ext, (int[]) {app->local.lower[0]-1,app->local.lower[1]-1});
+    
+    out = (double*) gkyl_array_fetch(f, idx_dest);
+    inp = (const double*) gkyl_array_cfetch(f, idx_src);
+    gkyl_copy_double_arr(f->ncomp, inp, out);
+  }
+}
+
 // apply wedge BCs
 void
 moment_apply_wedge_bc(const gkyl_moment_app *app, double tcurr,

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -20,6 +20,8 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
   
   // closure parameter, used by 10 moment
   sp->k0 = mom_sp->equation->type == GKYL_EQN_TEN_MOMENT ? gkyl_wv_ten_moment_k0(mom_sp->equation) : 0.0;
+  // check if we are running with gradient-based closure
+  sp->has_grad_closure = mom_sp->has_grad_closure == 0 ? 0 : mom_sp->has_grad_closure;
 
   sp->scheme_type = mom->scheme_type;
 
@@ -220,7 +222,8 @@ moment_species_apply_bc(const gkyl_moment_app *app, double tcurr,
     moment_apply_periodic_bc(app, sp->bc_buffer, app->periodic_dirs[d], f);
     is_non_periodic[app->periodic_dirs[d]] = 0;
   }
-  
+  if (ndim == 2)
+    moment_apply_periodic_corner_sync_2d(app, f);
   for (int d=0; d<ndim; ++d)
     if (is_non_periodic[d]) {
       // handle non-wedge BCs

--- a/apps/moment.c
+++ b/apps/moment.c
@@ -393,7 +393,7 @@ gkyl_moment_app_release(gkyl_moment_app* app)
     moment_field_release(&app->field);
 
   if (app->update_sources)
-    moment_coupling_release(&app->sources);
+    moment_coupling_release(app, &app->sources);
 
   if (app->update_mhd_source)
     mhd_src_release(&app->mhd_source);

--- a/regression/rt_10m_burch_grad_closure.c
+++ b/regression/rt_10m_burch_grad_closure.c
@@ -1,0 +1,362 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_ten_moment.h>
+#include <rt_arg_parse.h>
+
+void
+evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = ionMass/100.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double vAe = 0.2;
+  double n0 = 1.0;
+  double B0 = vAe*sqrt(n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+  double w0 = 1.0*di;
+  double psi0 = 0.1*B0*di;
+  double guide1 = 0.099*B0;
+  double guide2 = 0.099*B0;
+
+  double b1 = 1.696*B0;
+  double b2 = 1.00*B0;
+  double n1 = 0.062*n0;
+  double n2 = 1.0*n0;
+  double beta2 = 2.748;
+  double T_i2 = beta2*(b2*b2) / (2.0*n2*mu0);
+  double T_i1_T_i2 = 7.73 / 1.374;
+  double T_e1_T_i2 = 1.288 / 1.374;
+
+  double T_e1 = T_i2*T_e1_T_i2;
+  double T_i1  = T_i2*T_i1_T_i2;
+
+  // derived quantities (asymptotic values)
+  double T_e2 = (0.5*(b1*b1-b2*b2)+0.5*(guide1*guide1-guide2*guide2)+n1*(T_i1+T_e1)-n2*T_i2)/n2; //so the system is in force balance
+
+  double Lx = 40.96*di;
+  double Ly = 20.48*di;
+
+  double b1x = 0.5*(b2+b1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(b2-b1);
+  double b1y = 0.0;
+  double b1z = 0.5*(guide2-guide1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(guide2+guide1);
+
+  double Tvali = 0.5*(T_i2-T_i1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_i2+T_i1);
+  double Tvale = 0.5*(T_e2-T_e1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_e2+T_e1);
+  double n = (0.5*(b1*b1 - b1x*b1x) +0.5*(guide1*guide1 - b1z*b1z) + n1*(T_i1+T_e1))/(Tvali+Tvale);
+
+  double Bx = b1x - psi0*4.0*pi/Ly*sin(2.0*pi*x/Lx)*sin(4.0*pi*y/Ly);
+  double By = b1y + psi0*2.0*pi/Lx*cos(2.0*pi*x/Lx)*(1-cos(4.0*pi*y/Ly));
+  double Bz = b1z;
+
+  double TeFrac = Tvale/(Tvale + Tvali);
+  double TiFrac = Tvali/(Tvale + Tvali);
+
+  double Jx = 0.5*(guide2-guide1)/w0*((1.0/cosh((y-Ly*.25)/w0))*(1.0/cosh((y-Ly*.25)/w0)) 
+    - (1.0/cosh((y-Ly*.75)/w0))*(1.0/cosh((y-Ly*.75)/w0)) 
+    + (1.0/cosh((y-Ly*1.25)/w0))*(1.0/cosh((y-Ly*1.25)/w0)) 
+    - (1.0/cosh((y+Ly*.25)/w0))*(1.0/cosh((y+Ly*.25)/w0)));
+  double Jy = 0.0;
+  double Jz  = -0.5*(b2+b1)/w0*((1.0/cosh((y-Ly*.25)/w0))*(1.0/cosh((y-Ly*.25)/w0)) 
+    - (1.0/cosh((y-Ly*.75)/w0))*(1.0/cosh((y-Ly*.75)/w0)) 
+    + (1.0/cosh((y-Ly*1.25)/w0))*(1.0/cosh((y-Ly*1.25)/w0)) 
+    - (1.0/cosh((y+Ly*.25)/w0))*(1.0/cosh((y+Ly*.25)/w0))) 
+    - psi0*sin(2.0*pi*x/Lx)*((2.0*pi/Lx)*(2.0*pi/Lx)*(1 - cos(4.0*pi*y/Ly)) + (4.0*pi/Ly)*(4.0*pi/Ly)*cos(4.0*pi*y/Ly));
+   
+  double Jxe = Jx*TeFrac;
+  double Jye = Jy*TeFrac;
+  double Jze = Jz*TeFrac;
+
+  double rhoe = elcMass*n;
+  double momxe = (elcMass/elcCharge)*Jxe;
+  double momye = (elcMass/elcCharge)*Jye;
+  double momze = (elcMass/elcCharge)*Jze;
+  double pxxe = n*Tvale + momxe*momxe/rhoe;
+  double pxye = momxe*momye/rhoe;
+  double pxze = momxe*momze/rhoe;
+  double pyye = n*Tvale + momye*momye/rhoe;
+  double pyze = momye*momye/rhoe;
+  double pzze = n*Tvale + momze*momze/rhoe;
+
+  fout[0] = rhoe;
+  fout[1] = momxe; fout[2] = momye; fout[3] = momze;
+  fout[4] = pxxe; fout[5] = pxye; fout[6] = pxze;  
+  fout[7] = pyye; fout[8] = pyze; fout[9] = pzze;
+}
+
+void
+evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = ionMass/100.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double vAe = 0.2;
+  double n0 = 1.0;
+  double B0 = vAe*sqrt(n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+  double w0 = 1.0*di;
+  double psi0 = 0.1*B0*di;
+  double guide1 = 0.099*B0;
+  double guide2 = 0.099*B0;
+
+  double b1 = 1.696*B0;
+  double b2 = 1.00*B0;
+  double n1 = 0.062*n0;
+  double n2 = 1.0*n0;
+  double beta2 = 2.748;
+  double T_i2 = beta2*(b2*b2) / (2.0*n2*mu0);
+  double T_i1_T_i2 = 7.73 / 1.374;
+  double T_e1_T_i2 = 1.288 / 1.374;
+
+  double T_e1 = T_i2*T_e1_T_i2;
+  double T_i1  = T_i2*T_i1_T_i2;
+
+  // derived quantities (asymptotic values)
+  double T_e2 = (0.5*(b1*b1-b2*b2)+0.5*(guide1*guide1-guide2*guide2)+n1*(T_i1+T_e1)-n2*T_i2)/n2; //so the system is in force balance
+
+  double Lx = 40.96*di;
+  double Ly = 20.48*di;
+
+  double b1x = 0.5*(b2+b1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(b2-b1);
+  double b1y = 0.0;
+  double b1z = 0.5*(guide2-guide1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(guide2+guide1);
+  
+  double Tvali = 0.5*(T_i2-T_i1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_i2+T_i1);
+  double Tvale = 0.5*(T_e2-T_e1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_e2+T_e1);
+  double n = (0.5*(b1*b1 - b1x*b1x) +0.5*(guide1*guide1 - b1z*b1z) + n1*(T_i1+T_e1))/(Tvali+Tvale);
+
+  double Bx = b1x - psi0*4.0*pi/Ly*sin(2.0*pi*x/Lx)*sin(4.0*pi*y/Ly);
+  double By = b1y + psi0*2.0*pi/Lx*cos(2.0*pi*x/Lx)*(1-cos(4.0*pi*y/Ly));
+  double Bz = b1z;
+
+  double TeFrac = Tvale/(Tvale + Tvali);
+  double TiFrac = Tvali/(Tvale + Tvali);
+
+  double Jx = 0.5*(guide2-guide1)/w0*((1.0/cosh((y-Ly*.25)/w0))*(1.0/cosh((y-Ly*.25)/w0)) 
+    - (1.0/cosh((y-Ly*.75)/w0))*(1.0/cosh((y-Ly*.75)/w0)) 
+    + (1.0/cosh((y-Ly*1.25)/w0))*(1.0/cosh((y-Ly*1.25)/w0)) 
+    - (1.0/cosh((y+Ly*.25)/w0))*(1.0/cosh((y+Ly*.25)/w0)));
+  double Jy = 0.0;
+  double Jz  = -0.5*(b2+b1)/w0*((1.0/cosh((y-Ly*.25)/w0))*(1.0/cosh((y-Ly*.25)/w0)) 
+    - (1.0/cosh((y-Ly*.75)/w0))*(1.0/cosh((y-Ly*.75)/w0)) 
+    + (1.0/cosh((y-Ly*1.25)/w0))*(1.0/cosh((y-Ly*1.25)/w0)) 
+    - (1.0/cosh((y+Ly*.25)/w0))*(1.0/cosh((y+Ly*.25)/w0))) 
+    - psi0*sin(2.0*pi*x/Lx)*((2.0*pi/Lx)*(2.0*pi/Lx)*(1 - cos(4.0*pi*y/Ly)) + (4.0*pi/Ly)*(4.0*pi/Ly)*cos(4.0*pi*y/Ly));
+   
+  double Jxi = Jx*TiFrac;
+  double Jyi = Jy*TiFrac;
+  double Jzi = Jz*TiFrac;
+
+  double rhoi = ionMass*n;
+  double momxi = (ionMass/ionCharge)*Jxi;
+  double momyi = (ionMass/ionCharge)*Jyi;
+  double momzi = (ionMass/ionCharge)*Jzi;
+  double pxxi = n*Tvali + momxi*momxi/rhoi;
+  double pxyi = momxi*momyi/rhoi;
+  double pxzi = momxi*momzi/rhoi;
+  double pyyi = n*Tvali + momyi*momyi/rhoi;
+  double pyzi = momyi*momyi/rhoi;
+  double pzzi = n*Tvali + momzi*momzi/rhoi;
+
+  fout[0] = rhoi;
+  fout[1] = momxi; fout[2] = momyi; fout[3] = momzi;
+  fout[4] = pxxi; fout[5] = pxyi; fout[6] = pxzi;  
+  fout[7] = pyyi; fout[8] = pyzi; fout[9] = pzzi;   
+}
+
+void
+evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = ionMass/100.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double vAe = 0.2;
+  double n0 = 1.0;
+  double B0 = vAe*sqrt(n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+  double w0 = 1.0*di;
+  double psi0 = 0.1*B0*di;
+  double guide1 = 0.099*B0;
+  double guide2 = 0.099*B0;
+
+  double b1 = 1.696*B0;
+  double b2 = 1.00*B0;
+  double n1 = 0.062*n0;
+  double n2 = 1.0*n0;
+  double beta2 = 2.748;
+  double T_i2 = beta2*(b2*b2) / (2.0*n2*mu0);
+  double T_i1_T_i2 = 7.73 / 1.374;
+  double T_e1_T_i2 = 1.288 / 1.374;
+
+  double T_e1 = T_i2*T_e1_T_i2;
+  double T_i1  = T_i2*T_i1_T_i2;
+
+  // derived quantities (asymptotic values)
+  double T_e2 = (0.5*(b1*b1-b2*b2)+0.5*(guide1*guide1-guide2*guide2)+n1*(T_i1+T_e1)-n2*T_i2)/n2; //so the system is in force balance
+
+  double Lx = 40.96*di;
+  double Ly = 20.48*di;
+
+  double b1x = 0.5*(b2+b1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(b2-b1);
+  double b1y = 0.0;
+  double b1z = 0.5*(guide2-guide1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(guide2+guide1);
+  
+  double Tvali = 0.5*(T_i2-T_i1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_i2+T_i1);
+  double Tvale = 0.5*(T_e2-T_e1)*(tanh((y-Ly*.25)/w0)-tanh((y-Ly*.75)/w0) + tanh((y-Ly*1.25)/w0)-tanh((y+Ly*.25)/w0)+1)+0.5*(T_e2+T_e1);
+  double n = (0.5*(b1*b1 - b1x*b1x) +0.5*(guide1*guide1 - b1z*b1z) + n1*(T_i1+T_e1))/(Tvali+Tvale);
+
+  double Bx = b1x - psi0*4.0*pi/Ly*sin(2.0*pi*x/Lx)*sin(4.0*pi*y/Ly);
+  double By = b1y + psi0*2.0*pi/Lx*cos(2.0*pi*x/Lx)*(1-cos(4.0*pi*y/Ly));
+  double Bz = b1z;
+
+  // electric field
+  fout[0] = 0.0, fout[1] = 0.0; fout[2] = 0.0;
+  // magnetic field
+  fout[3] = Bx, fout[4] = By; fout[5] = Bz;
+
+  // correction potentials
+  fout[6] = 0.0; fout[7] = 0.0;
+}
+
+void
+write_data(struct gkyl_tm_trigger *iot, const gkyl_moment_app *app, double tcurr)
+{
+  if (gkyl_tm_trigger_check_and_bump(iot, tcurr))
+    gkyl_moment_app_write(app, tcurr, iot->curr-1);
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  // electron/ion equations
+  // d_e = 0.1, k0 = 1/d_e
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(10.0);
+  // d_i ~ 1.0, k0 = 1/(d_i)
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(1.0);
+
+  struct gkyl_moment_species elc = {
+    .name = "elc",
+    .charge = -1.0, .mass = 1.0/100.0,
+    .equation = elc_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalElcInit,
+  };
+  struct gkyl_moment_species ion = {
+    .name = "ion",
+    .charge = 1.0, .mass = 1.0,
+    .equation = ion_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalIonInit, 
+  };  
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "10m_burch_grad_closure",
+
+    .ndim = 2,
+    .lower = { 0.0, 0.0 },
+    .upper = { 40.96, 20.48 }, 
+    .cells = { 256, 128  },
+
+    .num_periodic_dir = 2,
+    .periodic_dirs = { 0, 1 },
+    .cfl_frac = 1.0,
+
+    .num_species = 2,
+    .species = { elc, ion },
+
+    .field = {
+      .epsilon0 = 1.0, .mu0 = 1.0,
+      .mag_error_speed_fact = 1.0,
+      
+      .evolve = 1,
+      .init = evalFieldInit,
+    }
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
+
+  // start, end and initial time-step
+  // OmegaCi^{-1} = 50 -> tend = 50 OmegaCi^{-1}
+  double tcurr = 0.0, tend = 2500.0;
+  int nframe = 50;
+  // create trigger for IO
+  struct gkyl_tm_trigger io_trig = { .dt = tend/nframe };
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  write_data(&io_trig, app, tcurr);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1;
+  while ((tcurr < tend) && (step <= app_args.num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    write_data(&io_trig, app, tcurr);
+
+    step += 1;
+  }
+
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Source updates took %g secs\n", stat.sources_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(elc_ten_moment);
+  gkyl_wv_eqn_release(ion_ten_moment);
+  gkyl_moment_app_release(app);  
+  
+  return 0;
+}

--- a/regression/rt_10m_gem_grad_closure.c
+++ b/regression/rt_10m_gem_grad_closure.c
@@ -1,0 +1,202 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_ten_moment.h>
+#include <rt_arg_parse.h>
+
+void
+evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double gasGamma = 5.0/3.0;
+  double elcMass = 1/25.0;
+  double elcCharge = -1.0;
+  double TiOverTe = 5.0;
+  double lambda = 0.5;
+  double n0 = 1.0;
+  double nbOverN0 = 0.2;
+  double B0 = 0.1;
+  double plasmaBeta = 1.0;
+  double TeFrac = 1.0/(1.0 + TiOverTe);
+  double sech2 = (1.0/cosh(y/lambda))*(1.0/cosh(y/lambda));
+
+  double n = n0*(sech2 + nbOverN0);
+  double Jz = -(B0/lambda)*sech2;
+  double Ttotal = plasmaBeta*(B0*B0)/2.0/n0;
+
+  double rhoe = n*elcMass;
+  double ezmom = (elcMass/elcCharge)*Jz*TeFrac;
+  double pre = n*Ttotal*TeFrac;
+
+  fout[0] = rhoe;
+  fout[1] = 0.0; fout[2] = 0.0; fout[3] = ezmom;
+  fout[4] = pre; fout[5] = 0.0; fout[6] = 0.0;  
+  fout[7] = pre; fout[8] = 0.0; fout[9] = pre + ezmom*ezmom/rhoe;  
+}
+
+void
+evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double gasGamma = 5.0/3.0;
+  double ionMass = 1.0;
+  double ionCharge = 1.0;
+  double TiOverTe = 5.0;
+  double lambda = 0.5;
+  double n0 = 1.0;
+  double nbOverN0 = 0.2;
+  double B0 = 0.1;
+  double plasmaBeta = 1.0;
+  double TiFrac = TiOverTe/(1.0 + TiOverTe);
+  double sech2 = (1.0/cosh(y/lambda))*(1.0/cosh(y/lambda));
+
+  double n = n0*(sech2 + nbOverN0);
+  double Jz = -(B0/lambda)*sech2;
+  double Ttotal = plasmaBeta*(B0*B0)/2.0/n0;
+
+  double rhoi = n*ionMass;
+  double izmom = (ionMass/ionCharge)*Jz*TiFrac;
+  double pri = n*Ttotal*TiFrac;
+
+  fout[0] = rhoi;
+  fout[1] = 0.0; fout[2] = 0.0; fout[3] = izmom;
+  fout[4] = pri; fout[5] = 0.0; fout[6] = 0.0;  
+  fout[7] = pri; fout[8] = 0.0; fout[9] = pri + izmom*izmom/rhoi;   
+}
+
+void
+evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double pi = 3.141592653589793238462643383279502884;
+  double lambda = 0.5;
+  double B0 = 0.1;
+  double psi0 = 0.1*B0;
+
+  double Lx = 25.6;
+  double Ly = 12.8;
+
+  double Bxb = B0 * tanh(y / lambda);
+  double Bx = Bxb - psi0 *(pi / Ly) * cos(2 * pi * x / Lx) * sin(pi * y / Ly);
+  double By = psi0 * (2 * pi / Lx) * sin(2 * pi * x / Lx) * cos(pi * y / Ly);
+  double Bz = 0.0;
+
+  // electric field
+  fout[0] = 0.0, fout[1] = 0.0; fout[2] = 0.0;
+  // magnetic field
+  fout[3] = Bx, fout[4] = By; fout[5] = Bz;
+
+  // correction potentials
+  fout[6] = 0.0; fout[7] = 0.0;
+}
+
+int
+main(int argc, char **argv)
+{
+  // d_e = 0.2, k0 = 1/d_e
+  double k0 = 5.0;
+  
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  // electron/ion equations
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(k0);
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(k0);
+
+  struct gkyl_moment_species elc = {
+    .name = "elc",
+    .charge = -1.0, .mass = 1.0/25.0,
+    .equation = elc_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalElcInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },   
+  };
+  struct gkyl_moment_species ion = {
+    .name = "ion",
+    .charge = 1.0, .mass = 1.0,
+    .equation = ion_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalIonInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },     
+  };  
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "10m_gem_grad_closure",
+
+    .ndim = 2,
+    .lower = { -12.8, -6.4 },
+    .upper = { 12.8, 6.4 }, 
+    .cells = { 128, 64  },
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 0 },
+    .cfl_frac = 1.0,
+
+    .num_species = 2,
+    .species = { elc, ion },
+
+    .field = {
+      .epsilon0 = 1.0, .mu0 = 1.0,
+      .mag_error_speed_fact = 1.0,
+      
+      .evolve = 1,
+      .init = evalFieldInit,
+      
+      .bcy = { GKYL_FIELD_PEC_WALL, GKYL_FIELD_PEC_WALL },
+    }
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = 1.0;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1;
+  while ((tcurr < tend) && (step <= app_args.num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Source updates took %g secs\n", stat.sources_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(elc_ten_moment);
+  gkyl_wv_eqn_release(ion_ten_moment);
+  gkyl_moment_app_release(app);  
+  
+  return 0;
+}

--- a/regression/rt_10m_lhdi.c
+++ b/regression/rt_10m_lhdi.c
@@ -1,0 +1,293 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_ten_moment.h>
+#include <rt_arg_parse.h>
+
+void
+evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+  double sech2 = (1.0/cosh(y/l))*(1.0/cosh(y/l));
+
+  double n = n0*sech2;
+  double nBackground = n0*nbOverN0;
+  double TeFrac = elcTemp / (elcTemp + ionTemp);
+  double TiFrac = 1.0 - TeFrac;
+  double i_y = 1.0;
+  double i_x = mode;
+  double JxNoise = -noiseAmp*(i_y*M_PI/Ly)*sin(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double JyNoise = -noiseAmp*(i_x*2.0*M_PI/Lx)*cos(i_y*M_PI*y/Ly)*cos(i_x*2.0*M_PI*x/Lx)/mode;
+
+  double Jx  = (B0/l)*(-sech2) + JxNoise;
+  double Jy  = JyNoise;
+
+  double rhoe = n*elcMass;
+  double exmom = (elcMass/elcCharge)*Jx*TeFrac;
+  double eymom = (elcMass/elcCharge)*Jy*TeFrac;
+  double pre = n*elcTemp;
+
+  fout[0] = rhoe;
+  fout[1] = exmom; fout[2] = eymom; fout[3] = 0.0;
+  fout[4] = pre + exmom*exmom/rhoe; fout[5] = exmom*eymom/rhoe; fout[6] = 0.0;  
+  fout[7] = pre + eymom*eymom/rhoe; fout[8] = 0.0; fout[9] = pre;  
+}
+
+void
+evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+  double sech2 = (1.0/cosh(y/l))*(1.0/cosh(y/l));
+
+  double n = n0*sech2;
+  double nBackground = n0*nbOverN0;
+  double TeFrac = elcTemp / (elcTemp + ionTemp);
+  double TiFrac = 1.0 - TeFrac;
+  double i_y = 1.0;
+  double i_x = mode;
+  double JxNoise = -noiseAmp*(i_y*M_PI/Ly)*sin(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double JyNoise = -noiseAmp*(i_x*2.0*M_PI/Lx)*cos(i_y*M_PI*y/Ly)*cos(i_x*2.0*M_PI*x/Lx)/mode;
+
+  double Jx  = (B0/l)*(-sech2) + JxNoise;
+  double Jy  = JyNoise;
+
+  double rhoi = n*ionMass;
+  double ixmom = (ionMass/ionCharge)*Jx*TiFrac;
+  double iymom = (ionMass/ionCharge)*Jy*TiFrac;
+  double pri = n*ionTemp;
+
+  fout[0] = rhoi;
+  fout[1] = ixmom; fout[2] = iymom; fout[3] = 0.0;
+  fout[4] = pri + ixmom*ixmom/rhoi; fout[5] = ixmom*iymom/rhoi; fout[6] = 0.0;  
+  fout[7] = pri + iymom*iymom/rhoi; fout[8] = 0.0; fout[9] = pri; 
+}
+
+void
+evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+
+  double i_y = 1.0;
+  double i_x = mode;
+  double BzNoise = noiseAmp*cos(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double Bzb = -B0*tanh(y/l);
+  double Bx = 0.0;
+  double By = 0.0;
+  double Bz = Bzb + BzNoise;
+
+  // electric field
+  fout[0] = 0.0, fout[1] = 0.0; fout[2] = 0.0;
+  // magnetic field
+  fout[3] = Bx, fout[4] = By; fout[5] = Bz;
+
+  // correction potentials
+  fout[6] = 0.0; fout[7] = 0.0;
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  // electron/ion equations
+  // d_e = 1.0, k0 = 1/d_e
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(1.0);
+  // d_i = 6.0, k0 = 1/d_i
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(1.0/6.0);
+
+  struct gkyl_moment_species elc = {
+    .name = "elc",
+    .charge = -1.0, .mass = 1.0,
+    .equation = elc_ten_moment,
+    .evolve = 1,
+    .init = evalElcInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },   
+  };
+  struct gkyl_moment_species ion = {
+    .name = "ion",
+    .charge = 1.0, .mass = 36.0,
+    .equation = ion_ten_moment,
+    .evolve = 1,
+    .init = evalIonInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },   
+  };  
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "10m_lhdi",
+
+    .ndim = 2,
+    .lower = { -3.2*5.720775535473554, -6.4*5.720775535473554 },
+    .upper = { 3.2*5.720775535473554, 6.4*5.720775535473554 }, 
+    .cells = { 64, 128  },
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 0 },
+    .cfl_frac = 1.0,
+
+    .num_species = 2,
+    .species = { elc, ion },
+
+    .field = {
+      .epsilon0 = 1.0, .mu0 = 1.0,
+      .mag_error_speed_fact = 1.0,
+      
+      .evolve = 1,
+      .init = evalFieldInit,
+      
+      .bcy = { GKYL_FIELD_PEC_WALL, GKYL_FIELD_PEC_WALL },
+    }
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
+
+  // start, end and initial time-step
+  // OmegaCi^{-1} ~ 181 -> tend ~ 6 OmegaCi^{-1}
+  double tcurr = 0.0, tend = 1100.0;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1;
+  while ((tcurr < tend) && (step <= app_args.num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Source updates took %g secs\n", stat.sources_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(elc_ten_moment);
+  gkyl_wv_eqn_release(ion_ten_moment);
+  gkyl_moment_app_release(app);  
+  
+  return 0;
+}

--- a/regression/rt_10m_lhdi_grad_closure.c
+++ b/regression/rt_10m_lhdi_grad_closure.c
@@ -1,0 +1,295 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_ten_moment.h>
+#include <rt_arg_parse.h>
+
+void
+evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+  double sech2 = (1.0/cosh(y/l))*(1.0/cosh(y/l));
+
+  double n = n0*sech2;
+  double nBackground = n0*nbOverN0;
+  double TeFrac = elcTemp / (elcTemp + ionTemp);
+  double TiFrac = 1.0 - TeFrac;
+  double i_y = 1.0;
+  double i_x = mode;
+  double JxNoise = -noiseAmp*(i_y*M_PI/Ly)*sin(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double JyNoise = -noiseAmp*(i_x*2.0*M_PI/Lx)*cos(i_y*M_PI*y/Ly)*cos(i_x*2.0*M_PI*x/Lx)/mode;
+
+  double Jx  = (B0/l)*(-sech2) + JxNoise;
+  double Jy  = JyNoise;
+
+  double rhoe = n*elcMass;
+  double exmom = (elcMass/elcCharge)*Jx*TeFrac;
+  double eymom = (elcMass/elcCharge)*Jy*TeFrac;
+  double pre = n*elcTemp;
+
+  fout[0] = rhoe;
+  fout[1] = exmom; fout[2] = eymom; fout[3] = 0.0;
+  fout[4] = pre + exmom*exmom/rhoe; fout[5] = exmom*eymom/rhoe; fout[6] = 0.0;  
+  fout[7] = pre + eymom*eymom/rhoe; fout[8] = 0.0; fout[9] = pre;  
+}
+
+void
+evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+  double sech2 = (1.0/cosh(y/l))*(1.0/cosh(y/l));
+
+  double n = n0*sech2;
+  double nBackground = n0*nbOverN0;
+  double TeFrac = elcTemp / (elcTemp + ionTemp);
+  double TiFrac = 1.0 - TeFrac;
+  double i_y = 1.0;
+  double i_x = mode;
+  double JxNoise = -noiseAmp*(i_y*M_PI/Ly)*sin(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double JyNoise = -noiseAmp*(i_x*2.0*M_PI/Lx)*cos(i_y*M_PI*y/Ly)*cos(i_x*2.0*M_PI*x/Lx)/mode;
+
+  double Jx  = (B0/l)*(-sech2) + JxNoise;
+  double Jy  = JyNoise;
+
+  double rhoi = n*ionMass;
+  double ixmom = (ionMass/ionCharge)*Jx*TiFrac;
+  double iymom = (ionMass/ionCharge)*Jy*TiFrac;
+  double pri = n*ionTemp;
+
+  fout[0] = rhoi;
+  fout[1] = ixmom; fout[2] = iymom; fout[3] = 0.0;
+  fout[4] = pri + ixmom*ixmom/rhoi; fout[5] = ixmom*iymom/rhoi; fout[6] = 0.0;  
+  fout[7] = pri + iymom*iymom/rhoi; fout[8] = 0.0; fout[9] = pri; 
+}
+
+void
+evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  double elcMass = 1.0;
+  double elcCharge = -1.0;
+  double ionMass = 36.0;
+  double ionCharge = 1.0;
+  double Te_Ti = 0.1;
+
+  // Initial conditions
+  double n0 = 1.0;
+  double nbOverN0 = 0.001;
+  double vtElc = 0.06;
+  double elcTemp = vtElc*vtElc*elcMass/2.0;
+  double ionTemp = elcTemp/Te_Ti;
+  double vtIon = sqrt(2.0*ionTemp/ionMass);
+
+  // electron beta
+  double beta = 1.0/11.0; // total beta = 1.0 = ion beta + electron beta
+  double vAe = vtElc/sqrt(beta);
+  double B0 = vAe; // derived from normalization of elcMass and n0
+  double vAi = vAe/sqrt(ionMass);
+
+  double omegaCi = ionCharge*B0/ionMass;
+  double omegaCe = ionCharge*B0/elcMass;
+
+  double larmor_elc = vtElc/omegaCe;
+  double larmor_ion = vtIon/omegaCi;
+
+  // perturbation
+  double noiseAmp = 0.0001;
+  double mode = 8.0;
+
+  double l = larmor_ion; // Current sheet width
+  double Lx = 6.4*l;
+  double Ly = 12.8*l;
+
+  double i_y = 1.0;
+  double i_x = mode;
+  double BzNoise = noiseAmp*cos(i_y*M_PI*y/Ly)*sin(i_x*2.0*M_PI*x/Lx)/mode;
+  double Bzb = -B0*tanh(y/l);
+  double Bx = 0.0;
+  double By = 0.0;
+  double Bz = Bzb + BzNoise;
+
+  // electric field
+  fout[0] = 0.0, fout[1] = 0.0; fout[2] = 0.0;
+  // magnetic field
+  fout[3] = Bx, fout[4] = By; fout[5] = Bz;
+
+  // correction potentials
+  fout[6] = 0.0; fout[7] = 0.0;
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+  // electron/ion equations
+  // d_e = 1.0, k0 = 1/d_e
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(1.0);
+  // d_i = 6.0, k0 = 1/d_i
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(1.0/6.0);
+
+  struct gkyl_moment_species elc = {
+    .name = "elc",
+    .charge = -1.0, .mass = 1.0,
+    .equation = elc_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalElcInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },   
+  };
+  struct gkyl_moment_species ion = {
+    .name = "ion",
+    .charge = 1.0, .mass = 36.0,
+    .equation = ion_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalIonInit,
+
+    .bcy = { GKYL_SPECIES_REFLECT, GKYL_SPECIES_REFLECT },   
+  };  
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "10m_lhdi_grad_closure",
+
+    .ndim = 2,
+    .lower = { -3.2*5.720775535473554, -6.4*5.720775535473554 },
+    .upper = { 3.2*5.720775535473554, 6.4*5.720775535473554 }, 
+    .cells = { 64, 128  },
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 0 },
+    .cfl_frac = 1.0,
+
+    .num_species = 2,
+    .species = { elc, ion },
+
+    .field = {
+      .epsilon0 = 1.0, .mu0 = 1.0,
+      .mag_error_speed_fact = 1.0,
+      
+      .evolve = 1,
+      .init = evalFieldInit,
+      
+      .bcy = { GKYL_FIELD_PEC_WALL, GKYL_FIELD_PEC_WALL },
+    }
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
+
+  // start, end and initial time-step
+  // OmegaCi^{-1} ~ 181 -> tend ~ 6 OmegaCi^{-1}
+  double tcurr = 0.0, tend = 1100.0;
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  gkyl_moment_app_write(app, tcurr, 0);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1;
+  while ((tcurr < tend) && (step <= app_args.num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    step += 1;
+  }
+
+  gkyl_moment_app_write(app, tcurr, 1);
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Source updates took %g secs\n", stat.sources_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(elc_ten_moment);
+  gkyl_wv_eqn_release(ion_ten_moment);
+  gkyl_moment_app_release(app);  
+  
+  return 0;
+}

--- a/regression/rt_10m_par_firehose_grad_closure.c
+++ b/regression/rt_10m_par_firehose_grad_closure.c
@@ -1,0 +1,280 @@
+#include <math.h>
+#include <stdio.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_moment.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_ten_moment.h>
+#include <rt_arg_parse.h>
+
+void
+evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1836.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = 1.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double Te_Ti = 1.0; // Ratio of electron to proton temperature
+  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
+  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
+  double n0 = 1.0; // Initial reference number density.
+  double B0 = vAe*sqrt(mu0*n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+
+  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
+  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
+  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
+  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
+  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+
+  double vtElc = vAe*sqrt(beta);
+  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
+  double elcTemp = vtElc*vtElc/2.0;
+
+  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
+  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
+
+  double rhoe = elcMass*n0;
+  double momxe = 0.0;
+  double momye = 0.0;
+  double momze = 0.0;
+  double pxxe = n0*elcTemp + momxe*momxe/rhoe;
+  double pxye = momxe*momye/rhoe;
+  double pxze = momxe*momze/rhoe;
+  double pyye = n0*elcTemp + momye*momye/rhoe;
+  double pyze = momye*momye/rhoe;
+  double pzze = n0*elcTemp + momze*momze/rhoe;
+
+  fout[0] = rhoe;
+  fout[1] = momxe; fout[2] = momye; fout[3] = momze;
+  fout[4] = pxxe; fout[5] = pxye; fout[6] = pxze;  
+  fout[7] = pyye; fout[8] = pyze; fout[9] = pzze;
+}
+
+void
+evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1836.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = 1.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double Te_Ti = 1.0; // Ratio of electron to proton temperature
+  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
+  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
+  double n0 = 1.0; // Initial reference number density.
+  double B0 = vAe*sqrt(mu0*n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+
+  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
+  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
+  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
+  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
+  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+
+  double vtElc = vAe*sqrt(beta);
+  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
+  double elcTemp = vtElc*vtElc/2.0;
+
+  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
+  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
+
+  double rhoi = ionMass*n0;
+  double momxi = 0.0;
+  double momyi = 0.0;
+  double momzi = 0.0;
+  double pxxi = n0*ionTempPar + momxi*momxi/rhoi;
+  double pxyi = momxi*momyi/rhoi;
+  double pxzi = momxi*momzi/rhoi;
+  double pyyi = n0*ionTempPerp + momyi*momyi/rhoi;
+  double pyzi = momyi*momyi/rhoi;
+  double pzzi = n0*ionTempPerp + momzi*momzi/rhoi;
+
+  fout[0] = rhoi;
+  fout[1] = momxi; fout[2] = momyi; fout[3] = momzi;
+  fout[4] = pxxi; fout[5] = pxyi; fout[6] = pxzi;  
+  fout[7] = pyyi; fout[8] = pyzi; fout[9] = pzzi;    
+}
+
+void
+evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0];
+  double pi = 3.141592653589793238462643383279502884;
+  // Physical constants (using normalized code units).
+  double gasGamma = 5.0/3.0;
+  double epsilon0 = 1.0; // Permittivity of free space.
+  double mu0 = 1.0; // Permiability of free space.
+  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
+  double ionMass = 1836.0; // Proton mass.
+  double ionCharge = 1.0; // Proton charge.
+  double elcMass = 1.0; // Electron mass.
+  double elcCharge = -1.0; // Electron charge.
+  double Te_Ti = 1.0; // Ratio of electron to proton temperature
+  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
+  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
+  double n0 = 1.0; // Initial reference number density.
+  double B0 = vAe*sqrt(mu0*n0*elcMass);
+  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
+  double di = lightSpeed/wpi;
+
+  pcg64_random_t rng = gkyl_pcg64_init(0);
+
+  double Bx = B0;
+  double By = 0.0, Bz = 0.0;
+
+  double alpha = 1.0e-6*B0;
+  double Lx = 12845.57;
+  double kx = 2.0*pi/Lx;
+  for (int i=0; i<48; ++i) {
+    By -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
+    Bz -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
+  }
+
+  // electric field
+  fout[0] = 0.0; fout[1] = 0.0; fout[2] = 0.0;
+  // magnetic field
+  fout[3] = Bx; fout[4] = By; fout[5] = Bz;
+
+  // correction potentials
+  fout[6] = 0.0; fout[7] = 0.0;
+}
+
+void
+write_data(struct gkyl_tm_trigger *iot, const gkyl_moment_app *app, double tcurr)
+{
+  if (gkyl_tm_trigger_check_and_bump(iot, tcurr))
+    gkyl_moment_app_write(app, tcurr, iot->curr-1);
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+
+  int NX = APP_ARGS_CHOOSE(app_args.xcells[0], 560);
+
+  if (app_args.trace_mem) {
+    gkyl_cu_dev_mem_debug_set(true);
+    gkyl_mem_debug_set(true);
+  }
+
+  double elc_k0 = 0.1; // rho_e ~ 10, k0e = 1.0/rho_e ~ 0.1
+  double ion_k0 = 0.002; // rho_i ~ 420, k0e = 1.0/rho_i ~ 0.002
+  
+  // electron/ion equations
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(elc_k0);
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(ion_k0);
+
+  struct gkyl_moment_species elc = {
+    .name = "elc",
+    .charge = -1.0, .mass = 1.0,
+    .equation = elc_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalElcInit,
+  };
+  struct gkyl_moment_species ion = {
+    .name = "ion",
+    .charge = 1.0, .mass = 1836.0,
+    .equation = ion_ten_moment,
+    .has_grad_closure = true,
+    .evolve = 1,
+    .init = evalIonInit,
+  };  
+
+  // VM app
+  struct gkyl_moment app_inp = {
+    .name = "10m_par_firehose_grad_closure",
+
+    .ndim = 1,
+    .lower = { 0.0 },
+    // Lx = 300 di ~ 12845.7
+    .upper = { 12845.57 }, 
+    .cells = { 560 },
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 0 },
+    .cfl_frac = 1.0,
+
+    .num_species = 2,
+    .species = { elc, ion },
+
+    .field = {
+      .epsilon0 = 1.0, .mu0 = 1.0,
+      .mag_error_speed_fact = 1.0,
+      
+      .evolve = 1,
+      .init = evalFieldInit,
+    }
+  };
+
+  // create app object
+  gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
+
+  // start, end and initial time-step
+  // Omega_ci^{-1} ~ 1e5
+  double tcurr = 0.0, tend = 1.0e7;
+  int nframe = 100;
+  // create trigger for IO
+  struct gkyl_tm_trigger io_trig = { .dt = tend/nframe };
+
+  // initialize simulation
+  gkyl_moment_app_apply_ic(app, tcurr);
+  write_data(&io_trig, app, tcurr);
+
+  // compute estimate of maximum stable time-step
+  double dt = gkyl_moment_app_max_dt(app);
+
+  long step = 1;
+  while ((tcurr < tend) && (step <= app_args.num_steps)) {
+    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    struct gkyl_update_status status = gkyl_moment_update(app, dt);
+    printf(" dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      printf("** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    write_data(&io_trig, app, tcurr);
+
+    step += 1;
+  }
+
+  gkyl_moment_app_stat_write(app);
+
+  struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
+
+  printf("\n");
+  printf("Number of update calls %ld\n", stat.nup);
+  printf("Number of failed time-steps %ld\n", stat.nfail);
+  printf("Species updates took %g secs\n", stat.species_tm);
+  printf("Field updates took %g secs\n", stat.field_tm);
+  printf("Source updates took %g secs\n", stat.sources_tm);
+  printf("Total updates took %g secs\n", stat.total_tm);
+
+  // simulation complete, free resources
+  gkyl_wv_eqn_release(elc_ten_moment);
+  gkyl_wv_eqn_release(ion_ten_moment);
+  gkyl_moment_app_release(app);  
+  
+  return 0;
+}

--- a/zero/gkyl_moment_em_coupling.h
+++ b/zero/gkyl_moment_em_coupling.h
@@ -52,7 +52,8 @@ gkyl_moment_em_coupling* gkyl_moment_em_coupling_new(struct gkyl_moment_em_coupl
 
 void gkyl_moment_em_coupling_advance(const gkyl_moment_em_coupling *mes, double dt,
   const struct gkyl_range *update_rng, 
-  struct gkyl_array *fluid[GKYL_MAX_SPECIES], const struct gkyl_array *app_accel[GKYL_MAX_SPECIES],
+  struct gkyl_array *fluid[GKYL_MAX_SPECIES], 
+  const struct gkyl_array *app_accel[GKYL_MAX_SPECIES], const struct gkyl_array *rhs[GKYL_MAX_SPECIES], 
   struct gkyl_array *em, const struct gkyl_array *app_current, const struct gkyl_array *ext_em);
 
 /**

--- a/zero/gkyl_moment_non_ideal_priv.h
+++ b/zero/gkyl_moment_non_ideal_priv.h
@@ -1,0 +1,239 @@
+#pragma once
+#include <math.h>
+
+// Private header, not for direct use in user code
+// Makes indexing cleaner
+static const unsigned RHO = 0;
+static const unsigned MX = 1;
+static const unsigned MY = 2;
+static const unsigned MZ = 3;
+static const unsigned ER = 4;
+
+static const unsigned P11 = 4;
+static const unsigned P12 = 5;
+static const unsigned P13 = 6;
+static const unsigned P22 = 7;
+static const unsigned P23 = 8;
+static const unsigned P33 = 9;
+
+static const unsigned EX = 0;
+static const unsigned EY = 1;
+static const unsigned EZ = 2;
+static const unsigned BX = 3;
+static const unsigned BY = 4;
+static const unsigned BZ = 5;
+static const unsigned PHIE = 6;
+static const unsigned PHIM = 7;
+
+// lower case l/u denote lower/upper with respect to edge
+
+// Calculate symmetrized gradient 1D
+// Based on Günter, Lackner, & Tichmann 2005 JCP
+static inline double
+calc_sym_grad_1D(double dx, double a_l, double a_u)
+{
+  return (a_u - a_l)/dx;
+}
+
+// Calculate symmetrized gradients 2D
+static inline double
+calc_sym_gradx_2D(double dx, double a_ll, double a_lu, double a_ul, double a_uu)
+{
+  return (a_ul + a_uu - a_ll - a_lu)/(2*dx);
+}
+
+static inline double
+calc_sym_grady_2D(double dy, double a_ll, double a_lu, double a_ul, double a_uu)
+{
+  return (a_lu + a_uu - a_ll - a_ul)/(2*dy);
+}
+
+// Calculate symmetrized gradients 3D
+static inline double
+calc_sym_gradx_3D(double dx, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
+{
+  return (a_ull + a_ulu + a_uul + a_uuu - a_lll - a_llu - a_lul - a_luu)/(4*dx);
+}
+
+static inline double
+calc_sym_grady_3D(double dy, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
+{
+  return (a_lul + a_luu + a_uul + a_uuu - a_lll - a_llu - a_ull - a_ulu)/(4*dy);
+}
+
+static inline double
+calc_sym_gradz_3D(double dz, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
+{
+  return (a_llu + a_luu + a_ulu + a_uuu - a_lll - a_lul - a_ull - a_uul)/(4*dz);
+}
+
+// In 1D, computes quantity at cell edge of two-cell interface
+static inline double
+calc_arithm_avg_1D(double a_l, double a_u)
+{
+  return 0.5*(a_l + a_u);
+}
+
+static inline double
+calc_harmonic_avg_1D(double a_l, double a_u)
+{
+  return 1.0/(0.5/a_l + 0.5/a_u);
+}
+
+// In 2D, computes quantity at cell corner of four-cell interface
+static inline double
+calc_arithm_avg_2D(double a_ll, double a_lu, double a_ul, double a_uu)
+{
+  return 0.25*(a_ll + a_lu + a_ul + a_uu);
+}
+
+static inline double
+calc_harmonic_avg_2D(double a_ll, double a_lu, double a_ul, double a_uu)
+{
+  return 1.0/(0.25/a_ll + 0.25/a_lu + 0.25/a_ul + 0.25/a_uu);
+}
+
+// In 3D, computes quantity at cell corner of eight-cell interface
+static inline double
+calc_arithm_avg_3D(double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
+{
+  return 0.125*(a_lll + a_llu + a_lul + a_luu + a_ull + a_ulu + a_uul + a_uuu);
+}
+
+static inline double
+calc_harmonic_avg_3D(double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
+{
+  return 1.0/(0.125/a_lll + 0.125/a_llu + 0.125/a_lul + 0.125/a_luu + 0.125/a_ull + 0.125/a_ulu + 0.125/a_uul + 0.125/a_uuu);
+}
+
+// Calculate grad(u)
+// In 1D, computes tensor at cell edge of two-cell interface
+static inline void
+calc_grad_u_1D(double dx, double u_l[3], double u_u[3], double grad_u[3])
+{
+  grad_u[0] = calc_sym_grad_1D(dx, u_l[0], u_u[0]);
+  grad_u[1] = calc_sym_grad_1D(dx, u_l[1], u_u[1]);
+  grad_u[2] = calc_sym_grad_1D(dx, u_l[2], u_u[2]);
+}
+
+// In 2D, computes tensor computes tensor in one corner of four-cell interface
+static inline void
+calc_grad_u_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul[3], double u_uu[3], double grad_u[6])
+{
+  grad_u[0] = calc_sym_gradx_2D(dx, u_ll[0], u_lu[0], u_ul[0], u_uu[0]);
+  grad_u[1] = calc_sym_gradx_2D(dx, u_ll[1], u_lu[1], u_ul[1], u_uu[1]);
+  grad_u[2] = calc_sym_gradx_2D(dx, u_ll[2], u_lu[2], u_ul[2], u_uu[2]);
+  
+  grad_u[3] = calc_sym_grady_2D(dy, u_ll[0], u_lu[0], u_ul[0], u_uu[0]);
+  grad_u[4] = calc_sym_grady_2D(dy, u_ll[1], u_lu[1], u_ul[1], u_uu[1]);
+  grad_u[5] = calc_sym_grady_2D(dy, u_ll[2], u_lu[2], u_ul[2], u_uu[2]);
+}
+
+// In 3D, computes tensor in one corner of eight-cell interface
+static inline void
+calc_grad_u_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3], double u_lul[3], double u_luu[3], double u_ull[3], double u_ulu[3], double u_uul[3], double u_uuu[3], double grad_u[9])
+{
+  grad_u[0] = calc_sym_gradx_3D(dx, u_lll[0], u_llu[0], u_lul[0], u_luu[0], u_ull[0], u_ulu[0], u_uul[0], u_uuu[0]);
+  grad_u[1] = calc_sym_gradx_3D(dx, u_lll[1], u_llu[1], u_lul[1], u_luu[1], u_ull[1], u_ulu[1], u_uul[1], u_uuu[1]);
+  grad_u[2] = calc_sym_gradx_3D(dx, u_lll[2], u_llu[2], u_lul[2], u_luu[2], u_ull[2], u_ulu[2], u_uul[2], u_uuu[2]);
+
+  grad_u[3] = calc_sym_grady_3D(dy, u_lll[0], u_llu[0], u_lul[0], u_luu[0], u_ull[0], u_ulu[0], u_uul[0], u_uuu[0]);
+  grad_u[4] = calc_sym_grady_3D(dy, u_lll[1], u_llu[1], u_lul[1], u_luu[1], u_ull[1], u_ulu[1], u_uul[1], u_uuu[1]);
+  grad_u[5] = calc_sym_grady_3D(dy, u_lll[2], u_llu[2], u_lul[2], u_luu[2], u_ull[2], u_ulu[2], u_uul[2], u_uuu[2]);
+
+  grad_u[6] = calc_sym_gradz_3D(dz, u_lll[0], u_llu[0], u_lul[0], u_luu[0], u_ull[0], u_ulu[0], u_uul[0], u_uuu[0]);
+  grad_u[7] = calc_sym_gradz_3D(dz, u_lll[1], u_llu[1], u_lul[1], u_luu[1], u_ull[1], u_ulu[1], u_uul[1], u_uuu[1]);
+  grad_u[8] = calc_sym_gradz_3D(dz, u_lll[2], u_llu[2], u_lul[2], u_luu[2], u_ull[2], u_ulu[2], u_uul[2], u_uuu[2]);
+}
+
+// Calculate rate of strain tensor
+// In 1D, computes tensor at cell edge of two-cell interface
+static inline void
+calc_ros_1D(double dx, double u_l[3], double u_u[3], double w[6])
+{
+  double grad_u[3] = {0.0};
+  calc_grad_u_1D(dx, u_l, u_u, grad_u);
+
+  w[0] = 4.0/3.0*grad_u[0];
+  w[1] = grad_u[1];
+  w[2] = grad_u[2];
+  w[3] = -2.0/3.0*grad_u[0];
+  w[4] = 0.0;
+  w[5] = -2.0/3.0*grad_u[0];
+}
+
+// In 2D, computes tensor in one corner of four-cell interface
+static inline void
+calc_ros_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul[3], double u_uu[3], double w[6])
+{
+  double grad_u[6] = {0.0};
+  calc_grad_u_2D(dx, dy, u_ll, u_lu, u_ul, u_uu, grad_u);
+
+  double divu = grad_u[0] + grad_u[4];
+  w[0] = 2.0*grad_u[0] - 2.0/3.0*divu;
+  w[1] = grad_u[1] + grad_u[3];
+  w[2] = grad_u[2];
+  w[3] = 2.0*grad_u[4] - 2.0/3.0*divu;
+  w[4] = grad_u[5];
+  w[5] = -2.0/3.0*divu;
+}
+
+// In 3D, computes tensor in one corner of eight-cell interface
+static inline void
+calc_ros_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3], double u_lul[3], double u_luu[3], double u_ull[3], double u_ulu[3], double u_uul[3], double u_uuu[3], double w[6])
+{
+  double grad_u[9] = {0.0};
+  calc_grad_u_3D(dx, dy, dz, u_lll, u_llu, u_lul, u_luu, u_ull, u_ulu, u_uul, u_uuu, grad_u);
+
+  double divu = grad_u[0] + grad_u[4] + grad_u[8];
+  w[0] = 2.0*grad_u[0] - 2.0/3.0*divu;
+  w[1] = grad_u[1] + grad_u[3];
+  w[2] = grad_u[2] + grad_u[6];
+  w[3] = 2.0*grad_u[4] - 2.0/3.0*divu;
+  w[4] = grad_u[5] + grad_u[7];
+  w[5] = 2.0*grad_u[8] - 2.0/3.0*divu;
+}
+
+// Magnetized closure helper functions
+// Calculate the magnitude of the local magnetic field
+static inline double
+calc_mag_b(const double em_tot[8])
+{
+  return sqrt(em_tot[BX]*em_tot[BX] + em_tot[BY]*em_tot[BY] + em_tot[BZ]*em_tot[BZ]);
+}
+
+// Calculate the cyclotron frequency based on the species' parameters
+static inline double
+calc_omega_c(double charge, double mass, const double em_tot[8])
+{
+  double omega_c = 0.0;
+  double Bmag = calc_mag_b(em_tot);
+  if (Bmag > 0.0)
+    omega_c = charge*Bmag/mass;
+  return omega_c;
+}
+
+// Calculate magnetic field unit vector
+static inline void
+calc_bhat(const double em_tot[8], double b[3])
+{
+  double Bx = em_tot[BX];
+  double By = em_tot[BY];
+  double Bz = em_tot[BZ];
+  double Bmag = calc_mag_b(em_tot);
+  // get magnetic field unit vector 
+  if (Bmag > 0.0) {
+    b[0] = Bx/Bmag;
+    b[1] = By/Bmag;
+    b[2] = Bz/Bmag;
+  }  
+}
+
+// Calculate the collision time based on the species' parameters
+// Note: assumes the electron-ion collision frequency so sqrt(2) may be missing
+//       coulomb_log considered constant, rho is mass density, temp is temperature
+static inline double
+calc_tau(double coulomb_log, double coll_fac, double epsilon0, double charge1, double charge2, double mass1, double mass2, double rho, double temp)
+{
+  return coll_fac*6.0*sqrt(2.0*M_PI*mass1*temp*M_PI*mass2*temp*M_PI*mass2*temp)*epsilon0*epsilon0/(coulomb_log*charge1*charge1*charge2*charge2*rho);
+}

--- a/zero/gkyl_ten_moment_grad_closure.h
+++ b/zero/gkyl_ten_moment_grad_closure.h
@@ -33,17 +33,19 @@ gkyl_ten_moment_grad_closure* gkyl_ten_moment_grad_closure_new(struct gkyl_ten_m
  * gkyl_sub_range_init method.
  *
  * @param gces Gradient closure updater object.
- * @param update_rng Range on which to compute.
- * @param fluid Input array of fluid variables (array size: nfluids)
+ * @param heat_flux_rng Range on which to compute heat flux tensor (cell nodes)
+ * @param update_rng Range on which to compute update.
+ * @param fluid Input array of fluid variables 
  * @param em Total EM variables (plasma + external)
- * @param cflrate CFL scalar rate (frequency) array (units of 1/[T])
+ * @param cflrate CFL scalar rate (frequency: units of 1/[T]) 
+ * @param heat_flux Array for storing intermediate computation of heat flux tensor (cell nodes)
  * @param rhs RHS output (NOTE: Returns RHS output of all nfluids)
  */
 
 void gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces, 
-  const struct gkyl_range *update_rng,
+  const struct gkyl_range *heat_flux_range, const struct gkyl_range *update_range,
   const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
-  struct gkyl_array *cflrate, struct gkyl_array *rhs);
+  struct gkyl_array *cflrate, struct gkyl_array *heat_flux, struct gkyl_array *rhs);
 
 /**
  * Delete updater.

--- a/zero/gkyl_ten_moment_grad_closure.h
+++ b/zero/gkyl_ten_moment_grad_closure.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <math.h>
+
+#include <gkyl_array.h>
+#include <gkyl_eqn_type.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
+#include <gkyl_util.h>
+
+struct gkyl_ten_moment_grad_closure_inp {
+    const struct gkyl_rect_grid *grid; // grid on which to solve equations
+    double k0; // inversedamping coefficient
+};
+
+// Object type
+typedef struct gkyl_ten_moment_grad_closure gkyl_ten_moment_grad_closure;
+
+/**
+ * Create new updater to update pressure tensor in 10 moment equations
+ * using a symmetrized gradient-based closure, q_ijk ~ \partial_i [_i T_{jk}]
+ * Returns RHS for accumulation in a forward Euler method.
+ *
+ * @param inp Input parameters to updater
+ */
+gkyl_ten_moment_grad_closure* gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp);
+
+/**
+ * Compute RHS contribution from symmetrized gradient-based closure
+ * in 10 moment system.  The update_rng MUST be a sub-range of the
+ * range on which the array is defined.  That is, it must be either
+ * the same range as the array range, or one created using the
+ * gkyl_sub_range_init method.
+ *
+ * @param gces Gradient closure updater object.
+ * @param update_rng Range on which to compute.
+ * @param fluid Input array of fluid variables (array size: nfluids)
+ * @param em Total EM variables (plasma + external)
+ * @param cflrate CFL scalar rate (frequency) array (units of 1/[T])
+ * @param rhs RHS output (NOTE: Returns RHS output of all nfluids)
+ */
+
+void gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces, 
+  const struct gkyl_range *update_rng,
+  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
+  struct gkyl_array *cflrate, struct gkyl_array *rhs);
+
+/**
+ * Delete updater.
+ *
+ * @param gces Updater to delete.
+ */
+void gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure *gces);

--- a/zero/gkyl_util.h
+++ b/zero/gkyl_util.h
@@ -218,6 +218,20 @@ gkyl_copy_long_arr(int n, const long* GKYL_RESTRICT inp, long* GKYL_RESTRICT out
 }
 
 /**
+ * Copy (small) double arrays.
+ *
+ * @param n Number of elements to copy
+ * @param inp Input array
+ * @param out Output array
+ */
+GKYL_CU_DH
+static inline void
+gkyl_copy_double_arr(int n, const double* GKYL_RESTRICT inp, double* GKYL_RESTRICT out)
+{
+  for (int i=0; i<n; ++i) out[i] = inp[i];
+}
+
+/**
  *   Round a/b to nearest higher integer value
  */
 GKYL_CU_DH

--- a/zero/moment_em_coupling.c
+++ b/zero/moment_em_coupling.c
@@ -37,7 +37,7 @@ struct gkyl_moment_em_coupling {
 // et. al. 2020 for details.
 static void
 pressure_tensor_rotate(double qbym, double dt, const double *em, const double *ext_em,
-  const double prRhs[6], double prOut[6])
+  double prOld[6], double prRhs[6], double prOut[6])
 {
   double Bx = em[BX] + ext_em[BX];
   double By = em[BY] + ext_em[BY];
@@ -62,12 +62,12 @@ pressure_tensor_rotate(double qbym, double dt, const double *em, const double *e
   double qb4 = qbym * qb3;
   double d = 1 + 5*(Bx2 + By2 + Bz2)*dtsq*qb2 + 4*(Bx2 + By2 + Bz2)*(Bx2 + By2 + Bz2)*dt4*qb4;
 
-  prOut[0] = 2.0*(prRhs[0] + 2*dt1*(Bz*prRhs[1] - By*prRhs[2])*qbym + dtsq*(5*Bx2*prRhs[0] + 2*Bx*(By*prRhs[1] + Bz*prRhs[2]) + Bz2*(3*prRhs[0] + 2*prRhs[3]) - 4*By*Bz*prRhs[4] + By2*(3*prRhs[0] + 2*prRhs[5]))*qb2 + 2*dt3*(4*Bx2*(Bz*prRhs[1] - By*prRhs[2]) - (By2 + Bz2)*(-(Bz*prRhs[1]) + By*prRhs[2]) - 3*Bx*(By2*prRhs[4] - Bz2*prRhs[4] + By*Bz*(-prRhs[3] + prRhs[5])))*qb3 + 2*dt4*(2*Bx4*prRhs[0] + 4*Bx3*(By*prRhs[1] + Bz*prRhs[2]) - 2*Bx*(By2 + Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + (By2 + Bz2)*(Bz2*(prRhs[0] + prRhs[3]) - 2*By*Bz*prRhs[4] + By2*(prRhs[0] + prRhs[5])) + Bx2*(4*By*Bz*prRhs[4] + By2*(3*prRhs[3] + prRhs[5]) + Bz2*(prRhs[3] + 3*prRhs[5])))*qb4)/d - prRhs[0];
-  prOut[1] =  2.0*(prRhs[1] + dt1*(Bx*prRhs[2] + Bz*(-prRhs[0] + prRhs[3]) - By*prRhs[4])*qbym + dtsq*(4*Bx2*prRhs[1] + 4*By2*prRhs[1] + Bz2*prRhs[1] + 3*By*Bz*prRhs[2] + Bx*(3*Bz*prRhs[4] + By*(prRhs[0] + prRhs[3] - 2*prRhs[5])))*qb2 + dt3*(4*Bx3*prRhs[2] - 2*Bx*(By2 + Bz2)*prRhs[2] + Bz3*(-prRhs[0] + prRhs[3]) - 4*By3*prRhs[4] + 2*By*Bz2*prRhs[4] - By2*Bz*(prRhs[0] - 4*prRhs[3] + 3*prRhs[5]) + Bx2*(2*By*prRhs[4] + Bz*(-4*prRhs[0] + prRhs[3] + 3*prRhs[5])))*qb3 + 2*Bx*By*dt4*(6*Bx*(By*prRhs[1] + Bz*prRhs[2]) + 6*By*Bz*prRhs[4] - Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + Bx2*(2*prRhs[0] - prRhs[3] - prRhs[5]) - By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]))*qb4)/d - prRhs[1];
-  prOut[2] =  2.0*(prRhs[2] + dt1*(-(Bx*prRhs[1]) + Bz*prRhs[4] + By*(prRhs[0] - prRhs[5]))*qbym + dtsq*(3*By*Bz*prRhs[1] + 4*Bx2*prRhs[2] + By2*prRhs[2] + 4*Bz2*prRhs[2] + Bx*(3*By*prRhs[4] + Bz*(prRhs[0] - 2*prRhs[3] + prRhs[5])))*qb2 + dt3*(-4*Bx3*prRhs[1] + 2*Bx*(By2 + Bz2)*prRhs[1] - 2*By2*Bz*prRhs[4] + 4*Bz3*prRhs[4] + By*Bz2*(prRhs[0] + 3*prRhs[3] - 4*prRhs[5]) + By3*(prRhs[0] - prRhs[5]) - Bx2*(2*Bz*prRhs[4] + By*(-4*prRhs[0] + 3*prRhs[3] + prRhs[5])))*qb3 + 2*Bx*Bz*dt4*(6*Bx*(By*prRhs[1] + Bz*prRhs[2]) + 6*By*Bz*prRhs[4] - Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + Bx2*(2*prRhs[0] - prRhs[3] - prRhs[5]) - By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]))*qb4)/d - prRhs[2];
-  prOut[3] =  2.0*(prRhs[3] + (-2*Bz*dt1*prRhs[1] + 2*Bx*dt1*prRhs[4])*qbym + dtsq*(2*Bx*By*prRhs[1] + 5*By2*prRhs[3] + Bz2*(2*prRhs[0] + 3*prRhs[3]) + Bz*(-4*Bx*prRhs[2] + 2*By*prRhs[4]) + Bx2*(3*prRhs[3] + 2*prRhs[5]))*qb2 + 2*dt3*(Bx2*(-(Bz*prRhs[1]) + 3*By*prRhs[2]) - Bz*(4*By2*prRhs[1] + Bz2*prRhs[1] + 3*By*Bz*prRhs[2]) + Bx3*prRhs[4] + Bx*(4*By2*prRhs[4] + Bz2*prRhs[4] + 3*By*Bz*(-prRhs[0] + prRhs[5])))*qb3 + 2*dt4*(-2*Bx3*(By*prRhs[1] + Bz*prRhs[2]) + 2*Bx*(2*By2 - Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + 2*By4*prRhs[3] + Bz4*(prRhs[0] + prRhs[3]) + 4*By3*Bz*prRhs[4] - 2*By*Bz3*prRhs[4] + Bx4*(prRhs[3] + prRhs[5]) + By2*Bz2*(prRhs[0] + 3*prRhs[5]) + Bx2*(-2*By*Bz*prRhs[4] + By2*(3*prRhs[0] + prRhs[5]) + Bz2*(prRhs[0] + 2*prRhs[3] + prRhs[5])))*qb4)/d - prRhs[3];
-  prOut[4] =  2.0*(prRhs[4] + dt1*(By*prRhs[1] - Bz*prRhs[2] + Bx*(-prRhs[3] + prRhs[5]))*qbym + dtsq*(3*Bx*Bz*prRhs[1] + Bx2*prRhs[4] + 4*By2*prRhs[4] + 4*Bz2*prRhs[4] + By*(3*Bx*prRhs[2] + Bz*(-2*prRhs[0] + prRhs[3] + prRhs[5])))*qb2 + dt3*(4*By3*prRhs[1] - 2*By*Bz2*prRhs[1] + 2*By2*Bz*prRhs[2] - 4*Bz3*prRhs[2] + Bx2*(-2*By*prRhs[1] + 2*Bz*prRhs[2]) + Bx3*(-prRhs[3] + prRhs[5]) + Bx*(-(Bz2*(3*prRhs[0] + prRhs[3] - 4*prRhs[5])) + By2*(3*prRhs[0] - 4*prRhs[3] + prRhs[5])))*qb3 - 2*By*Bz*dt4*(-6*Bx*(By*prRhs[1] + Bz*prRhs[2]) - 6*By*Bz*prRhs[4] + Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]) + Bx2*(-2*prRhs[0] + prRhs[3] + prRhs[5]))*qb4)/d - prRhs[4];
-  prOut[5] =  2.0*(prRhs[5] + 2*dt1*(By*prRhs[2] - Bx*prRhs[4])*qbym + dtsq*(2*Bx*Bz*prRhs[2] + By*(-4*Bx*prRhs[1] + 2*Bz*prRhs[4]) + 5*Bz2*prRhs[5] + By2*(2*prRhs[0] + 3*prRhs[5]) + Bx2*(2*prRhs[3] + 3*prRhs[5]))*qb2 - 2*dt3*(Bx2*(3*Bz*prRhs[1] - By*prRhs[2]) - By*(3*By*Bz*prRhs[1] + By2*prRhs[2] + 4*Bz2*prRhs[2]) + Bx3*prRhs[4] + Bx*(3*By*Bz*(-prRhs[0] + prRhs[3]) + By2*prRhs[4] + 4*Bz2*prRhs[4]))*qb3 + 2*dt4*(-2*Bx3*(By*prRhs[1] + Bz*prRhs[2]) - 2*Bx*(By2 - 2*Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + By2*Bz2*(prRhs[0] + 3*prRhs[3]) - 2*By3*Bz*prRhs[4] + 4*By*Bz3*prRhs[4] + 2*Bz4*prRhs[5] + By4*(prRhs[0] + prRhs[5]) + Bx4*(prRhs[3] + prRhs[5]) + Bx2*(Bz2*(3*prRhs[0] + prRhs[3]) - 2*By*Bz*prRhs[4] + By2*(prRhs[0] + prRhs[3] + 2*prRhs[5])))*qb4)/d - prRhs[5];
+  prOut[0] = 2.0*(prRhs[0] + 2*dt1*(Bz*prRhs[1] - By*prRhs[2])*qbym + dtsq*(5*Bx2*prRhs[0] + 2*Bx*(By*prRhs[1] + Bz*prRhs[2]) + Bz2*(3*prRhs[0] + 2*prRhs[3]) - 4*By*Bz*prRhs[4] + By2*(3*prRhs[0] + 2*prRhs[5]))*qb2 + 2*dt3*(4*Bx2*(Bz*prRhs[1] - By*prRhs[2]) - (By2 + Bz2)*(-(Bz*prRhs[1]) + By*prRhs[2]) - 3*Bx*(By2*prRhs[4] - Bz2*prRhs[4] + By*Bz*(-prRhs[3] + prRhs[5])))*qb3 + 2*dt4*(2*Bx4*prRhs[0] + 4*Bx3*(By*prRhs[1] + Bz*prRhs[2]) - 2*Bx*(By2 + Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + (By2 + Bz2)*(Bz2*(prRhs[0] + prRhs[3]) - 2*By*Bz*prRhs[4] + By2*(prRhs[0] + prRhs[5])) + Bx2*(4*By*Bz*prRhs[4] + By2*(3*prRhs[3] + prRhs[5]) + Bz2*(prRhs[3] + 3*prRhs[5])))*qb4)/d - prOld[0];
+  prOut[1] =  2.0*(prRhs[1] + dt1*(Bx*prRhs[2] + Bz*(-prRhs[0] + prRhs[3]) - By*prRhs[4])*qbym + dtsq*(4*Bx2*prRhs[1] + 4*By2*prRhs[1] + Bz2*prRhs[1] + 3*By*Bz*prRhs[2] + Bx*(3*Bz*prRhs[4] + By*(prRhs[0] + prRhs[3] - 2*prRhs[5])))*qb2 + dt3*(4*Bx3*prRhs[2] - 2*Bx*(By2 + Bz2)*prRhs[2] + Bz3*(-prRhs[0] + prRhs[3]) - 4*By3*prRhs[4] + 2*By*Bz2*prRhs[4] - By2*Bz*(prRhs[0] - 4*prRhs[3] + 3*prRhs[5]) + Bx2*(2*By*prRhs[4] + Bz*(-4*prRhs[0] + prRhs[3] + 3*prRhs[5])))*qb3 + 2*Bx*By*dt4*(6*Bx*(By*prRhs[1] + Bz*prRhs[2]) + 6*By*Bz*prRhs[4] - Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + Bx2*(2*prRhs[0] - prRhs[3] - prRhs[5]) - By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]))*qb4)/d - prOld[1];
+  prOut[2] =  2.0*(prRhs[2] + dt1*(-(Bx*prRhs[1]) + Bz*prRhs[4] + By*(prRhs[0] - prRhs[5]))*qbym + dtsq*(3*By*Bz*prRhs[1] + 4*Bx2*prRhs[2] + By2*prRhs[2] + 4*Bz2*prRhs[2] + Bx*(3*By*prRhs[4] + Bz*(prRhs[0] - 2*prRhs[3] + prRhs[5])))*qb2 + dt3*(-4*Bx3*prRhs[1] + 2*Bx*(By2 + Bz2)*prRhs[1] - 2*By2*Bz*prRhs[4] + 4*Bz3*prRhs[4] + By*Bz2*(prRhs[0] + 3*prRhs[3] - 4*prRhs[5]) + By3*(prRhs[0] - prRhs[5]) - Bx2*(2*Bz*prRhs[4] + By*(-4*prRhs[0] + 3*prRhs[3] + prRhs[5])))*qb3 + 2*Bx*Bz*dt4*(6*Bx*(By*prRhs[1] + Bz*prRhs[2]) + 6*By*Bz*prRhs[4] - Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + Bx2*(2*prRhs[0] - prRhs[3] - prRhs[5]) - By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]))*qb4)/d - prOld[2];
+  prOut[3] =  2.0*(prRhs[3] + (-2*Bz*dt1*prRhs[1] + 2*Bx*dt1*prRhs[4])*qbym + dtsq*(2*Bx*By*prRhs[1] + 5*By2*prRhs[3] + Bz2*(2*prRhs[0] + 3*prRhs[3]) + Bz*(-4*Bx*prRhs[2] + 2*By*prRhs[4]) + Bx2*(3*prRhs[3] + 2*prRhs[5]))*qb2 + 2*dt3*(Bx2*(-(Bz*prRhs[1]) + 3*By*prRhs[2]) - Bz*(4*By2*prRhs[1] + Bz2*prRhs[1] + 3*By*Bz*prRhs[2]) + Bx3*prRhs[4] + Bx*(4*By2*prRhs[4] + Bz2*prRhs[4] + 3*By*Bz*(-prRhs[0] + prRhs[5])))*qb3 + 2*dt4*(-2*Bx3*(By*prRhs[1] + Bz*prRhs[2]) + 2*Bx*(2*By2 - Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + 2*By4*prRhs[3] + Bz4*(prRhs[0] + prRhs[3]) + 4*By3*Bz*prRhs[4] - 2*By*Bz3*prRhs[4] + Bx4*(prRhs[3] + prRhs[5]) + By2*Bz2*(prRhs[0] + 3*prRhs[5]) + Bx2*(-2*By*Bz*prRhs[4] + By2*(3*prRhs[0] + prRhs[5]) + Bz2*(prRhs[0] + 2*prRhs[3] + prRhs[5])))*qb4)/d - prOld[3];
+  prOut[4] =  2.0*(prRhs[4] + dt1*(By*prRhs[1] - Bz*prRhs[2] + Bx*(-prRhs[3] + prRhs[5]))*qbym + dtsq*(3*Bx*Bz*prRhs[1] + Bx2*prRhs[4] + 4*By2*prRhs[4] + 4*Bz2*prRhs[4] + By*(3*Bx*prRhs[2] + Bz*(-2*prRhs[0] + prRhs[3] + prRhs[5])))*qb2 + dt3*(4*By3*prRhs[1] - 2*By*Bz2*prRhs[1] + 2*By2*Bz*prRhs[2] - 4*Bz3*prRhs[2] + Bx2*(-2*By*prRhs[1] + 2*Bz*prRhs[2]) + Bx3*(-prRhs[3] + prRhs[5]) + Bx*(-(Bz2*(3*prRhs[0] + prRhs[3] - 4*prRhs[5])) + By2*(3*prRhs[0] - 4*prRhs[3] + prRhs[5])))*qb3 - 2*By*Bz*dt4*(-6*Bx*(By*prRhs[1] + Bz*prRhs[2]) - 6*By*Bz*prRhs[4] + Bz2*(prRhs[0] + prRhs[3] - 2*prRhs[5]) + By2*(prRhs[0] - 2*prRhs[3] + prRhs[5]) + Bx2*(-2*prRhs[0] + prRhs[3] + prRhs[5]))*qb4)/d - prOld[4];
+  prOut[5] =  2.0*(prRhs[5] + 2*dt1*(By*prRhs[2] - Bx*prRhs[4])*qbym + dtsq*(2*Bx*Bz*prRhs[2] + By*(-4*Bx*prRhs[1] + 2*Bz*prRhs[4]) + 5*Bz2*prRhs[5] + By2*(2*prRhs[0] + 3*prRhs[5]) + Bx2*(2*prRhs[3] + 3*prRhs[5]))*qb2 - 2*dt3*(Bx2*(3*Bz*prRhs[1] - By*prRhs[2]) - By*(3*By*Bz*prRhs[1] + By2*prRhs[2] + 4*Bz2*prRhs[2]) + Bx3*prRhs[4] + Bx*(3*By*Bz*(-prRhs[0] + prRhs[3]) + By2*prRhs[4] + 4*Bz2*prRhs[4]))*qb3 + 2*dt4*(-2*Bx3*(By*prRhs[1] + Bz*prRhs[2]) - 2*Bx*(By2 - 2*Bz2)*(By*prRhs[1] + Bz*prRhs[2]) + By2*Bz2*(prRhs[0] + 3*prRhs[3]) - 2*By3*Bz*prRhs[4] + 4*By*Bz3*prRhs[4] + 2*Bz4*prRhs[5] + By4*(prRhs[0] + prRhs[5]) + Bx4*(prRhs[3] + prRhs[5]) + Bx2*(Bz2*(3*prRhs[0] + prRhs[3]) - 2*By*Bz*prRhs[4] + By2*(prRhs[0] + prRhs[3] + 2*prRhs[5])))*qb4)/d - prOld[5];
 }
 
 // Update momentum and E field using time-centered scheme. See Wang
@@ -235,15 +235,17 @@ neut_source_update(const gkyl_moment_em_coupling *mes, double dt,
 // See Wang et. al. 2020 JCP for details
 static void
 fluid_source_update(const gkyl_moment_em_coupling *mes, double dt,
-  double* fluids[GKYL_MAX_SPECIES], const double *app_accels[GKYL_MAX_SPECIES],
+  double* fluids[GKYL_MAX_SPECIES], 
+  const double *app_accels[GKYL_MAX_SPECIES], const double *rhs_s[GKYL_MAX_SPECIES], 
   double* em, const double* app_current, const double* ext_em)
 {
   int nfluids = mes->nfluids;
   double keOld[GKYL_MAX_SPECIES];
-  double prInp[6], prTen[GKYL_MAX_SPECIES][6];
+  double prInp[6], prRhs[6], prTen[GKYL_MAX_SPECIES][6];
   
   for (int n=0; n < nfluids; ++n) {
     const double *f = fluids[n];
+    const double *rhs = rhs_s[n];
     // If Euler equations, store old value of the kinetic energy for later update.
     if (mes->param[n].type == GKYL_EQN_EULER) {
       keOld[n] = 0.5 * (f[MX]*f[MX] + f[MY]*f[MY] + f[MZ]*f[MZ]) / f[RHO];
@@ -258,15 +260,23 @@ fluid_source_update(const gkyl_moment_em_coupling *mes, double dt,
       prInp[4] = f[P23] - f[MY] * f[MZ] / f[RHO];
       prInp[5] = f[P33] - f[MZ] * f[MZ] / f[RHO];
 
+      prRhs[0] = prInp[0] + 0.5*dt*rhs[P11];
+      prRhs[1] = prInp[1] + 0.5*dt*rhs[P12];
+      prRhs[2] = prInp[2] + 0.5*dt*rhs[P13];
+      prRhs[3] = prInp[3] + 0.5*dt*rhs[P22];
+      prRhs[4] = prInp[4] + 0.5*dt*rhs[P23];
+      prRhs[5] = prInp[5] + 0.5*dt*rhs[P33];
+
       double p = 1.0/3.0*(prInp[0] + prInp[3] + prInp[5]);
       double vth = sqrt(p/f[RHO]);
       double nu = vth*mes->param[n].k0;
       double edt = exp(nu*dt);
 
+
       // If permittivity of free-space is non-zero, EM fields exist
       // and we rotate pressure tensor around magnetic field 
       if (mes->epsilon0)
-        pressure_tensor_rotate(qbym, dt, em, ext_em, prInp, prTen[n]);
+        pressure_tensor_rotate(qbym, dt, em, ext_em, prInp, prRhs, prTen[n]);
 
       // Divide out integrating factor from collisional relaxation
       // (P - pI) = exp(-nu*dt)*(P - pI); where p is the isotropic pressure 
@@ -324,12 +334,14 @@ gkyl_moment_em_coupling_new(struct gkyl_moment_em_coupling_inp inp)
 void
 gkyl_moment_em_coupling_advance(const gkyl_moment_em_coupling *mes, double dt,
   const struct gkyl_range *update_range,
-  struct gkyl_array *fluid[GKYL_MAX_SPECIES], const struct gkyl_array *app_accel[GKYL_MAX_SPECIES],
+  struct gkyl_array *fluid[GKYL_MAX_SPECIES], 
+  const struct gkyl_array *app_accel[GKYL_MAX_SPECIES], const struct gkyl_array *rhs[GKYL_MAX_SPECIES],
   struct gkyl_array *em, const struct gkyl_array *app_current, const struct gkyl_array *ext_em)
 {
   int nfluids = mes->nfluids;
   double *fluids[GKYL_MAX_SPECIES];
   const double *app_accels[GKYL_MAX_SPECIES];
+  const double *rhs_s[GKYL_MAX_SPECIES];
 
   struct gkyl_range_iter iter;
   gkyl_range_iter_init(&iter, update_range);
@@ -340,9 +352,10 @@ gkyl_moment_em_coupling_advance(const gkyl_moment_em_coupling *mes, double dt,
     for (int n=0; n<nfluids; ++n) {
       fluids[n] = gkyl_array_fetch(fluid[n], lidx);
       app_accels[n] = gkyl_array_cfetch(app_accel[n], lidx);
+      rhs_s[n] = gkyl_array_cfetch(rhs[n], lidx);
     }
 
-    fluid_source_update(mes, dt, fluids, app_accels,
+    fluid_source_update(mes, dt, fluids, app_accels, rhs_s, 
       gkyl_array_fetch(em, lidx),
       gkyl_array_cfetch(app_current, lidx),
       gkyl_array_cfetch(ext_em, lidx)

--- a/zero/ten_moment_grad_closure.c
+++ b/zero/ten_moment_grad_closure.c
@@ -1,0 +1,698 @@
+#include <gkyl_alloc.h>
+#include <gkyl_array_ops.h>
+#include <gkyl_ten_moment_grad_closure.h>
+#include <gkyl_moment_non_ideal_priv.h>
+
+// Makes indexing cleaner
+static const unsigned T11 = 0;
+static const unsigned T12 = 1;
+static const unsigned T13 = 2;
+static const unsigned T22 = 3;
+static const unsigned T23 = 4;
+static const unsigned T33 = 5;
+
+static const unsigned Q111 = 0;
+static const unsigned Q112 = 1;
+static const unsigned Q113 = 2;
+static const unsigned Q122 = 3;
+static const unsigned Q123 = 4;
+static const unsigned Q133 = 5;
+static const unsigned Q222 = 6;
+static const unsigned Q223 = 7;
+static const unsigned Q233 = 8;
+static const unsigned Q333 = 9;
+
+// 1D stencil locations (L: lower, C: center, U: upper)
+enum loc_1d {
+  L_1D, C_1D, U_1D
+};
+
+// 2D stencil locations (L: lower, C: center, U: upper)
+enum loc_2d {
+  LL_2D, LC_2D, LU_2D,
+  CL_2D, CC_2D, CU_2D,
+  UL_2D, UC_2D, UU_2D
+};
+
+// 3D stencil locations (L: lower, C: center, U: upper)
+enum loc_3d {
+  LLL_3D, LLC_3D, LLU_3D,
+  LCL_3D, LCC_3D, LCU_3D,
+  LUL_3D, LUC_3D, LUU_3D,
+  
+  CLL_3D, CLC_3D, CLU_3D,
+  CCL_3D, CCC_3D, CCU_3D,
+  CUL_3D, CUC_3D, CUU_3D,
+
+  ULL_3D, ULC_3D, ULU_3D,
+  UCL_3D, UCC_3D, UCU_3D,
+  UUL_3D, UUC_3D, UUU_3D
+};
+
+struct gkyl_ten_moment_grad_closure {
+  struct gkyl_rect_grid grid; // grid object
+  int ndim; // number of dimensions
+  double k0; // damping coefficient
+};
+
+static void
+create_offsets(const struct gkyl_range *range, long offsets[])
+{
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, (int[]) { -1, -1, -1 }, (int[]) { 1, 1, 1 });
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
+
+static void
+unmag_grad_closure_update(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate, double *rhs_d)
+{
+  const int ndim = gces->ndim;
+  if (ndim == 1) {
+    const double dx = gces->grid.dx[0];
+    double Tij[3][6] = {0.0};
+    double rho[3] = {0.0};
+    double p[3] = {0.0}; 
+    for (int j = L_1D; j <= U_1D; ++j) {
+      rho[j] = fluid_d[j][RHO];
+      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
+              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
+              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
+      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    }
+    double rhoL = calc_harmonic_avg_1D(rho[L_1D], rho[C_1D]);
+    double pL = calc_harmonic_avg_1D(p[L_1D], p[C_1D]);
+    double rhoU = calc_harmonic_avg_1D(rho[C_1D], rho[U_1D]);
+    double pU = calc_harmonic_avg_1D(p[C_1D], p[U_1D]);
+    double vthL = sqrt(pL/rhoL);
+    double vthU = sqrt(pU/rhoU);
+
+    double dTdxL[6] = { calc_sym_grad_1D(dx, Tij[L_1D][T11], Tij[C_1D][T11]),
+                        calc_sym_grad_1D(dx, Tij[L_1D][T12], Tij[C_1D][T12]),
+                        calc_sym_grad_1D(dx, Tij[L_1D][T13], Tij[C_1D][T13]),
+                        calc_sym_grad_1D(dx, Tij[L_1D][T22], Tij[C_1D][T22]),
+                        calc_sym_grad_1D(dx, Tij[L_1D][T23], Tij[C_1D][T23]),
+                        calc_sym_grad_1D(dx, Tij[L_1D][T33], Tij[C_1D][T33]) };
+
+    double dTdxU[6] = { calc_sym_grad_1D(dx, Tij[C_1D][T11], Tij[U_1D][T11]),
+                        calc_sym_grad_1D(dx, Tij[C_1D][T12], Tij[U_1D][T12]),
+                        calc_sym_grad_1D(dx, Tij[C_1D][T13], Tij[U_1D][T13]),
+                        calc_sym_grad_1D(dx, Tij[C_1D][T22], Tij[U_1D][T22]),
+                        calc_sym_grad_1D(dx, Tij[C_1D][T23], Tij[U_1D][T23]),
+                        calc_sym_grad_1D(dx, Tij[C_1D][T33], Tij[U_1D][T33]) };
+                        
+    double qL[10] = {0.0};
+    double qU[10] = {0.0};
+    double alpha = 1.0/gces->k0;
+    
+    qL[Q111] = alpha*vthL*rhoL*(dTdxL[T11] + dTdxL[T11] + dTdxL[T11])/3.0;
+    qL[Q112] = alpha*vthL*rhoL*(dTdxL[T12] + dTdxL[T12])/3.0;
+    qL[Q113] = alpha*vthL*rhoL*(dTdxL[T13] + dTdxL[T13])/3.0;
+    qL[Q122] = alpha*vthL*rhoL*(dTdxL[T22])/3.0;
+    qL[Q123] = alpha*vthL*rhoL*(dTdxL[T23])/3.0;
+    qL[Q133] = alpha*vthL*rhoL*(dTdxL[T33])/3.0; 
+
+    qU[Q111] = alpha*vthU*rhoU*(dTdxU[T11] + dTdxU[T11] + dTdxU[T11])/3.0;
+    qU[Q112] = alpha*vthU*rhoU*(dTdxU[T12] + dTdxU[T12])/3.0;
+    qU[Q113] = alpha*vthU*rhoU*(dTdxU[T13] + dTdxU[T13])/3.0;
+    qU[Q122] = alpha*vthU*rhoU*(dTdxU[T22])/3.0;
+    qU[Q123] = alpha*vthU*rhoU*(dTdxU[T23])/3.0;
+    qU[Q133] = alpha*vthU*rhoU*(dTdxU[T33])/3.0; 
+
+    rhs_d[RHO] = 0.0;
+    rhs_d[MX] = 0.0;
+    rhs_d[MY] = 0.0;
+    rhs_d[MZ] = 0.0;
+    rhs_d[P11] = (qU[Q111] - qL[Q111])/dx;
+    rhs_d[P12] = (qU[Q112] - qL[Q112])/dx;
+    rhs_d[P13] = (qU[Q113] - qL[Q113])/dx;
+    rhs_d[P22] = (qU[Q122] - qL[Q122])/dx;
+    rhs_d[P23] = (qU[Q123] - qL[Q123])/dx;
+    rhs_d[P33] = (qU[Q133] - qL[Q133])/dx;
+  }
+  else if (ndim == 2) {
+    const double dx = gces->grid.dx[0];
+    const double dy = gces->grid.dx[1];
+    double Tij[9][6] = {0.0};
+    double rho[9] = {0.0};
+    double p[9] = {0.0}; 
+    for (int j = LL_2D; j <= UU_2D; ++j) {
+      rho[j] = fluid_d[j][RHO];
+      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
+              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
+              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
+      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];   	
+    }
+    double rhoLL = calc_harmonic_avg_2D(rho[LL_2D], rho[LC_2D], rho[CL_2D], rho[CC_2D]);
+    double pLL = calc_harmonic_avg_2D(p[LL_2D], p[LC_2D], p[CL_2D], p[CC_2D]);
+    double rhoLU = calc_harmonic_avg_2D(rho[LC_2D], rho[LU_2D], rho[CC_2D], rho[CU_2D]);
+    double pLU = calc_harmonic_avg_2D(p[LC_2D], p[LU_2D], p[CC_2D], p[CU_2D]);
+    double rhoUL = calc_harmonic_avg_2D(rho[CL_2D], rho[CC_2D], rho[UL_2D], rho[UC_2D]);
+    double pUL = calc_harmonic_avg_2D(p[CL_2D], p[CC_2D], p[UL_2D], p[UC_2D]);
+    double rhoUU = calc_harmonic_avg_2D(rho[CC_2D], rho[CU_2D], rho[UC_2D], rho[UU_2D]);
+    double pUU = calc_harmonic_avg_2D(p[CC_2D], p[CU_2D], p[UC_2D], p[UU_2D]);
+
+    double vthLL = sqrt(pLL/rhoLL);
+    double vthLU = sqrt(pLU/rhoLU);
+    double vthUL = sqrt(pUL/rhoUL);
+    double vthUU = sqrt(pUU/rhoUU);
+
+    double dTdxLL[6] = { calc_sym_gradx_2D(dx, Tij[LL_2D][T11], Tij[LC_2D][T11], Tij[CL_2D][T11], Tij[CC_2D][T11]),
+                         calc_sym_gradx_2D(dx, Tij[LL_2D][T12], Tij[LC_2D][T12], Tij[CL_2D][T12], Tij[CC_2D][T12]),
+                         calc_sym_gradx_2D(dx, Tij[LL_2D][T13], Tij[LC_2D][T13], Tij[CL_2D][T13], Tij[CC_2D][T13]),
+                         calc_sym_gradx_2D(dx, Tij[LL_2D][T22], Tij[LC_2D][T22], Tij[CL_2D][T22], Tij[CC_2D][T22]), 
+                         calc_sym_gradx_2D(dx, Tij[LL_2D][T23], Tij[LC_2D][T23], Tij[CL_2D][T23], Tij[CC_2D][T23]),
+                         calc_sym_gradx_2D(dx, Tij[LL_2D][T33], Tij[LC_2D][T33], Tij[CL_2D][T33], Tij[CC_2D][T33]) };
+
+    double dTdyLL[6] = { calc_sym_grady_2D(dy, Tij[LL_2D][T11], Tij[LC_2D][T11], Tij[CL_2D][T11], Tij[CC_2D][T11]),
+                         calc_sym_grady_2D(dy, Tij[LL_2D][T12], Tij[LC_2D][T12], Tij[CL_2D][T12], Tij[CC_2D][T12]),
+                         calc_sym_grady_2D(dy, Tij[LL_2D][T13], Tij[LC_2D][T13], Tij[CL_2D][T13], Tij[CC_2D][T13]),
+                         calc_sym_grady_2D(dy, Tij[LL_2D][T22], Tij[LC_2D][T22], Tij[CL_2D][T22], Tij[CC_2D][T22]), 
+                         calc_sym_grady_2D(dy, Tij[LL_2D][T23], Tij[LC_2D][T23], Tij[CL_2D][T23], Tij[CC_2D][T23]),
+                         calc_sym_grady_2D(dy, Tij[LL_2D][T33], Tij[LC_2D][T33], Tij[CL_2D][T33], Tij[CC_2D][T33]) };
+
+    double dTdxLU[6] = { calc_sym_gradx_2D(dx, Tij[LC_2D][T11], Tij[LU_2D][T11], Tij[CC_2D][T11], Tij[CU_2D][T11]),
+                         calc_sym_gradx_2D(dx, Tij[LC_2D][T12], Tij[LU_2D][T12], Tij[CC_2D][T12], Tij[CU_2D][T12]),
+                         calc_sym_gradx_2D(dx, Tij[LC_2D][T13], Tij[LU_2D][T13], Tij[CC_2D][T13], Tij[CU_2D][T13]),
+                         calc_sym_gradx_2D(dx, Tij[LC_2D][T22], Tij[LU_2D][T22], Tij[CC_2D][T22], Tij[CU_2D][T22]),
+                         calc_sym_gradx_2D(dx, Tij[LC_2D][T23], Tij[LU_2D][T23], Tij[CC_2D][T23], Tij[CU_2D][T23]),
+                         calc_sym_gradx_2D(dx, Tij[LC_2D][T33], Tij[LU_2D][T33], Tij[CC_2D][T33], Tij[CU_2D][T33]) };
+
+    double dTdyLU[6] = { calc_sym_grady_2D(dy, Tij[LC_2D][T11], Tij[LU_2D][T11], Tij[CC_2D][T11], Tij[CU_2D][T11]),
+                         calc_sym_grady_2D(dy, Tij[LC_2D][T12], Tij[LU_2D][T12], Tij[CC_2D][T12], Tij[CU_2D][T12]),
+                         calc_sym_grady_2D(dy, Tij[LC_2D][T13], Tij[LU_2D][T13], Tij[CC_2D][T13], Tij[CU_2D][T13]),
+                         calc_sym_grady_2D(dy, Tij[LC_2D][T22], Tij[LU_2D][T22], Tij[CC_2D][T22], Tij[CU_2D][T22]),
+                         calc_sym_grady_2D(dy, Tij[LC_2D][T23], Tij[LU_2D][T23], Tij[CC_2D][T23], Tij[CU_2D][T23]),
+                         calc_sym_grady_2D(dy, Tij[LC_2D][T33], Tij[LU_2D][T33], Tij[CC_2D][T33], Tij[CU_2D][T33]) };
+
+    double dTdxUL[6] = { calc_sym_gradx_2D(dx, Tij[CL_2D][T11], Tij[CC_2D][T11], Tij[UL_2D][T11], Tij[UC_2D][T11]),
+                         calc_sym_gradx_2D(dx, Tij[CL_2D][T12], Tij[CC_2D][T12], Tij[UL_2D][T12], Tij[UC_2D][T12]),
+                         calc_sym_gradx_2D(dx, Tij[CL_2D][T13], Tij[CC_2D][T13], Tij[UL_2D][T13], Tij[UC_2D][T13]),
+                         calc_sym_gradx_2D(dx, Tij[CL_2D][T22], Tij[CC_2D][T22], Tij[UL_2D][T22], Tij[UC_2D][T22]), 
+                         calc_sym_gradx_2D(dx, Tij[CL_2D][T23], Tij[CC_2D][T23], Tij[UL_2D][T23], Tij[UC_2D][T23]),
+                         calc_sym_gradx_2D(dx, Tij[CL_2D][T33], Tij[CC_2D][T33], Tij[UL_2D][T33], Tij[UC_2D][T33]) };
+
+    double dTdyUL[6] = { calc_sym_grady_2D(dy, Tij[CL_2D][T11], Tij[CC_2D][T11], Tij[UL_2D][T11], Tij[UC_2D][T11]),
+                         calc_sym_grady_2D(dy, Tij[CL_2D][T12], Tij[CC_2D][T12], Tij[UL_2D][T12], Tij[UC_2D][T12]),
+                         calc_sym_grady_2D(dy, Tij[CL_2D][T13], Tij[CC_2D][T13], Tij[UL_2D][T13], Tij[UC_2D][T13]),
+                         calc_sym_grady_2D(dy, Tij[CL_2D][T22], Tij[CC_2D][T22], Tij[UL_2D][T22], Tij[UC_2D][T22]), 
+                         calc_sym_grady_2D(dy, Tij[CL_2D][T23], Tij[CC_2D][T23], Tij[UL_2D][T23], Tij[UC_2D][T23]),
+                         calc_sym_grady_2D(dy, Tij[CL_2D][T33], Tij[CC_2D][T33], Tij[UL_2D][T33], Tij[UC_2D][T33]) };
+
+    double dTdxUU[6] = { calc_sym_gradx_2D(dx, Tij[CC_2D][T11], Tij[CU_2D][T11], Tij[UC_2D][T11], Tij[UU_2D][T11]),
+                         calc_sym_gradx_2D(dx, Tij[CC_2D][T12], Tij[CU_2D][T12], Tij[UC_2D][T12], Tij[UU_2D][T12]),
+                         calc_sym_gradx_2D(dx, Tij[CC_2D][T13], Tij[CU_2D][T13], Tij[UC_2D][T13], Tij[UU_2D][T13]),
+                         calc_sym_gradx_2D(dx, Tij[CC_2D][T22], Tij[CU_2D][T22], Tij[UC_2D][T22], Tij[UU_2D][T22]),
+                         calc_sym_gradx_2D(dx, Tij[CC_2D][T23], Tij[CU_2D][T23], Tij[UC_2D][T23], Tij[UU_2D][T23]),
+                         calc_sym_gradx_2D(dx, Tij[CC_2D][T33], Tij[CU_2D][T33], Tij[UC_2D][T33], Tij[UU_2D][T33]) };
+
+    double dTdyUU[6] = { calc_sym_grady_2D(dy, Tij[CC_2D][T11], Tij[CU_2D][T11], Tij[UC_2D][T11], Tij[UU_2D][T11]),
+                         calc_sym_grady_2D(dy, Tij[CC_2D][T12], Tij[CU_2D][T12], Tij[UC_2D][T12], Tij[UU_2D][T12]),
+                         calc_sym_grady_2D(dy, Tij[CC_2D][T13], Tij[CU_2D][T13], Tij[UC_2D][T13], Tij[UU_2D][T13]),
+                         calc_sym_grady_2D(dy, Tij[CC_2D][T22], Tij[CU_2D][T22], Tij[UC_2D][T22], Tij[UU_2D][T22]),
+                         calc_sym_grady_2D(dy, Tij[CC_2D][T23], Tij[CU_2D][T23], Tij[UC_2D][T23], Tij[UU_2D][T23]),
+                         calc_sym_grady_2D(dy, Tij[CC_2D][T33], Tij[CU_2D][T33], Tij[UC_2D][T33], Tij[UU_2D][T33]) };
+
+    double qLL[10] = {0.0};
+    double qLU[10] = {0.0};
+    double qUL[10] = {0.0};
+    double qUU[10] = {0.0};
+    double alpha = 1.0/gces->k0;
+    
+    qLL[Q111] = alpha*vthLL*rhoLL*(dTdxLL[T11] + dTdxLL[T11] + dTdxLL[T11])/3.0;
+    qLL[Q112] = alpha*vthLL*rhoLL*(dTdxLL[T12] + dTdxLL[T12] + dTdyLL[T11])/3.0;
+    qLL[Q113] = alpha*vthLL*rhoLL*(dTdxLL[T13] + dTdxLL[T13])/3.0;
+    qLL[Q122] = alpha*vthLL*rhoLL*(dTdxLL[T22] + dTdyLL[T12] + dTdyLL[T12])/3.0;
+    qLL[Q123] = alpha*vthLL*rhoLL*(dTdxLL[T23] + dTdyLL[T13])/3.0;
+    qLL[Q133] = alpha*vthLL*rhoLL*(dTdxLL[T33])/3.0; 
+    qLL[Q222] = alpha*vthLL*rhoLL*(dTdyLL[T22] + dTdyLL[T22] + dTdyLL[T22])/3.0;
+    qLL[Q223] = alpha*vthLL*rhoLL*(dTdyLL[T23] + dTdyLL[T23])/3.0;
+    qLL[Q233] = alpha*vthLL*rhoLL*(dTdyLL[T33])/3.0;
+
+    qLU[Q111] = alpha*vthLU*rhoLU*(dTdxLU[T11] + dTdxLU[T11] + dTdxLU[T11])/3.0;
+    qLU[Q112] = alpha*vthLU*rhoLU*(dTdxLU[T12] + dTdxLU[T12] + dTdyLU[T11])/3.0;
+    qLU[Q113] = alpha*vthLU*rhoLU*(dTdxLU[T13] + dTdxLU[T13])/3.0;
+    qLU[Q122] = alpha*vthLU*rhoLU*(dTdxLU[T22] + dTdyLU[T12] + dTdyLU[T12])/3.0;
+    qLU[Q123] = alpha*vthLU*rhoLU*(dTdxLU[T23] + dTdyLU[T13])/3.0;
+    qLU[Q133] = alpha*vthLU*rhoLU*(dTdxLU[T33])/3.0; 
+    qLU[Q222] = alpha*vthLU*rhoLU*(dTdyLU[T22] + dTdyLU[T22] + dTdyLU[T22])/3.0;
+    qLU[Q223] = alpha*vthLU*rhoLU*(dTdyLU[T23] + dTdyLU[T23])/3.0;
+    qLU[Q233] = alpha*vthLU*rhoLU*(dTdyLU[T33])/3.0;
+
+    qUL[Q111] = alpha*vthUL*rhoUL*(dTdxUL[T11] + dTdxUL[T11] + dTdxUL[T11])/3.0;
+    qUL[Q112] = alpha*vthUL*rhoUL*(dTdxUL[T12] + dTdxUL[T12] + dTdyUL[T11])/3.0;
+    qUL[Q113] = alpha*vthUL*rhoUL*(dTdxUL[T13] + dTdxUL[T13])/3.0;
+    qUL[Q122] = alpha*vthUL*rhoUL*(dTdxUL[T22] + dTdyUL[T12] + dTdyUL[T12])/3.0;
+    qUL[Q123] = alpha*vthUL*rhoUL*(dTdxUL[T23] + dTdyUL[T13])/3.0;
+    qUL[Q133] = alpha*vthUL*rhoUL*(dTdxUL[T33])/3.0; 
+    qUL[Q222] = alpha*vthUL*rhoUL*(dTdyUL[T22] + dTdyUL[T22] + dTdyUL[T22])/3.0;
+    qUL[Q223] = alpha*vthUL*rhoUL*(dTdyUL[T23] + dTdyUL[T23])/3.0;
+    qUL[Q233] = alpha*vthUL*rhoUL*(dTdyUL[T33])/3.0;
+
+    qUU[Q111] = alpha*vthUU*rhoUU*(dTdxUU[T11] + dTdxUU[T11] + dTdxUU[T11])/3.0;
+    qUU[Q112] = alpha*vthUU*rhoUU*(dTdxUU[T12] + dTdxUU[T12] + dTdyUU[T11])/3.0;
+    qUU[Q113] = alpha*vthUU*rhoUU*(dTdxUU[T13] + dTdxUU[T13])/3.0;
+    qUU[Q122] = alpha*vthUU*rhoUU*(dTdxUU[T22] + dTdyUU[T12] + dTdyUU[T12])/3.0;
+    qUU[Q123] = alpha*vthUU*rhoUU*(dTdxUU[T23] + dTdyUU[T13])/3.0;
+    qUU[Q133] = alpha*vthUU*rhoUU*(dTdxUU[T33])/3.0; 
+    qUU[Q222] = alpha*vthUU*rhoUU*(dTdyUU[T22] + dTdyUU[T22] + dTdyUU[T22])/3.0;
+    qUU[Q223] = alpha*vthUU*rhoUU*(dTdyUU[T23] + dTdyUU[T23])/3.0;
+    qUU[Q233] = alpha*vthUU*rhoUU*(dTdyUU[T33])/3.0;
+
+    double divQx[6] = { calc_sym_gradx_2D(dx, qLL[Q111], qLU[Q111], qUL[Q111], qUU[Q111]), 
+                        calc_sym_gradx_2D(dx, qLL[Q112], qLU[Q112], qUL[Q112], qUU[Q112]), 
+                        calc_sym_gradx_2D(dx, qLL[Q113], qLU[Q113], qUL[Q113], qUU[Q113]), 
+                        calc_sym_gradx_2D(dx, qLL[Q122], qLU[Q122], qUL[Q122], qUU[Q122]), 
+                        calc_sym_gradx_2D(dx, qLL[Q123], qLU[Q123], qUL[Q123], qUU[Q123]), 
+                        calc_sym_gradx_2D(dx, qLL[Q133], qLU[Q133], qUL[Q133], qUU[Q133]) };
+
+    double divQy[6] = { calc_sym_grady_2D(dy, qLL[Q112], qLU[Q112], qUL[Q112], qUU[Q112]), 
+                        calc_sym_grady_2D(dy, qLL[Q122], qLU[Q122], qUL[Q122], qUU[Q122]), 
+                        calc_sym_grady_2D(dy, qLL[Q123], qLU[Q123], qUL[Q123], qUU[Q123]), 
+                        calc_sym_grady_2D(dy, qLL[Q222], qLU[Q222], qUL[Q222], qUU[Q222]), 
+                        calc_sym_grady_2D(dy, qLL[Q223], qLU[Q223], qUL[Q223], qUU[Q223]), 
+                        calc_sym_grady_2D(dy, qLL[Q233], qLU[Q233], qUL[Q233], qUU[Q233]) };
+
+    rhs_d[RHO] = 0.0;
+    rhs_d[MX] = 0.0;
+    rhs_d[MY] = 0.0;
+    rhs_d[MZ] = 0.0;
+    rhs_d[P11] = divQx[0] + divQy[0];
+    rhs_d[P12] = divQx[1] + divQy[1];
+    rhs_d[P13] = divQx[2] + divQy[2];
+    rhs_d[P22] = divQx[3] + divQy[3];
+    rhs_d[P23] = divQx[4] + divQy[4];
+    rhs_d[P33] = divQx[5] + divQy[5];
+  }
+  else if (ndim == 3) {
+    const double dx = gces->grid.dx[0];
+    const double dy = gces->grid.dx[1];
+    const double dz = gces->grid.dx[2];
+    double Tij[27][6] = {0.0};
+    double rho[27] = {0.0};
+    double p[27] = {0.0}; 
+    for (int j = LLL_3D; j <= UUU_3D; ++j) {
+      rho[j] = fluid_d[j][RHO];
+      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
+              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
+              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
+      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];    
+    }
+
+    double rhoLLL = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLC_3D], rho[LCL_3D], rho[LCC_3D], rho[CLL_3D], rho[CLC_3D], rho[CCL_3D], rho[CCC_3D]);
+    double pLLL = calc_harmonic_avg_3D(p[LLL_3D], p[LLC_3D], p[LCL_3D], p[LCC_3D], p[CLL_3D], p[CLC_3D], p[CCL_3D], p[CCC_3D]);
+    double rhoLLU = calc_harmonic_avg_3D(rho[LLC_3D], rho[LLU_3D], rho[LCC_3D], rho[LCU_3D], rho[CLC_3D], rho[CLU_3D], rho[CCC_3D], rho[CCU_3D]);
+    double pLLU = calc_harmonic_avg_3D(p[LLC_3D], p[LLU_3D], p[LCC_3D], p[LCU_3D], p[CLC_3D], p[CLU_3D], p[CCC_3D], p[CCU_3D]);
+    double rhoLUL = calc_harmonic_avg_3D(rho[LCL_3D], rho[LCC_3D], rho[LUL_3D], rho[LUC_3D], rho[CCL_3D], rho[CCC_3D], rho[CUL_3D], rho[CUC_3D]);
+    double pLUL = calc_harmonic_avg_3D(p[LCL_3D], p[LCC_3D], p[LUL_3D], p[LUC_3D], p[CCL_3D], p[CCC_3D], p[CUL_3D], p[CUC_3D]);
+    double rhoLUU = calc_harmonic_avg_3D(rho[LCC_3D], rho[LCU_3D], rho[LUC_3D], rho[LUU_3D], rho[CCC_3D], rho[CCU_3D], rho[CUC_3D], rho[CUU_3D]);
+    double pLUU = calc_harmonic_avg_3D(p[LCC_3D], p[LCU_3D], p[LUC_3D], p[LUU_3D], p[CCC_3D], p[CCU_3D], p[CUC_3D], p[CUU_3D]);
+
+    double rhoULL = calc_harmonic_avg_3D(rho[CLL_3D], rho[CLC_3D], rho[CCL_3D], rho[CCC_3D], rho[ULL_3D], rho[ULC_3D], rho[UCL_3D], rho[UCC_3D]);
+    double pULL = calc_harmonic_avg_3D(p[CLL_3D], p[CLC_3D], p[CCL_3D], p[CCC_3D], p[ULL_3D], p[ULC_3D], p[UCL_3D], p[UCC_3D]);
+    double rhoULU = calc_harmonic_avg_3D(rho[CLC_3D], rho[CLU_3D], rho[CCC_3D], rho[CCU_3D], rho[ULC_3D], rho[ULU_3D], rho[UCC_3D], rho[UCU_3D]);
+    double pULU = calc_harmonic_avg_3D(p[CLC_3D], p[CLU_3D], p[CCC_3D], p[CCU_3D], p[ULC_3D], p[ULU_3D], p[UCC_3D], p[UCU_3D]);
+    double rhoUUL = calc_harmonic_avg_3D(rho[CCL_3D], rho[CCC_3D], rho[CUL_3D], rho[CUC_3D], rho[UCL_3D], rho[UCC_3D], rho[UUL_3D], rho[UUC_3D]);
+    double pUUL = calc_harmonic_avg_3D(p[CCL_3D], p[CCC_3D], p[CUL_3D], p[CUC_3D], p[UCL_3D], p[UCC_3D], p[UUL_3D], p[UUC_3D]);
+    double rhoUUU = calc_harmonic_avg_3D(rho[CCC_3D], rho[CCU_3D], rho[CUC_3D], rho[CUU_3D], rho[UCC_3D], rho[UCU_3D], rho[UUC_3D], rho[UUU_3D]);
+    double pUUU = calc_harmonic_avg_3D(p[CCC_3D], p[CCU_3D], p[CUC_3D], p[CUU_3D], p[UCC_3D], p[UCU_3D], p[UUC_3D], p[UUU_3D]);
+
+    double vthLLL = sqrt(pLLL/rhoLLL);
+    double vthLLU = sqrt(pLLU/rhoLLU);
+    double vthLUL = sqrt(pLUL/rhoLUL);
+    double vthLUU = sqrt(pLUU/rhoLUU);
+
+    double vthULL = sqrt(pULL/rhoULL);
+    double vthULU = sqrt(pULU/rhoULU);
+    double vthUUL = sqrt(pUUL/rhoUUL);
+    double vthUUU = sqrt(pUUU/rhoUUU);
+
+    double dTdxLLL[6] = { calc_sym_gradx_3D(dx, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
+
+    double dTdyLLL[6] = { calc_sym_grady_3D(dy, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
+
+    double dTdzLLL[6] = { calc_sym_gradz_3D(dz, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
+
+    double dTdxLLU[6] = { calc_sym_gradx_3D(dx, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
+
+    double dTdyLLU[6] = { calc_sym_grady_3D(dy, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
+
+    double dTdzLLU[6] = { calc_sym_gradz_3D(dz, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
+
+    double dTdxLUL[6] = { calc_sym_gradx_3D(dx, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
+
+    double dTdyLUL[6] = { calc_sym_grady_3D(dy, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
+
+    double dTdzLUL[6] = { calc_sym_gradz_3D(dz, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
+
+    double dTdxLUU[6] = { calc_sym_gradx_3D(dx, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
+
+    double dTdyLUU[6] = { calc_sym_grady_3D(dy, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
+
+    double dTdzLUU[6] = { calc_sym_gradz_3D(dz, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
+
+    double dTdxULL[6] = { calc_sym_gradx_3D(dx, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
+
+    double dTdyULL[6] = { calc_sym_grady_3D(dy, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
+
+    double dTdzULL[6] = { calc_sym_gradz_3D(dz, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
+
+    double dTdxULU[6] = { calc_sym_gradx_3D(dx, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
+
+    double dTdyULU[6] = { calc_sym_grady_3D(dy, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
+
+    double dTdzULU[6] = { calc_sym_gradz_3D(dz, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
+
+    double dTdxUUL[6] = { calc_sym_gradx_3D(dx, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
+
+    double dTdyUUL[6] = { calc_sym_grady_3D(dy, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
+
+    double dTdzUUL[6] = { calc_sym_gradz_3D(dz, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
+
+    double dTdxUUU[6] = { calc_sym_gradx_3D(dx, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
+                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
+                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
+                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
+                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
+                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
+
+    double dTdyUUU[6] = { calc_sym_grady_3D(dy, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
+                          calc_sym_grady_3D(dy, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
+                          calc_sym_grady_3D(dy, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
+                          calc_sym_grady_3D(dy, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
+                          calc_sym_grady_3D(dy, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
+                          calc_sym_grady_3D(dy, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
+
+    double dTdzUUU[6] = { calc_sym_gradz_3D(dz, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
+                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
+                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
+                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
+                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
+                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
+
+    double qLLL[10] = {0.0};
+    double qLLU[10] = {0.0};
+    double qLUL[10] = {0.0};
+    double qLUU[10] = {0.0};
+    double qULL[10] = {0.0};
+    double qULU[10] = {0.0};
+    double qUUL[10] = {0.0};
+    double qUUU[10] = {0.0};
+    double alpha = 1.0/gces->k0;
+
+    qLLL[Q111] = alpha*vthLLL*rhoLLL*(dTdxLLL[T11] + dTdxLLL[T11] + dTdxLLL[T11])/3.0;
+    qLLL[Q112] = alpha*vthLLL*rhoLLL*(dTdxLLL[T12] + dTdxLLL[T12] + dTdyLLL[T11])/3.0;
+    qLLL[Q113] = alpha*vthLLL*rhoLLL*(dTdxLLL[T13] + dTdxLLL[T13] + dTdzLLL[T11])/3.0;
+    qLLL[Q122] = alpha*vthLLL*rhoLLL*(dTdxLLL[T22] + dTdyLLL[T12] + dTdyLLL[T12])/3.0;
+    qLLL[Q123] = alpha*vthLLL*rhoLLL*(dTdxLLL[T23] + dTdyLLL[T13] + dTdzLLL[T12])/3.0;
+    qLLL[Q133] = alpha*vthLLL*rhoLLL*(dTdxLLL[T33] + dTdzLLL[T13] + dTdzLLL[T13])/3.0;
+    qLLL[Q222] = alpha*vthLLL*rhoLLL*(dTdyLLL[T22] + dTdyLLL[T22] + dTdyLLL[T22])/3.0;
+    qLLL[Q223] = alpha*vthLLL*rhoLLL*(dTdyLLL[T23] + dTdyLLL[T23] + dTdzLLL[T22])/3.0;
+    qLLL[Q233] = alpha*vthLLL*rhoLLL*(dTdyLLL[T33] + dTdzLLL[T23] + dTdzLLL[T23])/3.0;
+    qLLL[Q333] = alpha*vthLLL*rhoLLL*(dTdzLLL[T33] + dTdzLLL[T33] + dTdzLLL[T33])/3.0;
+
+    qLLU[Q111] = alpha*vthLLU*rhoLLU*(dTdxLLU[T11] + dTdxLLU[T11] + dTdxLLU[T11])/3.0;
+    qLLU[Q112] = alpha*vthLLU*rhoLLU*(dTdxLLU[T12] + dTdxLLU[T12] + dTdyLLU[T11])/3.0;
+    qLLU[Q113] = alpha*vthLLU*rhoLLU*(dTdxLLU[T13] + dTdxLLU[T13] + dTdzLLU[T11])/3.0;
+    qLLU[Q122] = alpha*vthLLU*rhoLLU*(dTdxLLU[T22] + dTdyLLU[T12] + dTdyLLU[T12])/3.0;
+    qLLU[Q123] = alpha*vthLLU*rhoLLU*(dTdxLLU[T23] + dTdyLLU[T13] + dTdzLLU[T12])/3.0;
+    qLLU[Q133] = alpha*vthLLU*rhoLLU*(dTdxLLU[T33] + dTdzLLU[T13] + dTdzLLU[T13])/3.0;
+    qLLU[Q222] = alpha*vthLLU*rhoLLU*(dTdyLLU[T22] + dTdyLLU[T22] + dTdyLLU[T22])/3.0;
+    qLLU[Q223] = alpha*vthLLU*rhoLLU*(dTdyLLU[T23] + dTdyLLU[T23] + dTdzLLU[T22])/3.0;
+    qLLU[Q233] = alpha*vthLLU*rhoLLU*(dTdyLLU[T33] + dTdzLLU[T23] + dTdzLLU[T23])/3.0;
+    qLLU[Q333] = alpha*vthLLU*rhoLLU*(dTdzLLU[T33] + dTdzLLU[T33] + dTdzLLU[T33])/3.0;
+
+    qLUL[Q111] = alpha*vthLUL*rhoLUL*(dTdxLUL[T11] + dTdxLUL[T11] + dTdxLUL[T11])/3.0;
+    qLUL[Q112] = alpha*vthLUL*rhoLUL*(dTdxLUL[T12] + dTdxLUL[T12] + dTdyLUL[T11])/3.0;
+    qLUL[Q113] = alpha*vthLUL*rhoLUL*(dTdxLUL[T13] + dTdxLUL[T13] + dTdzLUL[T11])/3.0;
+    qLUL[Q122] = alpha*vthLUL*rhoLUL*(dTdxLUL[T22] + dTdyLUL[T12] + dTdyLUL[T12])/3.0;
+    qLUL[Q123] = alpha*vthLUL*rhoLUL*(dTdxLUL[T23] + dTdyLUL[T13] + dTdzLUL[T12])/3.0;
+    qLUL[Q133] = alpha*vthLUL*rhoLUL*(dTdxLUL[T33] + dTdzLUL[T13] + dTdzLUL[T13])/3.0;
+    qLUL[Q222] = alpha*vthLUL*rhoLUL*(dTdyLUL[T22] + dTdyLUL[T22] + dTdyLUL[T22])/3.0;
+    qLUL[Q223] = alpha*vthLUL*rhoLUL*(dTdyLUL[T23] + dTdyLUL[T23] + dTdzLUL[T22])/3.0;
+    qLUL[Q233] = alpha*vthLUL*rhoLUL*(dTdyLUL[T33] + dTdzLUL[T23] + dTdzLUL[T23])/3.0;
+    qLUL[Q333] = alpha*vthLUL*rhoLUL*(dTdzLUL[T33] + dTdzLUL[T33] + dTdzLUL[T33])/3.0;
+
+    qLUU[Q111] = alpha*vthLUU*rhoLUU*(dTdxLUU[T11] + dTdxLUU[T11] + dTdxLUU[T11])/3.0;
+    qLUU[Q112] = alpha*vthLUU*rhoLUU*(dTdxLUU[T12] + dTdxLUU[T12] + dTdyLUU[T11])/3.0;
+    qLUU[Q113] = alpha*vthLUU*rhoLUU*(dTdxLUU[T13] + dTdxLUU[T13] + dTdzLUU[T11])/3.0;
+    qLUU[Q122] = alpha*vthLUU*rhoLUU*(dTdxLUU[T22] + dTdyLUU[T12] + dTdyLUU[T12])/3.0;
+    qLUU[Q123] = alpha*vthLUU*rhoLUU*(dTdxLUU[T23] + dTdyLUU[T13] + dTdzLUU[T12])/3.0;
+    qLUU[Q133] = alpha*vthLUU*rhoLUU*(dTdxLUU[T33] + dTdzLUU[T13] + dTdzLUU[T13])/3.0;
+    qLUU[Q222] = alpha*vthLUU*rhoLUU*(dTdyLUU[T22] + dTdyLUU[T22] + dTdyLUU[T22])/3.0;
+    qLUU[Q223] = alpha*vthLUU*rhoLUU*(dTdyLUU[T23] + dTdyLUU[T23] + dTdzLUU[T22])/3.0;
+    qLUU[Q233] = alpha*vthLUU*rhoLUU*(dTdyLUU[T33] + dTdzLUU[T23] + dTdzLUU[T23])/3.0;
+    qLUU[Q333] = alpha*vthLUU*rhoLUU*(dTdzLUU[T33] + dTdzLUU[T33] + dTdzLUU[T33])/3.0;
+
+    qULL[Q111] = alpha*vthULL*rhoULL*(dTdxULL[T11] + dTdxULL[T11] + dTdxULL[T11])/3.0;
+    qULL[Q112] = alpha*vthULL*rhoULL*(dTdxULL[T12] + dTdxULL[T12] + dTdyULL[T11])/3.0;
+    qULL[Q113] = alpha*vthULL*rhoULL*(dTdxULL[T13] + dTdxULL[T13] + dTdzULL[T11])/3.0;
+    qULL[Q122] = alpha*vthULL*rhoULL*(dTdxULL[T22] + dTdyULL[T12] + dTdyULL[T12])/3.0;
+    qULL[Q123] = alpha*vthULL*rhoULL*(dTdxULL[T23] + dTdyULL[T13] + dTdzULL[T12])/3.0;
+    qULL[Q133] = alpha*vthULL*rhoULL*(dTdxULL[T33] + dTdzULL[T13] + dTdzULL[T13])/3.0;
+    qULL[Q222] = alpha*vthULL*rhoULL*(dTdyULL[T22] + dTdyULL[T22] + dTdyULL[T22])/3.0;
+    qULL[Q223] = alpha*vthULL*rhoULL*(dTdyULL[T23] + dTdyULL[T23] + dTdzULL[T22])/3.0;
+    qULL[Q233] = alpha*vthULL*rhoULL*(dTdyULL[T33] + dTdzULL[T23] + dTdzULL[T23])/3.0;
+    qULL[Q333] = alpha*vthULL*rhoULL*(dTdzULL[T33] + dTdzULL[T33] + dTdzULL[T33])/3.0;
+
+    qULU[Q111] = alpha*vthULU*rhoULU*(dTdxULU[T11] + dTdxULU[T11] + dTdxULU[T11])/3.0;
+    qULU[Q112] = alpha*vthULU*rhoULU*(dTdxULU[T12] + dTdxULU[T12] + dTdyULU[T11])/3.0;
+    qULU[Q113] = alpha*vthULU*rhoULU*(dTdxULU[T13] + dTdxULU[T13] + dTdzULU[T11])/3.0;
+    qULU[Q122] = alpha*vthULU*rhoULU*(dTdxULU[T22] + dTdyULU[T12] + dTdyULU[T12])/3.0;
+    qULU[Q123] = alpha*vthULU*rhoULU*(dTdxULU[T23] + dTdyULU[T13] + dTdzULU[T12])/3.0;
+    qULU[Q133] = alpha*vthULU*rhoULU*(dTdxULU[T33] + dTdzULU[T13] + dTdzULU[T13])/3.0;
+    qULU[Q222] = alpha*vthULU*rhoULU*(dTdyULU[T22] + dTdyULU[T22] + dTdyULU[T22])/3.0;
+    qULU[Q223] = alpha*vthULU*rhoULU*(dTdyULU[T23] + dTdyULU[T23] + dTdzULU[T22])/3.0;
+    qULU[Q233] = alpha*vthULU*rhoULU*(dTdyULU[T33] + dTdzULU[T23] + dTdzULU[T23])/3.0;
+    qULU[Q333] = alpha*vthULU*rhoULU*(dTdzULU[T33] + dTdzULU[T33] + dTdzULU[T33])/3.0;
+
+    qUUL[Q111] = alpha*vthUUL*rhoUUL*(dTdxUUL[T11] + dTdxUUL[T11] + dTdxUUL[T11])/3.0;
+    qUUL[Q112] = alpha*vthUUL*rhoUUL*(dTdxUUL[T12] + dTdxUUL[T12] + dTdyUUL[T11])/3.0;
+    qUUL[Q113] = alpha*vthUUL*rhoUUL*(dTdxUUL[T13] + dTdxUUL[T13] + dTdzUUL[T11])/3.0;
+    qUUL[Q122] = alpha*vthUUL*rhoUUL*(dTdxUUL[T22] + dTdyUUL[T12] + dTdyUUL[T12])/3.0;
+    qUUL[Q123] = alpha*vthUUL*rhoUUL*(dTdxUUL[T23] + dTdyUUL[T13] + dTdzUUL[T12])/3.0;
+    qUUL[Q133] = alpha*vthUUL*rhoUUL*(dTdxUUL[T33] + dTdzUUL[T13] + dTdzUUL[T13])/3.0;
+    qUUL[Q222] = alpha*vthUUL*rhoUUL*(dTdyUUL[T22] + dTdyUUL[T22] + dTdyUUL[T22])/3.0;
+    qUUL[Q223] = alpha*vthUUL*rhoUUL*(dTdyUUL[T23] + dTdyUUL[T23] + dTdzUUL[T22])/3.0;
+    qUUL[Q233] = alpha*vthUUL*rhoUUL*(dTdyUUL[T33] + dTdzUUL[T23] + dTdzUUL[T23])/3.0;
+    qUUL[Q333] = alpha*vthUUL*rhoUUL*(dTdzUUL[T33] + dTdzUUL[T33] + dTdzUUL[T33])/3.0;
+
+    qUUU[Q111] = alpha*vthUUU*rhoUUU*(dTdxUUU[T11] + dTdxUUU[T11] + dTdxUUU[T11])/3.0;
+    qUUU[Q112] = alpha*vthUUU*rhoUUU*(dTdxUUU[T12] + dTdxUUU[T12] + dTdyUUU[T11])/3.0;
+    qUUU[Q113] = alpha*vthUUU*rhoUUU*(dTdxUUU[T13] + dTdxUUU[T13] + dTdzUUU[T11])/3.0;
+    qUUU[Q122] = alpha*vthUUU*rhoUUU*(dTdxUUU[T22] + dTdyUUU[T12] + dTdyUUU[T12])/3.0;
+    qUUU[Q123] = alpha*vthUUU*rhoUUU*(dTdxUUU[T23] + dTdyUUU[T13] + dTdzUUU[T12])/3.0;
+    qUUU[Q133] = alpha*vthUUU*rhoUUU*(dTdxUUU[T33] + dTdzUUU[T13] + dTdzUUU[T13])/3.0;
+    qUUU[Q222] = alpha*vthUUU*rhoUUU*(dTdyUUU[T22] + dTdyUUU[T22] + dTdyUUU[T22])/3.0;
+    qUUU[Q223] = alpha*vthUUU*rhoUUU*(dTdyUUU[T23] + dTdyUUU[T23] + dTdzUUU[T22])/3.0;
+    qUUU[Q233] = alpha*vthUUU*rhoUUU*(dTdyUUU[T33] + dTdzUUU[T23] + dTdzUUU[T23])/3.0;
+    qUUU[Q333] = alpha*vthUUU*rhoUUU*(dTdzUUU[T33] + dTdzUUU[T33] + dTdzUUU[T33])/3.0;
+
+    double divQx[6] = { calc_sym_gradx_3D(dx, qLLL[Q111], qLLU[Q111], qLUL[Q111], qLUU[Q111], qULL[Q111], qULU[Q111], qUUL[Q111], qUUU[Q111]), 
+                        calc_sym_gradx_3D(dx, qLLL[Q112], qLLU[Q112], qLUL[Q112], qLUU[Q112], qULL[Q112], qULU[Q112], qUUL[Q112], qUUU[Q112]), 
+                        calc_sym_gradx_3D(dx, qLLL[Q113], qLLU[Q113], qLUL[Q113], qLUU[Q113], qULL[Q113], qULU[Q113], qUUL[Q113], qUUU[Q113]), 
+                        calc_sym_gradx_3D(dx, qLLL[Q122], qLLU[Q122], qLUL[Q122], qLUU[Q122], qULL[Q122], qULU[Q122], qUUL[Q122], qUUU[Q122]), 
+                        calc_sym_gradx_3D(dx, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
+                        calc_sym_gradx_3D(dx, qLLL[Q133], qLLU[Q133], qLUL[Q133], qLUU[Q133], qULL[Q133], qULU[Q133], qUUL[Q133], qUUU[Q133]) };
+
+    double divQy[6] = { calc_sym_grady_3D(dy, qLLL[Q112], qLLU[Q112], qLUL[Q112], qLUU[Q112], qULL[Q112], qULU[Q112], qUUL[Q112], qUUU[Q112]), 
+                        calc_sym_grady_3D(dy, qLLL[Q122], qLLU[Q122], qLUL[Q122], qLUU[Q122], qULL[Q122], qULU[Q122], qUUL[Q122], qUUU[Q122]), 
+                        calc_sym_grady_3D(dy, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
+                        calc_sym_grady_3D(dy, qLLL[Q222], qLLU[Q222], qLUL[Q222], qLUU[Q222], qULL[Q222], qULU[Q222], qUUL[Q222], qUUU[Q222]), 
+                        calc_sym_grady_3D(dy, qLLL[Q223], qLLU[Q223], qLUL[Q223], qLUU[Q223], qULL[Q223], qULU[Q223], qUUL[Q223], qUUU[Q223]), 
+                        calc_sym_grady_3D(dy, qLLL[Q233], qLLU[Q233], qLUL[Q233], qLUU[Q233], qULL[Q233], qULU[Q233], qUUL[Q233], qUUU[Q233]) };
+
+    double divQz[6] = { calc_sym_gradz_3D(dz, qLLL[Q113], qLLU[Q113], qLUL[Q113], qLUU[Q113], qULL[Q113], qULU[Q113], qUUL[Q113], qUUU[Q113]), 
+                        calc_sym_gradz_3D(dz, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
+                        calc_sym_gradz_3D(dz, qLLL[Q133], qLLU[Q133], qLUL[Q133], qLUU[Q133], qULL[Q133], qULU[Q133], qUUL[Q133], qUUU[Q133]), 
+                        calc_sym_gradz_3D(dz, qLLL[Q223], qLLU[Q223], qLUL[Q223], qLUU[Q223], qULL[Q223], qULU[Q223], qUUL[Q223], qUUU[Q223]), 
+                        calc_sym_gradz_3D(dz, qLLL[Q233], qLLU[Q233], qLUL[Q233], qLUU[Q233], qULL[Q233], qULU[Q233], qUUL[Q233], qUUU[Q233]), 
+                        calc_sym_gradz_3D(dz, qLLL[Q333], qLLU[Q333], qLUL[Q333], qLUU[Q333], qULL[Q333], qULU[Q333], qUUL[Q333], qUUU[Q333]) };
+
+    rhs_d[RHO] = 0.0;
+    rhs_d[MX] = 0.0;
+    rhs_d[MY] = 0.0;
+    rhs_d[MZ] = 0.0;
+    rhs_d[P11] = divQx[0] + divQy[0] + divQz[0];
+    rhs_d[P12] = divQx[1] + divQy[1] + divQz[1];
+    rhs_d[P13] = divQx[2] + divQy[2] + divQz[2];
+    rhs_d[P22] = divQx[3] + divQy[3] + divQz[3];
+    rhs_d[P23] = divQx[4] + divQy[4] + divQz[4];
+    rhs_d[P33] = divQx[5] + divQy[5] + divQz[5];
+  }
+}
+
+gkyl_ten_moment_grad_closure*
+gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
+{
+  gkyl_ten_moment_grad_closure *up = gkyl_malloc(sizeof(gkyl_ten_moment_grad_closure));
+
+  up->grid = *(inp.grid);
+  up->ndim = up->grid.ndim;
+  up->k0 = inp.k0;
+
+  return up;
+}
+
+void
+gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces, 
+  const struct gkyl_range *update_range,
+  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
+  struct gkyl_array *cflrate, struct gkyl_array *rhs)
+{
+  int ndim = update_range->ndim;
+  long sz[] = { 3, 9, 27 };
+
+  long offsets[sz[ndim-1]];
+  create_offsets(update_range, offsets);
+
+  const double* fluid_d[sz[ndim-1]];
+  double *rhs_d;
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, update_range);
+  while (gkyl_range_iter_next(&iter)) {
+    
+    long linc = gkyl_range_idx(update_range, iter.idx);
+    
+    for (int i=0; i<sz[ndim-1]; ++i)
+      fluid_d[i] =  gkyl_array_cfetch(fluid, linc + offsets[i]); 
+
+    rhs_d = gkyl_array_fetch(rhs, linc);
+    unmag_grad_closure_update(gces, fluid_d, gkyl_array_fetch(cflrate, linc), rhs_d);
+  }
+}
+
+void
+gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure* up)
+{
+  free(up);
+}

--- a/zero/ten_moment_grad_closure.c
+++ b/zero/ten_moment_grad_closure.c
@@ -22,31 +22,23 @@ static const unsigned Q223 = 7;
 static const unsigned Q233 = 8;
 static const unsigned Q333 = 9;
 
-// 1D stencil locations (L: lower, C: center, U: upper)
+// 1D stencil locations (L: lower, U: upper)
 enum loc_1d {
-  L_1D, C_1D, U_1D
+  L_1D, U_1D
 };
 
-// 2D stencil locations (L: lower, C: center, U: upper)
+// 2D stencil locations (L: lower, U: upper)
 enum loc_2d {
-  LL_2D, LC_2D, LU_2D,
-  CL_2D, CC_2D, CU_2D,
-  UL_2D, UC_2D, UU_2D
+  LL_2D, LU_2D,
+  UL_2D, UU_2D
 };
 
-// 3D stencil locations (L: lower, C: center, U: upper)
+// 3D stencil locations (L: lower, U: upper)
 enum loc_3d {
-  LLL_3D, LLC_3D, LLU_3D,
-  LCL_3D, LCC_3D, LCU_3D,
-  LUL_3D, LUC_3D, LUU_3D,
-  
-  CLL_3D, CLC_3D, CLU_3D,
-  CCL_3D, CCC_3D, CCU_3D,
-  CUL_3D, CUC_3D, CUU_3D,
-
-  ULL_3D, ULC_3D, ULU_3D,
-  UCL_3D, UCC_3D, UCU_3D,
-  UUL_3D, UUC_3D, UUU_3D
+  LLL_3D, LLU_3D,
+  LUL_3D, LUU_3D,
+  ULL_3D, ULU_3D,
+  UUL_3D, UUU_3D
 };
 
 struct gkyl_ten_moment_grad_closure {
@@ -56,11 +48,11 @@ struct gkyl_ten_moment_grad_closure {
 };
 
 static void
-create_offsets(const struct gkyl_range *range, long offsets[])
+create_offsets_vertices(const struct gkyl_range *range, long offsets[])
 {
   // box spanning stencil
   struct gkyl_range box3;
-  gkyl_range_init(&box3, range->ndim, (int[]) { -1, -1, -1 }, (int[]) { 1, 1, 1 });
+  gkyl_range_init(&box3, range->ndim, (int[]) { -1, -1, -1 }, (int[]) { 0, 0, 0 });
 
   struct gkyl_range_iter iter3;
   gkyl_range_iter_init(&iter3, &box3);
@@ -72,582 +64,265 @@ create_offsets(const struct gkyl_range *range, long offsets[])
 }
 
 static void
-unmag_grad_closure_update(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double *rhs_d)
+create_offsets_centers(const struct gkyl_range *range, long offsets[])
+{
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, (int[]) { 0, 0, 0 }, (int[]) { 1, 1, 1 });
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
+
+static void
+var_setup(const gkyl_ten_moment_grad_closure *gces, 
+  int start, int end, 
+  const double *fluid_d[], 
+  double rho[], double p[], double Tij[][6])
+{
+  for (int j = start; j <= end; ++j) {
+    rho[j] = fluid_d[j][RHO];
+    p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
+          + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
+          + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
+    Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+    Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
+  }
+}
+
+static void
+calc_unmag_heat_flux(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate, double *heat_flux_d)
 {
   const int ndim = gces->ndim;
+  double rho_avg = 0.0;
+  double p_avg = 0.0;
+  double dTdx[6] = {0.0};
+  double dTdy[6] = {0.0};
+  double dTdz[6] = {0.0};
+
   if (ndim == 1) {
     const double dx = gces->grid.dx[0];
-    double Tij[3][6] = {0.0};
-    double rho[3] = {0.0};
-    double p[3] = {0.0}; 
-    for (int j = L_1D; j <= U_1D; ++j) {
-      rho[j] = fluid_d[j][RHO];
-      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
-              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
-              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
-      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    }
-    double rhoL = calc_harmonic_avg_1D(rho[L_1D], rho[C_1D]);
-    double pL = calc_harmonic_avg_1D(p[L_1D], p[C_1D]);
-    double rhoU = calc_harmonic_avg_1D(rho[C_1D], rho[U_1D]);
-    double pU = calc_harmonic_avg_1D(p[C_1D], p[U_1D]);
-    double vthL = sqrt(pL/rhoL);
-    double vthU = sqrt(pU/rhoU);
+    double Tij[2][6] = {0.0};
+    double rho[2] = {0.0};
+    double p[2] = {0.0}; 
+    var_setup(gces, L_1D, U_1D, fluid_d, rho, p, Tij);
 
-    double dTdxL[6] = { calc_sym_grad_1D(dx, Tij[L_1D][T11], Tij[C_1D][T11]),
-                        calc_sym_grad_1D(dx, Tij[L_1D][T12], Tij[C_1D][T12]),
-                        calc_sym_grad_1D(dx, Tij[L_1D][T13], Tij[C_1D][T13]),
-                        calc_sym_grad_1D(dx, Tij[L_1D][T22], Tij[C_1D][T22]),
-                        calc_sym_grad_1D(dx, Tij[L_1D][T23], Tij[C_1D][T23]),
-                        calc_sym_grad_1D(dx, Tij[L_1D][T33], Tij[C_1D][T33]) };
+    rho_avg = calc_harmonic_avg_1D(rho[L_1D], rho[U_1D]);
+    p_avg = calc_harmonic_avg_1D(p[L_1D], p[U_1D]);
 
-    double dTdxU[6] = { calc_sym_grad_1D(dx, Tij[C_1D][T11], Tij[U_1D][T11]),
-                        calc_sym_grad_1D(dx, Tij[C_1D][T12], Tij[U_1D][T12]),
-                        calc_sym_grad_1D(dx, Tij[C_1D][T13], Tij[U_1D][T13]),
-                        calc_sym_grad_1D(dx, Tij[C_1D][T22], Tij[U_1D][T22]),
-                        calc_sym_grad_1D(dx, Tij[C_1D][T23], Tij[U_1D][T23]),
-                        calc_sym_grad_1D(dx, Tij[C_1D][T33], Tij[U_1D][T33]) };
-                        
-    double qL[10] = {0.0};
-    double qU[10] = {0.0};
-    double alpha = 1.0/gces->k0;
-    
-    qL[Q111] = alpha*vthL*rhoL*(dTdxL[T11] + dTdxL[T11] + dTdxL[T11])/3.0;
-    qL[Q112] = alpha*vthL*rhoL*(dTdxL[T12] + dTdxL[T12])/3.0;
-    qL[Q113] = alpha*vthL*rhoL*(dTdxL[T13] + dTdxL[T13])/3.0;
-    qL[Q122] = alpha*vthL*rhoL*(dTdxL[T22])/3.0;
-    qL[Q123] = alpha*vthL*rhoL*(dTdxL[T23])/3.0;
-    qL[Q133] = alpha*vthL*rhoL*(dTdxL[T33])/3.0; 
-
-    qU[Q111] = alpha*vthU*rhoU*(dTdxU[T11] + dTdxU[T11] + dTdxU[T11])/3.0;
-    qU[Q112] = alpha*vthU*rhoU*(dTdxU[T12] + dTdxU[T12])/3.0;
-    qU[Q113] = alpha*vthU*rhoU*(dTdxU[T13] + dTdxU[T13])/3.0;
-    qU[Q122] = alpha*vthU*rhoU*(dTdxU[T22])/3.0;
-    qU[Q123] = alpha*vthU*rhoU*(dTdxU[T23])/3.0;
-    qU[Q133] = alpha*vthU*rhoU*(dTdxU[T33])/3.0; 
-
-    rhs_d[RHO] = 0.0;
-    rhs_d[MX] = 0.0;
-    rhs_d[MY] = 0.0;
-    rhs_d[MZ] = 0.0;
-    rhs_d[P11] = (qU[Q111] - qL[Q111])/dx;
-    rhs_d[P12] = (qU[Q112] - qL[Q112])/dx;
-    rhs_d[P13] = (qU[Q113] - qL[Q113])/dx;
-    rhs_d[P22] = (qU[Q122] - qL[Q122])/dx;
-    rhs_d[P23] = (qU[Q123] - qL[Q123])/dx;
-    rhs_d[P33] = (qU[Q133] - qL[Q133])/dx;
+    dTdx[0] = calc_sym_grad_1D(dx, Tij[L_1D][T11], Tij[U_1D][T11]); 
+    dTdx[1] = calc_sym_grad_1D(dx, Tij[L_1D][T12], Tij[U_1D][T12]); 
+    dTdx[2] = calc_sym_grad_1D(dx, Tij[L_1D][T13], Tij[U_1D][T13]); 
+    dTdx[3] = calc_sym_grad_1D(dx, Tij[L_1D][T22], Tij[U_1D][T22]); 
+    dTdx[4] = calc_sym_grad_1D(dx, Tij[L_1D][T23], Tij[U_1D][T23]); 
+    dTdx[5] = calc_sym_grad_1D(dx, Tij[L_1D][T33], Tij[U_1D][T33]);
   }
   else if (ndim == 2) {
     const double dx = gces->grid.dx[0];
     const double dy = gces->grid.dx[1];
-    double Tij[9][6] = {0.0};
-    double rho[9] = {0.0};
-    double p[9] = {0.0}; 
-    for (int j = LL_2D; j <= UU_2D; ++j) {
-      rho[j] = fluid_d[j][RHO];
-      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
-              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
-              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
-      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];   	
-    }
-    double rhoLL = calc_harmonic_avg_2D(rho[LL_2D], rho[LC_2D], rho[CL_2D], rho[CC_2D]);
-    double pLL = calc_harmonic_avg_2D(p[LL_2D], p[LC_2D], p[CL_2D], p[CC_2D]);
-    double rhoLU = calc_harmonic_avg_2D(rho[LC_2D], rho[LU_2D], rho[CC_2D], rho[CU_2D]);
-    double pLU = calc_harmonic_avg_2D(p[LC_2D], p[LU_2D], p[CC_2D], p[CU_2D]);
-    double rhoUL = calc_harmonic_avg_2D(rho[CL_2D], rho[CC_2D], rho[UL_2D], rho[UC_2D]);
-    double pUL = calc_harmonic_avg_2D(p[CL_2D], p[CC_2D], p[UL_2D], p[UC_2D]);
-    double rhoUU = calc_harmonic_avg_2D(rho[CC_2D], rho[CU_2D], rho[UC_2D], rho[UU_2D]);
-    double pUU = calc_harmonic_avg_2D(p[CC_2D], p[CU_2D], p[UC_2D], p[UU_2D]);
+    double Tij[4][6] = {0.0};
+    double rho[4] = {0.0};
+    double p[4] = {0.0}; 
+    var_setup(gces, LL_2D, UU_2D, fluid_d, rho, p, Tij);
 
-    double vthLL = sqrt(pLL/rhoLL);
-    double vthLU = sqrt(pLU/rhoLU);
-    double vthUL = sqrt(pUL/rhoUL);
-    double vthUU = sqrt(pUU/rhoUU);
+    rho_avg = calc_harmonic_avg_2D(rho[LL_2D], rho[LU_2D], rho[UL_2D], rho[UU_2D]);
+    p_avg = calc_harmonic_avg_2D(p[LL_2D], p[LU_2D], p[UL_2D], p[UU_2D]);
 
-    double dTdxLL[6] = { calc_sym_gradx_2D(dx, Tij[LL_2D][T11], Tij[LC_2D][T11], Tij[CL_2D][T11], Tij[CC_2D][T11]),
-                         calc_sym_gradx_2D(dx, Tij[LL_2D][T12], Tij[LC_2D][T12], Tij[CL_2D][T12], Tij[CC_2D][T12]),
-                         calc_sym_gradx_2D(dx, Tij[LL_2D][T13], Tij[LC_2D][T13], Tij[CL_2D][T13], Tij[CC_2D][T13]),
-                         calc_sym_gradx_2D(dx, Tij[LL_2D][T22], Tij[LC_2D][T22], Tij[CL_2D][T22], Tij[CC_2D][T22]), 
-                         calc_sym_gradx_2D(dx, Tij[LL_2D][T23], Tij[LC_2D][T23], Tij[CL_2D][T23], Tij[CC_2D][T23]),
-                         calc_sym_gradx_2D(dx, Tij[LL_2D][T33], Tij[LC_2D][T33], Tij[CL_2D][T33], Tij[CC_2D][T33]) };
+    dTdx[0] = calc_sym_gradx_2D(dx, Tij[LL_2D][T11], Tij[LU_2D][T11], Tij[UL_2D][T11], Tij[UU_2D][T11]); 
+    dTdx[1] = calc_sym_gradx_2D(dx, Tij[LL_2D][T12], Tij[LU_2D][T12], Tij[UL_2D][T12], Tij[UU_2D][T12]); 
+    dTdx[2] = calc_sym_gradx_2D(dx, Tij[LL_2D][T13], Tij[LU_2D][T13], Tij[UL_2D][T13], Tij[UU_2D][T13]); 
+    dTdx[3] = calc_sym_gradx_2D(dx, Tij[LL_2D][T22], Tij[LU_2D][T22], Tij[UL_2D][T22], Tij[UU_2D][T22]); 
+    dTdx[4] = calc_sym_gradx_2D(dx, Tij[LL_2D][T23], Tij[LU_2D][T23], Tij[UL_2D][T23], Tij[UU_2D][T23]); 
+    dTdx[5] = calc_sym_gradx_2D(dx, Tij[LL_2D][T33], Tij[LU_2D][T33], Tij[UL_2D][T33], Tij[UU_2D][T33]);
 
-    double dTdyLL[6] = { calc_sym_grady_2D(dy, Tij[LL_2D][T11], Tij[LC_2D][T11], Tij[CL_2D][T11], Tij[CC_2D][T11]),
-                         calc_sym_grady_2D(dy, Tij[LL_2D][T12], Tij[LC_2D][T12], Tij[CL_2D][T12], Tij[CC_2D][T12]),
-                         calc_sym_grady_2D(dy, Tij[LL_2D][T13], Tij[LC_2D][T13], Tij[CL_2D][T13], Tij[CC_2D][T13]),
-                         calc_sym_grady_2D(dy, Tij[LL_2D][T22], Tij[LC_2D][T22], Tij[CL_2D][T22], Tij[CC_2D][T22]), 
-                         calc_sym_grady_2D(dy, Tij[LL_2D][T23], Tij[LC_2D][T23], Tij[CL_2D][T23], Tij[CC_2D][T23]),
-                         calc_sym_grady_2D(dy, Tij[LL_2D][T33], Tij[LC_2D][T33], Tij[CL_2D][T33], Tij[CC_2D][T33]) };
-
-    double dTdxLU[6] = { calc_sym_gradx_2D(dx, Tij[LC_2D][T11], Tij[LU_2D][T11], Tij[CC_2D][T11], Tij[CU_2D][T11]),
-                         calc_sym_gradx_2D(dx, Tij[LC_2D][T12], Tij[LU_2D][T12], Tij[CC_2D][T12], Tij[CU_2D][T12]),
-                         calc_sym_gradx_2D(dx, Tij[LC_2D][T13], Tij[LU_2D][T13], Tij[CC_2D][T13], Tij[CU_2D][T13]),
-                         calc_sym_gradx_2D(dx, Tij[LC_2D][T22], Tij[LU_2D][T22], Tij[CC_2D][T22], Tij[CU_2D][T22]),
-                         calc_sym_gradx_2D(dx, Tij[LC_2D][T23], Tij[LU_2D][T23], Tij[CC_2D][T23], Tij[CU_2D][T23]),
-                         calc_sym_gradx_2D(dx, Tij[LC_2D][T33], Tij[LU_2D][T33], Tij[CC_2D][T33], Tij[CU_2D][T33]) };
-
-    double dTdyLU[6] = { calc_sym_grady_2D(dy, Tij[LC_2D][T11], Tij[LU_2D][T11], Tij[CC_2D][T11], Tij[CU_2D][T11]),
-                         calc_sym_grady_2D(dy, Tij[LC_2D][T12], Tij[LU_2D][T12], Tij[CC_2D][T12], Tij[CU_2D][T12]),
-                         calc_sym_grady_2D(dy, Tij[LC_2D][T13], Tij[LU_2D][T13], Tij[CC_2D][T13], Tij[CU_2D][T13]),
-                         calc_sym_grady_2D(dy, Tij[LC_2D][T22], Tij[LU_2D][T22], Tij[CC_2D][T22], Tij[CU_2D][T22]),
-                         calc_sym_grady_2D(dy, Tij[LC_2D][T23], Tij[LU_2D][T23], Tij[CC_2D][T23], Tij[CU_2D][T23]),
-                         calc_sym_grady_2D(dy, Tij[LC_2D][T33], Tij[LU_2D][T33], Tij[CC_2D][T33], Tij[CU_2D][T33]) };
-
-    double dTdxUL[6] = { calc_sym_gradx_2D(dx, Tij[CL_2D][T11], Tij[CC_2D][T11], Tij[UL_2D][T11], Tij[UC_2D][T11]),
-                         calc_sym_gradx_2D(dx, Tij[CL_2D][T12], Tij[CC_2D][T12], Tij[UL_2D][T12], Tij[UC_2D][T12]),
-                         calc_sym_gradx_2D(dx, Tij[CL_2D][T13], Tij[CC_2D][T13], Tij[UL_2D][T13], Tij[UC_2D][T13]),
-                         calc_sym_gradx_2D(dx, Tij[CL_2D][T22], Tij[CC_2D][T22], Tij[UL_2D][T22], Tij[UC_2D][T22]), 
-                         calc_sym_gradx_2D(dx, Tij[CL_2D][T23], Tij[CC_2D][T23], Tij[UL_2D][T23], Tij[UC_2D][T23]),
-                         calc_sym_gradx_2D(dx, Tij[CL_2D][T33], Tij[CC_2D][T33], Tij[UL_2D][T33], Tij[UC_2D][T33]) };
-
-    double dTdyUL[6] = { calc_sym_grady_2D(dy, Tij[CL_2D][T11], Tij[CC_2D][T11], Tij[UL_2D][T11], Tij[UC_2D][T11]),
-                         calc_sym_grady_2D(dy, Tij[CL_2D][T12], Tij[CC_2D][T12], Tij[UL_2D][T12], Tij[UC_2D][T12]),
-                         calc_sym_grady_2D(dy, Tij[CL_2D][T13], Tij[CC_2D][T13], Tij[UL_2D][T13], Tij[UC_2D][T13]),
-                         calc_sym_grady_2D(dy, Tij[CL_2D][T22], Tij[CC_2D][T22], Tij[UL_2D][T22], Tij[UC_2D][T22]), 
-                         calc_sym_grady_2D(dy, Tij[CL_2D][T23], Tij[CC_2D][T23], Tij[UL_2D][T23], Tij[UC_2D][T23]),
-                         calc_sym_grady_2D(dy, Tij[CL_2D][T33], Tij[CC_2D][T33], Tij[UL_2D][T33], Tij[UC_2D][T33]) };
-
-    double dTdxUU[6] = { calc_sym_gradx_2D(dx, Tij[CC_2D][T11], Tij[CU_2D][T11], Tij[UC_2D][T11], Tij[UU_2D][T11]),
-                         calc_sym_gradx_2D(dx, Tij[CC_2D][T12], Tij[CU_2D][T12], Tij[UC_2D][T12], Tij[UU_2D][T12]),
-                         calc_sym_gradx_2D(dx, Tij[CC_2D][T13], Tij[CU_2D][T13], Tij[UC_2D][T13], Tij[UU_2D][T13]),
-                         calc_sym_gradx_2D(dx, Tij[CC_2D][T22], Tij[CU_2D][T22], Tij[UC_2D][T22], Tij[UU_2D][T22]),
-                         calc_sym_gradx_2D(dx, Tij[CC_2D][T23], Tij[CU_2D][T23], Tij[UC_2D][T23], Tij[UU_2D][T23]),
-                         calc_sym_gradx_2D(dx, Tij[CC_2D][T33], Tij[CU_2D][T33], Tij[UC_2D][T33], Tij[UU_2D][T33]) };
-
-    double dTdyUU[6] = { calc_sym_grady_2D(dy, Tij[CC_2D][T11], Tij[CU_2D][T11], Tij[UC_2D][T11], Tij[UU_2D][T11]),
-                         calc_sym_grady_2D(dy, Tij[CC_2D][T12], Tij[CU_2D][T12], Tij[UC_2D][T12], Tij[UU_2D][T12]),
-                         calc_sym_grady_2D(dy, Tij[CC_2D][T13], Tij[CU_2D][T13], Tij[UC_2D][T13], Tij[UU_2D][T13]),
-                         calc_sym_grady_2D(dy, Tij[CC_2D][T22], Tij[CU_2D][T22], Tij[UC_2D][T22], Tij[UU_2D][T22]),
-                         calc_sym_grady_2D(dy, Tij[CC_2D][T23], Tij[CU_2D][T23], Tij[UC_2D][T23], Tij[UU_2D][T23]),
-                         calc_sym_grady_2D(dy, Tij[CC_2D][T33], Tij[CU_2D][T33], Tij[UC_2D][T33], Tij[UU_2D][T33]) };
-
-    double qLL[10] = {0.0};
-    double qLU[10] = {0.0};
-    double qUL[10] = {0.0};
-    double qUU[10] = {0.0};
-    double alpha = 1.0/gces->k0;
-    
-    qLL[Q111] = alpha*vthLL*rhoLL*(dTdxLL[T11] + dTdxLL[T11] + dTdxLL[T11])/3.0;
-    qLL[Q112] = alpha*vthLL*rhoLL*(dTdxLL[T12] + dTdxLL[T12] + dTdyLL[T11])/3.0;
-    qLL[Q113] = alpha*vthLL*rhoLL*(dTdxLL[T13] + dTdxLL[T13])/3.0;
-    qLL[Q122] = alpha*vthLL*rhoLL*(dTdxLL[T22] + dTdyLL[T12] + dTdyLL[T12])/3.0;
-    qLL[Q123] = alpha*vthLL*rhoLL*(dTdxLL[T23] + dTdyLL[T13])/3.0;
-    qLL[Q133] = alpha*vthLL*rhoLL*(dTdxLL[T33])/3.0; 
-    qLL[Q222] = alpha*vthLL*rhoLL*(dTdyLL[T22] + dTdyLL[T22] + dTdyLL[T22])/3.0;
-    qLL[Q223] = alpha*vthLL*rhoLL*(dTdyLL[T23] + dTdyLL[T23])/3.0;
-    qLL[Q233] = alpha*vthLL*rhoLL*(dTdyLL[T33])/3.0;
-
-    qLU[Q111] = alpha*vthLU*rhoLU*(dTdxLU[T11] + dTdxLU[T11] + dTdxLU[T11])/3.0;
-    qLU[Q112] = alpha*vthLU*rhoLU*(dTdxLU[T12] + dTdxLU[T12] + dTdyLU[T11])/3.0;
-    qLU[Q113] = alpha*vthLU*rhoLU*(dTdxLU[T13] + dTdxLU[T13])/3.0;
-    qLU[Q122] = alpha*vthLU*rhoLU*(dTdxLU[T22] + dTdyLU[T12] + dTdyLU[T12])/3.0;
-    qLU[Q123] = alpha*vthLU*rhoLU*(dTdxLU[T23] + dTdyLU[T13])/3.0;
-    qLU[Q133] = alpha*vthLU*rhoLU*(dTdxLU[T33])/3.0; 
-    qLU[Q222] = alpha*vthLU*rhoLU*(dTdyLU[T22] + dTdyLU[T22] + dTdyLU[T22])/3.0;
-    qLU[Q223] = alpha*vthLU*rhoLU*(dTdyLU[T23] + dTdyLU[T23])/3.0;
-    qLU[Q233] = alpha*vthLU*rhoLU*(dTdyLU[T33])/3.0;
-
-    qUL[Q111] = alpha*vthUL*rhoUL*(dTdxUL[T11] + dTdxUL[T11] + dTdxUL[T11])/3.0;
-    qUL[Q112] = alpha*vthUL*rhoUL*(dTdxUL[T12] + dTdxUL[T12] + dTdyUL[T11])/3.0;
-    qUL[Q113] = alpha*vthUL*rhoUL*(dTdxUL[T13] + dTdxUL[T13])/3.0;
-    qUL[Q122] = alpha*vthUL*rhoUL*(dTdxUL[T22] + dTdyUL[T12] + dTdyUL[T12])/3.0;
-    qUL[Q123] = alpha*vthUL*rhoUL*(dTdxUL[T23] + dTdyUL[T13])/3.0;
-    qUL[Q133] = alpha*vthUL*rhoUL*(dTdxUL[T33])/3.0; 
-    qUL[Q222] = alpha*vthUL*rhoUL*(dTdyUL[T22] + dTdyUL[T22] + dTdyUL[T22])/3.0;
-    qUL[Q223] = alpha*vthUL*rhoUL*(dTdyUL[T23] + dTdyUL[T23])/3.0;
-    qUL[Q233] = alpha*vthUL*rhoUL*(dTdyUL[T33])/3.0;
-
-    qUU[Q111] = alpha*vthUU*rhoUU*(dTdxUU[T11] + dTdxUU[T11] + dTdxUU[T11])/3.0;
-    qUU[Q112] = alpha*vthUU*rhoUU*(dTdxUU[T12] + dTdxUU[T12] + dTdyUU[T11])/3.0;
-    qUU[Q113] = alpha*vthUU*rhoUU*(dTdxUU[T13] + dTdxUU[T13])/3.0;
-    qUU[Q122] = alpha*vthUU*rhoUU*(dTdxUU[T22] + dTdyUU[T12] + dTdyUU[T12])/3.0;
-    qUU[Q123] = alpha*vthUU*rhoUU*(dTdxUU[T23] + dTdyUU[T13])/3.0;
-    qUU[Q133] = alpha*vthUU*rhoUU*(dTdxUU[T33])/3.0; 
-    qUU[Q222] = alpha*vthUU*rhoUU*(dTdyUU[T22] + dTdyUU[T22] + dTdyUU[T22])/3.0;
-    qUU[Q223] = alpha*vthUU*rhoUU*(dTdyUU[T23] + dTdyUU[T23])/3.0;
-    qUU[Q233] = alpha*vthUU*rhoUU*(dTdyUU[T33])/3.0;
-
-    double divQx[6] = { calc_sym_gradx_2D(dx, qLL[Q111], qLU[Q111], qUL[Q111], qUU[Q111]), 
-                        calc_sym_gradx_2D(dx, qLL[Q112], qLU[Q112], qUL[Q112], qUU[Q112]), 
-                        calc_sym_gradx_2D(dx, qLL[Q113], qLU[Q113], qUL[Q113], qUU[Q113]), 
-                        calc_sym_gradx_2D(dx, qLL[Q122], qLU[Q122], qUL[Q122], qUU[Q122]), 
-                        calc_sym_gradx_2D(dx, qLL[Q123], qLU[Q123], qUL[Q123], qUU[Q123]), 
-                        calc_sym_gradx_2D(dx, qLL[Q133], qLU[Q133], qUL[Q133], qUU[Q133]) };
-
-    double divQy[6] = { calc_sym_grady_2D(dy, qLL[Q112], qLU[Q112], qUL[Q112], qUU[Q112]), 
-                        calc_sym_grady_2D(dy, qLL[Q122], qLU[Q122], qUL[Q122], qUU[Q122]), 
-                        calc_sym_grady_2D(dy, qLL[Q123], qLU[Q123], qUL[Q123], qUU[Q123]), 
-                        calc_sym_grady_2D(dy, qLL[Q222], qLU[Q222], qUL[Q222], qUU[Q222]), 
-                        calc_sym_grady_2D(dy, qLL[Q223], qLU[Q223], qUL[Q223], qUU[Q223]), 
-                        calc_sym_grady_2D(dy, qLL[Q233], qLU[Q233], qUL[Q233], qUU[Q233]) };
-
-    rhs_d[RHO] = 0.0;
-    rhs_d[MX] = 0.0;
-    rhs_d[MY] = 0.0;
-    rhs_d[MZ] = 0.0;
-    rhs_d[P11] = divQx[0] + divQy[0];
-    rhs_d[P12] = divQx[1] + divQy[1];
-    rhs_d[P13] = divQx[2] + divQy[2];
-    rhs_d[P22] = divQx[3] + divQy[3];
-    rhs_d[P23] = divQx[4] + divQy[4];
-    rhs_d[P33] = divQx[5] + divQy[5];
+    dTdy[0] = calc_sym_grady_2D(dy, Tij[LL_2D][T11], Tij[LU_2D][T11], Tij[UL_2D][T11], Tij[UU_2D][T11]); 
+    dTdy[1] = calc_sym_grady_2D(dy, Tij[LL_2D][T12], Tij[LU_2D][T12], Tij[UL_2D][T12], Tij[UU_2D][T12]); 
+    dTdy[2] = calc_sym_grady_2D(dy, Tij[LL_2D][T13], Tij[LU_2D][T13], Tij[UL_2D][T13], Tij[UU_2D][T13]); 
+    dTdy[3] = calc_sym_grady_2D(dy, Tij[LL_2D][T22], Tij[LU_2D][T22], Tij[UL_2D][T22], Tij[UU_2D][T22]); 
+    dTdy[4] = calc_sym_grady_2D(dy, Tij[LL_2D][T23], Tij[LU_2D][T23], Tij[UL_2D][T23], Tij[UU_2D][T23]); 
+    dTdy[5] = calc_sym_grady_2D(dy, Tij[LL_2D][T33], Tij[LU_2D][T33], Tij[UL_2D][T33], Tij[UU_2D][T33]);
   }
   else if (ndim == 3) {
     const double dx = gces->grid.dx[0];
     const double dy = gces->grid.dx[1];
     const double dz = gces->grid.dx[2];
-    double Tij[27][6] = {0.0};
-    double rho[27] = {0.0};
-    double p[27] = {0.0}; 
-    for (int j = LLL_3D; j <= UUU_3D; ++j) {
-      rho[j] = fluid_d[j][RHO];
-      p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
-              + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
-              + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
-      Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-      Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];    
-    }
 
-    double rhoLLL = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLC_3D], rho[LCL_3D], rho[LCC_3D], rho[CLL_3D], rho[CLC_3D], rho[CCL_3D], rho[CCC_3D]);
-    double pLLL = calc_harmonic_avg_3D(p[LLL_3D], p[LLC_3D], p[LCL_3D], p[LCC_3D], p[CLL_3D], p[CLC_3D], p[CCL_3D], p[CCC_3D]);
-    double rhoLLU = calc_harmonic_avg_3D(rho[LLC_3D], rho[LLU_3D], rho[LCC_3D], rho[LCU_3D], rho[CLC_3D], rho[CLU_3D], rho[CCC_3D], rho[CCU_3D]);
-    double pLLU = calc_harmonic_avg_3D(p[LLC_3D], p[LLU_3D], p[LCC_3D], p[LCU_3D], p[CLC_3D], p[CLU_3D], p[CCC_3D], p[CCU_3D]);
-    double rhoLUL = calc_harmonic_avg_3D(rho[LCL_3D], rho[LCC_3D], rho[LUL_3D], rho[LUC_3D], rho[CCL_3D], rho[CCC_3D], rho[CUL_3D], rho[CUC_3D]);
-    double pLUL = calc_harmonic_avg_3D(p[LCL_3D], p[LCC_3D], p[LUL_3D], p[LUC_3D], p[CCL_3D], p[CCC_3D], p[CUL_3D], p[CUC_3D]);
-    double rhoLUU = calc_harmonic_avg_3D(rho[LCC_3D], rho[LCU_3D], rho[LUC_3D], rho[LUU_3D], rho[CCC_3D], rho[CCU_3D], rho[CUC_3D], rho[CUU_3D]);
-    double pLUU = calc_harmonic_avg_3D(p[LCC_3D], p[LCU_3D], p[LUC_3D], p[LUU_3D], p[CCC_3D], p[CCU_3D], p[CUC_3D], p[CUU_3D]);
+    double Tij[8][6] = {0.0};
+    double rho[8] = {0.0};
+    double p[8] = {0.0}; 
+    var_setup(gces, LLL_3D, UUU_3D, fluid_d, rho, p, Tij);
 
-    double rhoULL = calc_harmonic_avg_3D(rho[CLL_3D], rho[CLC_3D], rho[CCL_3D], rho[CCC_3D], rho[ULL_3D], rho[ULC_3D], rho[UCL_3D], rho[UCC_3D]);
-    double pULL = calc_harmonic_avg_3D(p[CLL_3D], p[CLC_3D], p[CCL_3D], p[CCC_3D], p[ULL_3D], p[ULC_3D], p[UCL_3D], p[UCC_3D]);
-    double rhoULU = calc_harmonic_avg_3D(rho[CLC_3D], rho[CLU_3D], rho[CCC_3D], rho[CCU_3D], rho[ULC_3D], rho[ULU_3D], rho[UCC_3D], rho[UCU_3D]);
-    double pULU = calc_harmonic_avg_3D(p[CLC_3D], p[CLU_3D], p[CCC_3D], p[CCU_3D], p[ULC_3D], p[ULU_3D], p[UCC_3D], p[UCU_3D]);
-    double rhoUUL = calc_harmonic_avg_3D(rho[CCL_3D], rho[CCC_3D], rho[CUL_3D], rho[CUC_3D], rho[UCL_3D], rho[UCC_3D], rho[UUL_3D], rho[UUC_3D]);
-    double pUUL = calc_harmonic_avg_3D(p[CCL_3D], p[CCC_3D], p[CUL_3D], p[CUC_3D], p[UCL_3D], p[UCC_3D], p[UUL_3D], p[UUC_3D]);
-    double rhoUUU = calc_harmonic_avg_3D(rho[CCC_3D], rho[CCU_3D], rho[CUC_3D], rho[CUU_3D], rho[UCC_3D], rho[UCU_3D], rho[UUC_3D], rho[UUU_3D]);
-    double pUUU = calc_harmonic_avg_3D(p[CCC_3D], p[CCU_3D], p[CUC_3D], p[CUU_3D], p[UCC_3D], p[UCU_3D], p[UUC_3D], p[UUU_3D]);
+    rho_avg = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLU_3D], rho[LUL_3D], rho[LUU_3D],
+                                   rho[ULL_3D], rho[ULU_3D], rho[UUL_3D], rho[UUU_3D]);
+    p_avg = calc_harmonic_avg_3D(p[LLL_3D], p[LLU_3D], p[LUL_3D], p[LUU_3D],
+                                 p[ULL_3D], p[ULU_3D], p[UUL_3D], p[UUU_3D]);
 
-    double vthLLL = sqrt(pLLL/rhoLLL);
-    double vthLLU = sqrt(pLLU/rhoLLU);
-    double vthLUL = sqrt(pLUL/rhoLUL);
-    double vthLUU = sqrt(pLUU/rhoLUU);
+    dTdx[0] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11], 
+                                    Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]); 
+    dTdx[1] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12], 
+                                    Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]); 
+    dTdx[2] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13], 
+                                    Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]); 
+    dTdx[3] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22], 
+                                    Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]); 
+    dTdx[4] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23], 
+                                    Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]); 
+    dTdx[5] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33], 
+                                    Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
 
-    double vthULL = sqrt(pULL/rhoULL);
-    double vthULU = sqrt(pULU/rhoULU);
-    double vthUUL = sqrt(pUUL/rhoUUL);
-    double vthUUU = sqrt(pUUU/rhoUUU);
+    dTdy[0] = calc_sym_grady_3D(dy, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11], 
+                                    Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]); 
+    dTdy[1] = calc_sym_grady_3D(dy, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12], 
+                                    Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]); 
+    dTdy[2] = calc_sym_grady_3D(dy, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13], 
+                                    Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]); 
+    dTdy[3] = calc_sym_grady_3D(dy, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22], 
+                                    Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]); 
+    dTdy[4] = calc_sym_grady_3D(dy, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23], 
+                                    Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]); 
+    dTdy[5] = calc_sym_grady_3D(dy, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33], 
+                                    Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
 
-    double dTdxLLL[6] = { calc_sym_gradx_3D(dx, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
-
-    double dTdyLLL[6] = { calc_sym_grady_3D(dy, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
-
-    double dTdzLLL[6] = { calc_sym_gradz_3D(dz, Tij[LLL_3D][T11], Tij[LLC_3D][T11], Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T12], Tij[LLC_3D][T12], Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T13], Tij[LLC_3D][T13], Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T22], Tij[LLC_3D][T22], Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T23], Tij[LLC_3D][T23], Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[LLL_3D][T33], Tij[LLC_3D][T33], Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33]) };
-
-    double dTdxLLU[6] = { calc_sym_gradx_3D(dx, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
-
-    double dTdyLLU[6] = { calc_sym_grady_3D(dy, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
-
-    double dTdzLLU[6] = { calc_sym_gradz_3D(dz, Tij[LLC_3D][T11], Tij[LLU_3D][T11], Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T12], Tij[LLU_3D][T12], Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T13], Tij[LLU_3D][T13], Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T22], Tij[LLU_3D][T22], Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T23], Tij[LLU_3D][T23], Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[LLC_3D][T33], Tij[LLU_3D][T33], Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33]) };
-
-    double dTdxLUL[6] = { calc_sym_gradx_3D(dx, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
-
-    double dTdyLUL[6] = { calc_sym_grady_3D(dy, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
-
-    double dTdzLUL[6] = { calc_sym_gradz_3D(dz, Tij[LCL_3D][T11], Tij[LCC_3D][T11], Tij[LUL_3D][T11], Tij[LUC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T12], Tij[LCC_3D][T12], Tij[LUL_3D][T12], Tij[LUC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T13], Tij[LCC_3D][T13], Tij[LUL_3D][T13], Tij[LUC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T22], Tij[LCC_3D][T22], Tij[LUL_3D][T22], Tij[LUC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T23], Tij[LCC_3D][T23], Tij[LUL_3D][T23], Tij[LUC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[LCL_3D][T33], Tij[LCC_3D][T33], Tij[LUL_3D][T33], Tij[LUC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33]) };
-
-    double dTdxLUU[6] = { calc_sym_gradx_3D(dx, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
-
-    double dTdyLUU[6] = { calc_sym_grady_3D(dy, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
-
-    double dTdzLUU[6] = { calc_sym_gradz_3D(dz, Tij[LCC_3D][T11], Tij[LCU_3D][T11], Tij[LUC_3D][T11], Tij[LUU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T12], Tij[LCU_3D][T12], Tij[LUC_3D][T12], Tij[LUU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T13], Tij[LCU_3D][T13], Tij[LUC_3D][T13], Tij[LUU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T22], Tij[LCU_3D][T22], Tij[LUC_3D][T22], Tij[LUU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T23], Tij[LCU_3D][T23], Tij[LUC_3D][T23], Tij[LUU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[LCC_3D][T33], Tij[LCU_3D][T33], Tij[LUC_3D][T33], Tij[LUU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33]) };
-
-    double dTdxULL[6] = { calc_sym_gradx_3D(dx, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
-
-    double dTdyULL[6] = { calc_sym_grady_3D(dy, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
-
-    double dTdzULL[6] = { calc_sym_gradz_3D(dz, Tij[CLL_3D][T11], Tij[CLC_3D][T11], Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[ULL_3D][T11], Tij[ULC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T12], Tij[CLC_3D][T12], Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[ULL_3D][T12], Tij[ULC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T13], Tij[CLC_3D][T13], Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[ULL_3D][T13], Tij[ULC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T22], Tij[CLC_3D][T22], Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[ULL_3D][T22], Tij[ULC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T23], Tij[CLC_3D][T23], Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[ULL_3D][T23], Tij[ULC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[CLL_3D][T33], Tij[CLC_3D][T33], Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[ULL_3D][T33], Tij[ULC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33]) };
-
-    double dTdxULU[6] = { calc_sym_gradx_3D(dx, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
-
-    double dTdyULU[6] = { calc_sym_grady_3D(dy, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
-
-    double dTdzULU[6] = { calc_sym_gradz_3D(dz, Tij[CLC_3D][T11], Tij[CLU_3D][T11], Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[ULC_3D][T11], Tij[ULU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T12], Tij[CLU_3D][T12], Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[ULC_3D][T12], Tij[ULU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T13], Tij[CLU_3D][T13], Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[ULC_3D][T13], Tij[ULU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T22], Tij[CLU_3D][T22], Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[ULC_3D][T22], Tij[ULU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T23], Tij[CLU_3D][T23], Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[ULC_3D][T23], Tij[ULU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[CLC_3D][T33], Tij[CLU_3D][T33], Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[ULC_3D][T33], Tij[ULU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33]) };
-
-    double dTdxUUL[6] = { calc_sym_gradx_3D(dx, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
-
-    double dTdyUUL[6] = { calc_sym_grady_3D(dy, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
-
-    double dTdzUUL[6] = { calc_sym_gradz_3D(dz, Tij[CCL_3D][T11], Tij[CCC_3D][T11], Tij[CUL_3D][T11], Tij[CUC_3D][T11], Tij[UCL_3D][T11], Tij[UCC_3D][T11], Tij[UUL_3D][T11], Tij[UUC_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T12], Tij[CCC_3D][T12], Tij[CUL_3D][T12], Tij[CUC_3D][T12], Tij[UCL_3D][T12], Tij[UCC_3D][T12], Tij[UUL_3D][T12], Tij[UUC_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T13], Tij[CCC_3D][T13], Tij[CUL_3D][T13], Tij[CUC_3D][T13], Tij[UCL_3D][T13], Tij[UCC_3D][T13], Tij[UUL_3D][T13], Tij[UUC_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T22], Tij[CCC_3D][T22], Tij[CUL_3D][T22], Tij[CUC_3D][T22], Tij[UCL_3D][T22], Tij[UCC_3D][T22], Tij[UUL_3D][T22], Tij[UUC_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T23], Tij[CCC_3D][T23], Tij[CUL_3D][T23], Tij[CUC_3D][T23], Tij[UCL_3D][T23], Tij[UCC_3D][T23], Tij[UUL_3D][T23], Tij[UUC_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[CCL_3D][T33], Tij[CCC_3D][T33], Tij[CUL_3D][T33], Tij[CUC_3D][T33], Tij[UCL_3D][T33], Tij[UCC_3D][T33], Tij[UUL_3D][T33], Tij[UUC_3D][T33]) };
-
-    double dTdxUUU[6] = { calc_sym_gradx_3D(dx, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
-                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
-                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
-                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
-                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
-                          calc_sym_gradx_3D(dx, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
-
-    double dTdyUUU[6] = { calc_sym_grady_3D(dy, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
-                          calc_sym_grady_3D(dy, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
-                          calc_sym_grady_3D(dy, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
-                          calc_sym_grady_3D(dy, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
-                          calc_sym_grady_3D(dy, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
-                          calc_sym_grady_3D(dy, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
-
-    double dTdzUUU[6] = { calc_sym_gradz_3D(dz, Tij[CCC_3D][T11], Tij[CCU_3D][T11], Tij[CUC_3D][T11], Tij[CUU_3D][T11], Tij[UCC_3D][T11], Tij[UCU_3D][T11], Tij[UUC_3D][T11], Tij[UUU_3D][T11]),
-                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T12], Tij[CCU_3D][T12], Tij[CUC_3D][T12], Tij[CUU_3D][T12], Tij[UCC_3D][T12], Tij[UCU_3D][T12], Tij[UUC_3D][T12], Tij[UUU_3D][T12]),
-                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T13], Tij[CCU_3D][T13], Tij[CUC_3D][T13], Tij[CUU_3D][T13], Tij[UCC_3D][T13], Tij[UCU_3D][T13], Tij[UUC_3D][T13], Tij[UUU_3D][T13]),
-                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T22], Tij[CCU_3D][T22], Tij[CUC_3D][T22], Tij[CUU_3D][T22], Tij[UCC_3D][T22], Tij[UCU_3D][T22], Tij[UUC_3D][T22], Tij[UUU_3D][T22]),
-                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T23], Tij[CCU_3D][T23], Tij[CUC_3D][T23], Tij[CUU_3D][T23], Tij[UCC_3D][T23], Tij[UCU_3D][T23], Tij[UUC_3D][T23], Tij[UUU_3D][T23]),
-                          calc_sym_gradz_3D(dz, Tij[CCC_3D][T33], Tij[CCU_3D][T33], Tij[CUC_3D][T33], Tij[CUU_3D][T33], Tij[UCC_3D][T33], Tij[UCU_3D][T33], Tij[UUC_3D][T33], Tij[UUU_3D][T33]) };
-
-    double qLLL[10] = {0.0};
-    double qLLU[10] = {0.0};
-    double qLUL[10] = {0.0};
-    double qLUU[10] = {0.0};
-    double qULL[10] = {0.0};
-    double qULU[10] = {0.0};
-    double qUUL[10] = {0.0};
-    double qUUU[10] = {0.0};
-    double alpha = 1.0/gces->k0;
-
-    qLLL[Q111] = alpha*vthLLL*rhoLLL*(dTdxLLL[T11] + dTdxLLL[T11] + dTdxLLL[T11])/3.0;
-    qLLL[Q112] = alpha*vthLLL*rhoLLL*(dTdxLLL[T12] + dTdxLLL[T12] + dTdyLLL[T11])/3.0;
-    qLLL[Q113] = alpha*vthLLL*rhoLLL*(dTdxLLL[T13] + dTdxLLL[T13] + dTdzLLL[T11])/3.0;
-    qLLL[Q122] = alpha*vthLLL*rhoLLL*(dTdxLLL[T22] + dTdyLLL[T12] + dTdyLLL[T12])/3.0;
-    qLLL[Q123] = alpha*vthLLL*rhoLLL*(dTdxLLL[T23] + dTdyLLL[T13] + dTdzLLL[T12])/3.0;
-    qLLL[Q133] = alpha*vthLLL*rhoLLL*(dTdxLLL[T33] + dTdzLLL[T13] + dTdzLLL[T13])/3.0;
-    qLLL[Q222] = alpha*vthLLL*rhoLLL*(dTdyLLL[T22] + dTdyLLL[T22] + dTdyLLL[T22])/3.0;
-    qLLL[Q223] = alpha*vthLLL*rhoLLL*(dTdyLLL[T23] + dTdyLLL[T23] + dTdzLLL[T22])/3.0;
-    qLLL[Q233] = alpha*vthLLL*rhoLLL*(dTdyLLL[T33] + dTdzLLL[T23] + dTdzLLL[T23])/3.0;
-    qLLL[Q333] = alpha*vthLLL*rhoLLL*(dTdzLLL[T33] + dTdzLLL[T33] + dTdzLLL[T33])/3.0;
-
-    qLLU[Q111] = alpha*vthLLU*rhoLLU*(dTdxLLU[T11] + dTdxLLU[T11] + dTdxLLU[T11])/3.0;
-    qLLU[Q112] = alpha*vthLLU*rhoLLU*(dTdxLLU[T12] + dTdxLLU[T12] + dTdyLLU[T11])/3.0;
-    qLLU[Q113] = alpha*vthLLU*rhoLLU*(dTdxLLU[T13] + dTdxLLU[T13] + dTdzLLU[T11])/3.0;
-    qLLU[Q122] = alpha*vthLLU*rhoLLU*(dTdxLLU[T22] + dTdyLLU[T12] + dTdyLLU[T12])/3.0;
-    qLLU[Q123] = alpha*vthLLU*rhoLLU*(dTdxLLU[T23] + dTdyLLU[T13] + dTdzLLU[T12])/3.0;
-    qLLU[Q133] = alpha*vthLLU*rhoLLU*(dTdxLLU[T33] + dTdzLLU[T13] + dTdzLLU[T13])/3.0;
-    qLLU[Q222] = alpha*vthLLU*rhoLLU*(dTdyLLU[T22] + dTdyLLU[T22] + dTdyLLU[T22])/3.0;
-    qLLU[Q223] = alpha*vthLLU*rhoLLU*(dTdyLLU[T23] + dTdyLLU[T23] + dTdzLLU[T22])/3.0;
-    qLLU[Q233] = alpha*vthLLU*rhoLLU*(dTdyLLU[T33] + dTdzLLU[T23] + dTdzLLU[T23])/3.0;
-    qLLU[Q333] = alpha*vthLLU*rhoLLU*(dTdzLLU[T33] + dTdzLLU[T33] + dTdzLLU[T33])/3.0;
-
-    qLUL[Q111] = alpha*vthLUL*rhoLUL*(dTdxLUL[T11] + dTdxLUL[T11] + dTdxLUL[T11])/3.0;
-    qLUL[Q112] = alpha*vthLUL*rhoLUL*(dTdxLUL[T12] + dTdxLUL[T12] + dTdyLUL[T11])/3.0;
-    qLUL[Q113] = alpha*vthLUL*rhoLUL*(dTdxLUL[T13] + dTdxLUL[T13] + dTdzLUL[T11])/3.0;
-    qLUL[Q122] = alpha*vthLUL*rhoLUL*(dTdxLUL[T22] + dTdyLUL[T12] + dTdyLUL[T12])/3.0;
-    qLUL[Q123] = alpha*vthLUL*rhoLUL*(dTdxLUL[T23] + dTdyLUL[T13] + dTdzLUL[T12])/3.0;
-    qLUL[Q133] = alpha*vthLUL*rhoLUL*(dTdxLUL[T33] + dTdzLUL[T13] + dTdzLUL[T13])/3.0;
-    qLUL[Q222] = alpha*vthLUL*rhoLUL*(dTdyLUL[T22] + dTdyLUL[T22] + dTdyLUL[T22])/3.0;
-    qLUL[Q223] = alpha*vthLUL*rhoLUL*(dTdyLUL[T23] + dTdyLUL[T23] + dTdzLUL[T22])/3.0;
-    qLUL[Q233] = alpha*vthLUL*rhoLUL*(dTdyLUL[T33] + dTdzLUL[T23] + dTdzLUL[T23])/3.0;
-    qLUL[Q333] = alpha*vthLUL*rhoLUL*(dTdzLUL[T33] + dTdzLUL[T33] + dTdzLUL[T33])/3.0;
-
-    qLUU[Q111] = alpha*vthLUU*rhoLUU*(dTdxLUU[T11] + dTdxLUU[T11] + dTdxLUU[T11])/3.0;
-    qLUU[Q112] = alpha*vthLUU*rhoLUU*(dTdxLUU[T12] + dTdxLUU[T12] + dTdyLUU[T11])/3.0;
-    qLUU[Q113] = alpha*vthLUU*rhoLUU*(dTdxLUU[T13] + dTdxLUU[T13] + dTdzLUU[T11])/3.0;
-    qLUU[Q122] = alpha*vthLUU*rhoLUU*(dTdxLUU[T22] + dTdyLUU[T12] + dTdyLUU[T12])/3.0;
-    qLUU[Q123] = alpha*vthLUU*rhoLUU*(dTdxLUU[T23] + dTdyLUU[T13] + dTdzLUU[T12])/3.0;
-    qLUU[Q133] = alpha*vthLUU*rhoLUU*(dTdxLUU[T33] + dTdzLUU[T13] + dTdzLUU[T13])/3.0;
-    qLUU[Q222] = alpha*vthLUU*rhoLUU*(dTdyLUU[T22] + dTdyLUU[T22] + dTdyLUU[T22])/3.0;
-    qLUU[Q223] = alpha*vthLUU*rhoLUU*(dTdyLUU[T23] + dTdyLUU[T23] + dTdzLUU[T22])/3.0;
-    qLUU[Q233] = alpha*vthLUU*rhoLUU*(dTdyLUU[T33] + dTdzLUU[T23] + dTdzLUU[T23])/3.0;
-    qLUU[Q333] = alpha*vthLUU*rhoLUU*(dTdzLUU[T33] + dTdzLUU[T33] + dTdzLUU[T33])/3.0;
-
-    qULL[Q111] = alpha*vthULL*rhoULL*(dTdxULL[T11] + dTdxULL[T11] + dTdxULL[T11])/3.0;
-    qULL[Q112] = alpha*vthULL*rhoULL*(dTdxULL[T12] + dTdxULL[T12] + dTdyULL[T11])/3.0;
-    qULL[Q113] = alpha*vthULL*rhoULL*(dTdxULL[T13] + dTdxULL[T13] + dTdzULL[T11])/3.0;
-    qULL[Q122] = alpha*vthULL*rhoULL*(dTdxULL[T22] + dTdyULL[T12] + dTdyULL[T12])/3.0;
-    qULL[Q123] = alpha*vthULL*rhoULL*(dTdxULL[T23] + dTdyULL[T13] + dTdzULL[T12])/3.0;
-    qULL[Q133] = alpha*vthULL*rhoULL*(dTdxULL[T33] + dTdzULL[T13] + dTdzULL[T13])/3.0;
-    qULL[Q222] = alpha*vthULL*rhoULL*(dTdyULL[T22] + dTdyULL[T22] + dTdyULL[T22])/3.0;
-    qULL[Q223] = alpha*vthULL*rhoULL*(dTdyULL[T23] + dTdyULL[T23] + dTdzULL[T22])/3.0;
-    qULL[Q233] = alpha*vthULL*rhoULL*(dTdyULL[T33] + dTdzULL[T23] + dTdzULL[T23])/3.0;
-    qULL[Q333] = alpha*vthULL*rhoULL*(dTdzULL[T33] + dTdzULL[T33] + dTdzULL[T33])/3.0;
-
-    qULU[Q111] = alpha*vthULU*rhoULU*(dTdxULU[T11] + dTdxULU[T11] + dTdxULU[T11])/3.0;
-    qULU[Q112] = alpha*vthULU*rhoULU*(dTdxULU[T12] + dTdxULU[T12] + dTdyULU[T11])/3.0;
-    qULU[Q113] = alpha*vthULU*rhoULU*(dTdxULU[T13] + dTdxULU[T13] + dTdzULU[T11])/3.0;
-    qULU[Q122] = alpha*vthULU*rhoULU*(dTdxULU[T22] + dTdyULU[T12] + dTdyULU[T12])/3.0;
-    qULU[Q123] = alpha*vthULU*rhoULU*(dTdxULU[T23] + dTdyULU[T13] + dTdzULU[T12])/3.0;
-    qULU[Q133] = alpha*vthULU*rhoULU*(dTdxULU[T33] + dTdzULU[T13] + dTdzULU[T13])/3.0;
-    qULU[Q222] = alpha*vthULU*rhoULU*(dTdyULU[T22] + dTdyULU[T22] + dTdyULU[T22])/3.0;
-    qULU[Q223] = alpha*vthULU*rhoULU*(dTdyULU[T23] + dTdyULU[T23] + dTdzULU[T22])/3.0;
-    qULU[Q233] = alpha*vthULU*rhoULU*(dTdyULU[T33] + dTdzULU[T23] + dTdzULU[T23])/3.0;
-    qULU[Q333] = alpha*vthULU*rhoULU*(dTdzULU[T33] + dTdzULU[T33] + dTdzULU[T33])/3.0;
-
-    qUUL[Q111] = alpha*vthUUL*rhoUUL*(dTdxUUL[T11] + dTdxUUL[T11] + dTdxUUL[T11])/3.0;
-    qUUL[Q112] = alpha*vthUUL*rhoUUL*(dTdxUUL[T12] + dTdxUUL[T12] + dTdyUUL[T11])/3.0;
-    qUUL[Q113] = alpha*vthUUL*rhoUUL*(dTdxUUL[T13] + dTdxUUL[T13] + dTdzUUL[T11])/3.0;
-    qUUL[Q122] = alpha*vthUUL*rhoUUL*(dTdxUUL[T22] + dTdyUUL[T12] + dTdyUUL[T12])/3.0;
-    qUUL[Q123] = alpha*vthUUL*rhoUUL*(dTdxUUL[T23] + dTdyUUL[T13] + dTdzUUL[T12])/3.0;
-    qUUL[Q133] = alpha*vthUUL*rhoUUL*(dTdxUUL[T33] + dTdzUUL[T13] + dTdzUUL[T13])/3.0;
-    qUUL[Q222] = alpha*vthUUL*rhoUUL*(dTdyUUL[T22] + dTdyUUL[T22] + dTdyUUL[T22])/3.0;
-    qUUL[Q223] = alpha*vthUUL*rhoUUL*(dTdyUUL[T23] + dTdyUUL[T23] + dTdzUUL[T22])/3.0;
-    qUUL[Q233] = alpha*vthUUL*rhoUUL*(dTdyUUL[T33] + dTdzUUL[T23] + dTdzUUL[T23])/3.0;
-    qUUL[Q333] = alpha*vthUUL*rhoUUL*(dTdzUUL[T33] + dTdzUUL[T33] + dTdzUUL[T33])/3.0;
-
-    qUUU[Q111] = alpha*vthUUU*rhoUUU*(dTdxUUU[T11] + dTdxUUU[T11] + dTdxUUU[T11])/3.0;
-    qUUU[Q112] = alpha*vthUUU*rhoUUU*(dTdxUUU[T12] + dTdxUUU[T12] + dTdyUUU[T11])/3.0;
-    qUUU[Q113] = alpha*vthUUU*rhoUUU*(dTdxUUU[T13] + dTdxUUU[T13] + dTdzUUU[T11])/3.0;
-    qUUU[Q122] = alpha*vthUUU*rhoUUU*(dTdxUUU[T22] + dTdyUUU[T12] + dTdyUUU[T12])/3.0;
-    qUUU[Q123] = alpha*vthUUU*rhoUUU*(dTdxUUU[T23] + dTdyUUU[T13] + dTdzUUU[T12])/3.0;
-    qUUU[Q133] = alpha*vthUUU*rhoUUU*(dTdxUUU[T33] + dTdzUUU[T13] + dTdzUUU[T13])/3.0;
-    qUUU[Q222] = alpha*vthUUU*rhoUUU*(dTdyUUU[T22] + dTdyUUU[T22] + dTdyUUU[T22])/3.0;
-    qUUU[Q223] = alpha*vthUUU*rhoUUU*(dTdyUUU[T23] + dTdyUUU[T23] + dTdzUUU[T22])/3.0;
-    qUUU[Q233] = alpha*vthUUU*rhoUUU*(dTdyUUU[T33] + dTdzUUU[T23] + dTdzUUU[T23])/3.0;
-    qUUU[Q333] = alpha*vthUUU*rhoUUU*(dTdzUUU[T33] + dTdzUUU[T33] + dTdzUUU[T33])/3.0;
-
-    double divQx[6] = { calc_sym_gradx_3D(dx, qLLL[Q111], qLLU[Q111], qLUL[Q111], qLUU[Q111], qULL[Q111], qULU[Q111], qUUL[Q111], qUUU[Q111]), 
-                        calc_sym_gradx_3D(dx, qLLL[Q112], qLLU[Q112], qLUL[Q112], qLUU[Q112], qULL[Q112], qULU[Q112], qUUL[Q112], qUUU[Q112]), 
-                        calc_sym_gradx_3D(dx, qLLL[Q113], qLLU[Q113], qLUL[Q113], qLUU[Q113], qULL[Q113], qULU[Q113], qUUL[Q113], qUUU[Q113]), 
-                        calc_sym_gradx_3D(dx, qLLL[Q122], qLLU[Q122], qLUL[Q122], qLUU[Q122], qULL[Q122], qULU[Q122], qUUL[Q122], qUUU[Q122]), 
-                        calc_sym_gradx_3D(dx, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
-                        calc_sym_gradx_3D(dx, qLLL[Q133], qLLU[Q133], qLUL[Q133], qLUU[Q133], qULL[Q133], qULU[Q133], qUUL[Q133], qUUU[Q133]) };
-
-    double divQy[6] = { calc_sym_grady_3D(dy, qLLL[Q112], qLLU[Q112], qLUL[Q112], qLUU[Q112], qULL[Q112], qULU[Q112], qUUL[Q112], qUUU[Q112]), 
-                        calc_sym_grady_3D(dy, qLLL[Q122], qLLU[Q122], qLUL[Q122], qLUU[Q122], qULL[Q122], qULU[Q122], qUUL[Q122], qUUU[Q122]), 
-                        calc_sym_grady_3D(dy, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
-                        calc_sym_grady_3D(dy, qLLL[Q222], qLLU[Q222], qLUL[Q222], qLUU[Q222], qULL[Q222], qULU[Q222], qUUL[Q222], qUUU[Q222]), 
-                        calc_sym_grady_3D(dy, qLLL[Q223], qLLU[Q223], qLUL[Q223], qLUU[Q223], qULL[Q223], qULU[Q223], qUUL[Q223], qUUU[Q223]), 
-                        calc_sym_grady_3D(dy, qLLL[Q233], qLLU[Q233], qLUL[Q233], qLUU[Q233], qULL[Q233], qULU[Q233], qUUL[Q233], qUUU[Q233]) };
-
-    double divQz[6] = { calc_sym_gradz_3D(dz, qLLL[Q113], qLLU[Q113], qLUL[Q113], qLUU[Q113], qULL[Q113], qULU[Q113], qUUL[Q113], qUUU[Q113]), 
-                        calc_sym_gradz_3D(dz, qLLL[Q123], qLLU[Q123], qLUL[Q123], qLUU[Q123], qULL[Q123], qULU[Q123], qUUL[Q123], qUUU[Q123]), 
-                        calc_sym_gradz_3D(dz, qLLL[Q133], qLLU[Q133], qLUL[Q133], qLUU[Q133], qULL[Q133], qULU[Q133], qUUL[Q133], qUUU[Q133]), 
-                        calc_sym_gradz_3D(dz, qLLL[Q223], qLLU[Q223], qLUL[Q223], qLUU[Q223], qULL[Q223], qULU[Q223], qUUL[Q223], qUUU[Q223]), 
-                        calc_sym_gradz_3D(dz, qLLL[Q233], qLLU[Q233], qLUL[Q233], qLUU[Q233], qULL[Q233], qULU[Q233], qUUL[Q233], qUUU[Q233]), 
-                        calc_sym_gradz_3D(dz, qLLL[Q333], qLLU[Q333], qLUL[Q333], qLUU[Q333], qULL[Q333], qULU[Q333], qUUL[Q333], qUUU[Q333]) };
-
-    rhs_d[RHO] = 0.0;
-    rhs_d[MX] = 0.0;
-    rhs_d[MY] = 0.0;
-    rhs_d[MZ] = 0.0;
-    rhs_d[P11] = divQx[0] + divQy[0] + divQz[0];
-    rhs_d[P12] = divQx[1] + divQy[1] + divQz[1];
-    rhs_d[P13] = divQx[2] + divQy[2] + divQz[2];
-    rhs_d[P22] = divQx[3] + divQy[3] + divQz[3];
-    rhs_d[P23] = divQx[4] + divQy[4] + divQz[4];
-    rhs_d[P33] = divQx[5] + divQy[5] + divQz[5];
+    dTdz[0] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11], 
+                                    Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]); 
+    dTdz[1] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12], 
+                                    Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]); 
+    dTdz[2] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13], 
+                                    Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]); 
+    dTdz[3] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22], 
+                                    Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]); 
+    dTdz[4] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23], 
+                                    Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]); 
+    dTdz[5] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33], 
+                                    Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
   }
+  double alpha = 1.0/gces->k0;
+  double vth_avg = sqrt(p_avg/rho_avg);
+  heat_flux_d[Q111] = alpha*vth_avg*rho_avg*(dTdx[T11] + dTdx[T11] + dTdx[T11])/3.0;
+  heat_flux_d[Q112] = alpha*vth_avg*rho_avg*(dTdx[T12] + dTdx[T12] + dTdy[T11])/3.0;
+  heat_flux_d[Q113] = alpha*vth_avg*rho_avg*(dTdx[T13] + dTdx[T13] + dTdz[T11])/3.0;
+  heat_flux_d[Q122] = alpha*vth_avg*rho_avg*(dTdx[T22] + dTdy[T12] + dTdy[T12])/3.0;
+  heat_flux_d[Q123] = alpha*vth_avg*rho_avg*(dTdx[T23] + dTdy[T13] + dTdz[T12])/3.0;
+  heat_flux_d[Q133] = alpha*vth_avg*rho_avg*(dTdx[T33] + dTdz[T13] + dTdz[T13])/3.0;
+  heat_flux_d[Q222] = alpha*vth_avg*rho_avg*(dTdy[T22] + dTdy[T22] + dTdy[T22])/3.0;
+  heat_flux_d[Q223] = alpha*vth_avg*rho_avg*(dTdy[T23] + dTdy[T23] + dTdz[T22])/3.0;
+  heat_flux_d[Q233] = alpha*vth_avg*rho_avg*(dTdy[T33] + dTdz[T23] + dTdz[T23])/3.0;
+  heat_flux_d[Q333] = alpha*vth_avg*rho_avg*(dTdz[T33] + dTdz[T33] + dTdz[T33])/3.0;
+}
+
+static void
+calc_grad_closure_update(const gkyl_ten_moment_grad_closure *gces,
+  const double *heat_flux_d[], double *rhs)
+{
+  const int ndim = gces->ndim;
+  double divQx[6] = {0.0};
+  double divQy[6] = {0.0};
+  double divQz[6] = {0.0};
+
+  if (ndim == 1) {
+    const double dx = gces->grid.dx[0];
+    double q[2][10] = {0.0};
+    for (int j = L_1D; j <= U_1D; ++j)
+      for (int k = 0; k < 10; ++k)
+        q[j][k] = heat_flux_d[j][k];
+
+    divQx[0] = calc_sym_grad_1D(dx, q[L_1D][Q111], q[U_1D][Q111]); 
+    divQx[1] = calc_sym_grad_1D(dx, q[L_1D][Q112], q[U_1D][Q112]); 
+    divQx[2] = calc_sym_grad_1D(dx, q[L_1D][Q113], q[U_1D][Q113]); 
+    divQx[3] = calc_sym_grad_1D(dx, q[L_1D][Q122], q[U_1D][Q122]); 
+    divQx[4] = calc_sym_grad_1D(dx, q[L_1D][Q123], q[U_1D][Q123]); 
+    divQx[5] = calc_sym_grad_1D(dx, q[L_1D][Q133], q[U_1D][Q133]);
+  }
+  else if (ndim == 2) {
+    const double dx = gces->grid.dx[0];
+    const double dy = gces->grid.dx[1];
+    double q[4][10] = {0.0};
+    for (int j = LL_2D; j <= UU_2D; ++j)
+      for (int k = 0; k < 10; ++k)
+        q[j][k] = heat_flux_d[j][k];
+
+    divQx[0] = calc_sym_gradx_2D(dx, q[LL_2D][Q111], q[LU_2D][Q111], q[UL_2D][Q111], q[UU_2D][Q111]); 
+    divQx[1] = calc_sym_gradx_2D(dx, q[LL_2D][Q112], q[LU_2D][Q112], q[UL_2D][Q112], q[UU_2D][Q112]); 
+    divQx[2] = calc_sym_gradx_2D(dx, q[LL_2D][Q113], q[LU_2D][Q113], q[UL_2D][Q113], q[UU_2D][Q113]); 
+    divQx[3] = calc_sym_gradx_2D(dx, q[LL_2D][Q122], q[LU_2D][Q122], q[UL_2D][Q122], q[UU_2D][Q122]); 
+    divQx[4] = calc_sym_gradx_2D(dx, q[LL_2D][Q123], q[LU_2D][Q123], q[UL_2D][Q123], q[UU_2D][Q123]); 
+    divQx[5] = calc_sym_gradx_2D(dx, q[LL_2D][Q133], q[LU_2D][Q133], q[UL_2D][Q133], q[UU_2D][Q133]);
+
+    divQy[0] = calc_sym_grady_2D(dy, q[LL_2D][Q112], q[LU_2D][Q112], q[UL_2D][Q112], q[UU_2D][Q112]); 
+    divQy[1] = calc_sym_grady_2D(dy, q[LL_2D][Q122], q[LU_2D][Q122], q[UL_2D][Q122], q[UU_2D][Q122]); 
+    divQy[2] = calc_sym_grady_2D(dy, q[LL_2D][Q123], q[LU_2D][Q123], q[UL_2D][Q123], q[UU_2D][Q123]); 
+    divQy[3] = calc_sym_grady_2D(dy, q[LL_2D][Q222], q[LU_2D][Q222], q[UL_2D][Q222], q[UU_2D][Q222]); 
+    divQy[4] = calc_sym_grady_2D(dy, q[LL_2D][Q223], q[LU_2D][Q223], q[UL_2D][Q223], q[UU_2D][Q223]); 
+    divQy[5] = calc_sym_grady_2D(dy, q[LL_2D][Q233], q[LU_2D][Q233], q[UL_2D][Q233], q[UU_2D][Q233]);
+  }
+  else if (ndim == 3) {
+    const double dx = gces->grid.dx[0];
+    const double dy = gces->grid.dx[1];
+    const double dz = gces->grid.dx[2];
+    double q[8][10] = {0.0};
+    for (int j = LLL_3D; j <= UUU_3D; ++j)
+      for (int k = 0; k < 10; ++k)
+        q[j][k] = heat_flux_d[j][k];
+
+    divQx[0] = calc_sym_gradx_3D(dx, q[LLL_3D][Q111], q[LLU_3D][Q111], q[LUL_3D][Q111], q[LUU_3D][Q111], 
+                                     q[ULL_3D][Q111], q[ULU_3D][Q111], q[UUL_3D][Q111], q[UUU_3D][Q111]); 
+    divQx[1] = calc_sym_gradx_3D(dx, q[LLL_3D][Q112], q[LLU_3D][Q112], q[LUL_3D][Q112], q[LUU_3D][Q112], 
+                                     q[ULL_3D][Q112], q[ULU_3D][Q112], q[UUL_3D][Q112], q[UUU_3D][Q112]); 
+    divQx[2] = calc_sym_gradx_3D(dx, q[LLL_3D][Q113], q[LLU_3D][Q113], q[LUL_3D][Q113], q[LUU_3D][Q113], 
+                                     q[ULL_3D][Q113], q[ULU_3D][Q113], q[UUL_3D][Q113], q[UUU_3D][Q113]); 
+    divQx[3] = calc_sym_gradx_3D(dx, q[LLL_3D][Q122], q[LLU_3D][Q122], q[LUL_3D][Q122], q[LUU_3D][Q122], 
+                                     q[ULL_3D][Q122], q[ULU_3D][Q122], q[UUL_3D][Q122], q[UUU_3D][Q122]); 
+    divQx[4] = calc_sym_gradx_3D(dx, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123], 
+                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]); 
+    divQx[5] = calc_sym_gradx_3D(dx, q[LLL_3D][Q133], q[LLU_3D][Q133], q[LUL_3D][Q133], q[LUU_3D][Q133], 
+                                     q[ULL_3D][Q133], q[ULU_3D][Q133], q[UUL_3D][Q133], q[UUU_3D][Q133]);
+
+    divQy[0] = calc_sym_grady_3D(dy, q[LLL_3D][Q112], q[LLU_3D][Q112], q[LUL_3D][Q112], q[LUU_3D][Q112], 
+                                     q[ULL_3D][Q112], q[ULU_3D][Q112], q[UUL_3D][Q112], q[UUU_3D][Q112]); 
+    divQy[1] = calc_sym_grady_3D(dy, q[LLL_3D][Q122], q[LLU_3D][Q122], q[LUL_3D][Q122], q[LUU_3D][Q122], 
+                                     q[ULL_3D][Q122], q[ULU_3D][Q122], q[UUL_3D][Q122], q[UUU_3D][Q122]); 
+    divQy[2] = calc_sym_grady_3D(dy, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123], 
+                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]); 
+    divQy[3] = calc_sym_grady_3D(dy, q[LLL_3D][Q222], q[LLU_3D][Q222], q[LUL_3D][Q222], q[LUU_3D][Q222], 
+                                     q[ULL_3D][Q222], q[ULU_3D][Q222], q[UUL_3D][Q222], q[UUU_3D][Q222]); 
+    divQy[4] = calc_sym_grady_3D(dy, q[LLL_3D][Q223], q[LLU_3D][Q223], q[LUL_3D][Q223], q[LUU_3D][Q223], 
+                                     q[ULL_3D][Q223], q[ULU_3D][Q223], q[UUL_3D][Q223], q[UUU_3D][Q223]); 
+    divQy[5] = calc_sym_grady_3D(dy, q[LLL_3D][Q233], q[LLU_3D][Q233], q[LUL_3D][Q233], q[LUU_3D][Q233], 
+                                     q[ULL_3D][Q233], q[ULU_3D][Q233], q[UUL_3D][Q233], q[UUU_3D][Q233]);
+
+    divQz[0] = calc_sym_gradz_3D(dz, q[LLL_3D][Q113], q[LLU_3D][Q113], q[LUL_3D][Q113], q[LUU_3D][Q113], 
+                                     q[ULL_3D][Q113], q[ULU_3D][Q113], q[UUL_3D][Q113], q[UUU_3D][Q113]); 
+    divQz[1] = calc_sym_gradz_3D(dz, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123], 
+                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]); 
+    divQz[2] = calc_sym_gradz_3D(dz, q[LLL_3D][Q133], q[LLU_3D][Q133], q[LUL_3D][Q133], q[LUU_3D][Q133], 
+                                     q[ULL_3D][Q133], q[ULU_3D][Q133], q[UUL_3D][Q133], q[UUU_3D][Q133]); 
+    divQz[3] = calc_sym_gradz_3D(dz, q[LLL_3D][Q223], q[LLU_3D][Q223], q[LUL_3D][Q223], q[LUU_3D][Q223], 
+                                     q[ULL_3D][Q223], q[ULU_3D][Q223], q[UUL_3D][Q223], q[UUU_3D][Q223]); 
+    divQz[4] = calc_sym_gradz_3D(dz, q[LLL_3D][Q233], q[LLU_3D][Q233], q[LUL_3D][Q233], q[LUU_3D][Q233], 
+                                     q[ULL_3D][Q233], q[ULU_3D][Q233], q[UUL_3D][Q233], q[UUU_3D][Q233]); 
+    divQz[5] = calc_sym_gradz_3D(dz, q[LLL_3D][Q333], q[LLU_3D][Q333], q[LUL_3D][Q333], q[LUU_3D][Q333], 
+                                     q[ULL_3D][Q333], q[ULU_3D][Q333], q[UUL_3D][Q333], q[UUU_3D][Q333]);
+  }
+  rhs[RHO] = 0.0;
+  rhs[MX] = 0.0;
+  rhs[MY] = 0.0;
+  rhs[MZ] = 0.0;
+  rhs[P11] = divQx[0] + divQy[0] + divQz[0];
+  rhs[P12] = divQx[1] + divQy[1] + divQz[1];
+  rhs[P13] = divQx[2] + divQy[2] + divQz[2];
+  rhs[P22] = divQx[3] + divQy[3] + divQz[3];
+  rhs[P23] = divQx[4] + divQy[4] + divQz[4];
+  rhs[P33] = divQx[5] + divQy[5] + divQz[5];
 }
 
 gkyl_ten_moment_grad_closure*
@@ -664,30 +339,56 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 
 void
 gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces, 
-  const struct gkyl_range *update_range,
+  const struct gkyl_range *heat_flux_range, const struct gkyl_range *update_range,
   const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
-  struct gkyl_array *cflrate, struct gkyl_array *rhs)
+  struct gkyl_array *cflrate, struct gkyl_array *heat_flux, 
+  struct gkyl_array *rhs)
 {
   int ndim = update_range->ndim;
-  long sz[] = { 3, 9, 27 };
+  long sz[] = { 2, 4, 8 };
 
-  long offsets[sz[ndim-1]];
-  create_offsets(update_range, offsets);
+  long offsets_vertices[sz[ndim-1]];
+  create_offsets_vertices(heat_flux_range, offsets_vertices);
 
+  long offsets_centers[sz[ndim-1]];
+  create_offsets_centers(update_range, offsets_centers);
+  
   const double* fluid_d[sz[ndim-1]];
+  const double* em_tot_d[sz[ndim-1]];
+  double *heat_flux_d;
+  const double* heat_flux_up[sz[ndim-1]];
   double *rhs_d;
 
-  struct gkyl_range_iter iter;
-  gkyl_range_iter_init(&iter, update_range);
-  while (gkyl_range_iter_next(&iter)) {
+  struct gkyl_range_iter iter_vertex;
+  gkyl_range_iter_init(&iter_vertex, heat_flux_range);
+  while (gkyl_range_iter_next(&iter_vertex)) {
     
-    long linc = gkyl_range_idx(update_range, iter.idx);
+    long linc_vertex = gkyl_range_idx(heat_flux_range, iter_vertex.idx);
+    long linc_center = gkyl_range_idx(update_range, iter_vertex.idx);
+    
+    for (int i=0; i<sz[ndim-1]; ++i) {
+      em_tot_d[i] =  gkyl_array_cfetch(em_tot, linc_center + offsets_vertices[i]); 
+      fluid_d[i] = gkyl_array_cfetch(fluid, linc_center + offsets_vertices[i]);
+    }
+    
+    heat_flux_d = gkyl_array_fetch(heat_flux, linc_vertex);
+
+    calc_unmag_heat_flux(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center), heat_flux_d);
+  }
+
+  struct gkyl_range_iter iter_center;
+  gkyl_range_iter_init(&iter_center, update_range);
+  while (gkyl_range_iter_next(&iter_center)) {
+    
+    long linc_vertex = gkyl_range_idx(heat_flux_range, iter_center.idx);
+    long linc_center = gkyl_range_idx(update_range, iter_center.idx);
     
     for (int i=0; i<sz[ndim-1]; ++i)
-      fluid_d[i] =  gkyl_array_cfetch(fluid, linc + offsets[i]); 
+      heat_flux_up[i] = gkyl_array_fetch(heat_flux, linc_vertex + offsets_centers[i]);
+    
+    rhs_d = gkyl_array_fetch(rhs, linc_center);
 
-    rhs_d = gkyl_array_fetch(rhs, linc);
-    unmag_grad_closure_update(gces, fluid_d, gkyl_array_fetch(cflrate, linc), rhs_d);
+    calc_grad_closure_update(gces, heat_flux_up, rhs_d);
   }
 }
 


### PR DESCRIPTION
We have had a functional gradient-based closure in 10 moment in at least 2 different branches but we have never merged it into main because we were always doing additional development work in those branches. 

I have adapted the gradient-based closure to be functional in the current version of main by just adding an additional RHS term to the pressure before it's rotated around the magnetic field (i.e., treating div(q) as an explicit source in the time integration).

In the long term we will want to split the non-ideal terms out from the source solve (or make the source solve do another operator split to treat these types of dissipative terms). But the gradient-based closure is very mature (especially compared to Braginskii) and people want to use it, so let's get this functionality in main.

NOTE: STILL NEEDS CORNER SYNCS IN 3D FOR FULL FUNCTIONALITY