### PR TITLE
Collisions between 5-moment fluid species

### DIFF
--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -91,6 +91,11 @@ struct gkyl_moment {
   int num_species; // number of species
   struct gkyl_moment_species species[GKYL_MAX_SPECIES]; // species objects
   struct gkyl_moment_field field; // field object
+
+  bool has_collision; // has collisions
+  // scaling factors for collision frequencies so that nu_sr=nu_base_sr/rho_s
+  // nu_rs=nu_base_rs/rho_r, and nu_base_sr=nu_base_rs
+  double nu_base[GKYL_MAX_SPECIES][GKYL_MAX_SPECIES];
 };
 
 // Simulation statistics

--- a/apps/gkyl_moment_priv.h
+++ b/apps/gkyl_moment_priv.h
@@ -206,6 +206,11 @@ struct gkyl_moment_app {
 
   // pointer to function that takes a single-step of simulation
   struct gkyl_update_status (*update_func)(gkyl_moment_app* app, double dt0);
+
+  bool has_collision; // has collisions
+  // scaling factors for collision frequencies so that nu_sr=nu_base_sr/rho_s
+  // nu_rs=nu_base_rs/rho_r, and nu_base_sr=nu_base_rs
+  double nu_base[GKYL_MAX_SPECIES][GKYL_MAX_SPECIES];
 };
 
 /** Some common functions to species and fields */

--- a/apps/mom_coupling.c
+++ b/apps/mom_coupling.c
@@ -21,6 +21,11 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
       .k0 = app->species[i].has_grad_closure ? 0.0 : app->species[i].k0,
     };
 
+  src_inp.has_collision = app->has_collision;
+  for (int s=0; s<app->num_species; ++s)
+    for (int r=0; r<app->num_species; ++r)
+      src_inp.nu_base[s][r] = app->nu_base[s][r];
+
   // create updater to solve for sources
   src->slvr = gkyl_moment_em_coupling_new(src_inp);
 

--- a/apps/moment.c
+++ b/apps/moment.c
@@ -96,6 +96,13 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
   for (int i=0; i<ns; ++i)
     moment_species_init(mom, &mom->species[i], app, &app->species[i]);
 
+  // specify collision parameters in the exposed app
+  app->has_collision = mom->has_collision;
+  int num_entries = app->num_species * (app->num_species-1) / 2;
+  for (int s=0; s<app->num_species; ++s)
+    for (int r=0; r<app->num_species; ++r)
+      app->nu_base[s][r] = mom->nu_base[s][r];
+
   // check if we should update sources
   app->update_sources = 0;
   if (app->has_field && ns>0) {

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -51,6 +51,11 @@ test_mat_base()
     for (size_t i=0; i<m->nr; ++i)
       TEST_CHECK( gkyl_mat_get(m, i, j) == gkyl_mat_get(m2, i, j) );
 
+  double old = gkyl_mat_get(m, 3, 4);
+  double inc = -123.0;
+  gkyl_mat_inc(m, 3, 4, inc);
+  TEST_CHECK( gkyl_mat_get(m, 3, 4) == old + inc );
+
   gkyl_mat_release(m);
   gkyl_mat_release(m2);
 }
@@ -125,6 +130,7 @@ test_mat_linsolve()
       val += 1.0;
     }
   gkyl_mat_set(A,2,2,10.0); // ensures determinant is not zero
+  struct gkyl_mat *AA = gkyl_mat_clone(A);
 
   //gkyl_mat_show("A", stdout, A);
 
@@ -145,7 +151,23 @@ test_mat_linsolve()
   TEST_CHECK( gkyl_compare(gkyl_mat_get(x,0,0), -1.0, 1e-15) );
   TEST_CHECK( gkyl_compare(gkyl_mat_get(x,1,0), 1.0, 1e-15) );
   TEST_CHECK( gkyl_compare(gkyl_mat_get(x,2,0), 0.0, 1e-15) );
-  
+ 
+  // trivial extension of the test above; rhs is two column vectors
+  struct gkyl_mat *xx = gkyl_mat_new(3, 2, 1.0);
+  gkyl_mat_set(xx, 0, 1, 2.0);
+  gkyl_mat_set(xx, 1, 1, 2.0);
+  gkyl_mat_set(xx, 2, 1, 2.0);
+  status = gkyl_mat_linsolve_lu(AA, xx, gkyl_mem_buff_data(ipiv));
+
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,0,0), -1.0, 1e-15) );
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,1,0), 1.0, 1e-15) );
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,2,0), 0.0, 1e-15) );
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,0,1), -2.0, 1e-15) );
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,1,1), 2.0, 1e-15) );
+  TEST_CHECK( gkyl_compare(gkyl_mat_get(xx,2,1), 0.0, 1e-15) );
+
+  gkyl_mat_release(AA);
+  gkyl_mat_release(xx);
   gkyl_mat_release(A);
   gkyl_mat_release(x);
   gkyl_mem_buff_release(ipiv);
@@ -394,3 +416,4 @@ TEST_LIST = {
 #endif
   { NULL, NULL },
 };
+

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -63,6 +63,16 @@ gkyl_mat_set(struct gkyl_mat *mat, size_t r, size_t c, double val)
 }
 
 /**
+ * Increase value in matrix.
+ */
+GKYL_CU_DH
+static inline void
+gkyl_mat_inc(struct gkyl_mat *mat, size_t r, size_t c, double val)
+{
+  mat->data[c*mat->nr+r] += val;
+}
+
+/**
  * Get value from matrix.
  */
 GKYL_CU_DH

--- a/zero/gkyl_moment_em_coupling.h
+++ b/zero/gkyl_moment_em_coupling.h
@@ -20,6 +20,11 @@ struct gkyl_moment_em_coupling_inp {
   int nfluids; // number of fluids
   struct gkyl_moment_em_coupling_data param[GKYL_MAX_SPECIES]; // species data
   double epsilon0;
+
+  bool has_collision; // has collisions
+  // scaling factors for collision frequencies so that nu_sr=nu_base_sr/rho_s
+  // nu_rs=nu_base_rs/rho_r, and nu_base_sr=nu_base_rs
+  double nu_base[GKYL_MAX_SPECIES][GKYL_MAX_SPECIES];
 };
 
 // Object type


### PR DESCRIPTION
Adapt Pull Request #122 which was closed without merging.

Gkyl side change: https://github.com/ammarhakim/gkyl/pull/115

That PR was used in a bunch of tests but this new PR has not been extensively tested (though it does not break anything).

During the simulation, one has   `nu_sr=base*rho_r` and   `nu_rs=base*rho_s` to satisfy
  `nu_sr*rho_s=nu_rs*rho_r=base*rho_s*rho_r`.

    struct gkyl_moment app_inp = {
        // ...
        .has_collision = true,
        // scaling factors for collision frequencies;
        // the matrix must be symmetric;
        .nu_base =
          {
            {0,          0,          nu_base_en}, // ee, ei, en
            {0,          0,          nu_base_in}, // ie, ii, in
            {nu_base_en, nu_base_in, 0         }  // ne, ni, nn
          },
      }