### PR TITLE
Moments: FUNC boundary conditions for fluid species and field

### DIFF
--- a/apps/gkyl_app.h
+++ b/apps/gkyl_app.h
@@ -25,4 +25,5 @@ enum gkyl_field_bc_type {
   GKYL_FIELD_COPY = 0, // copy BCs
   GKYL_FIELD_PEC_WALL, // perfect electrical conductor (PEC) BCs
   GKYL_FIELD_WEDGE, // specialized "wedge" BCs for RZ-theta
+  GKYL_FIELD_FUNC, // Function boundary conditions
 };

--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -22,13 +22,19 @@ struct gkyl_moment_species {
   void *ctx; // context for initial condition init function (and potentially other functions)
   // pointer to initialization function
   void (*init)(double t, const double *xn, double *fout, void *ctx);
-  // pointer to boundary condition functions
-  void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
   // pointer to applied acceleration/forces function
   void (*app_accel_func)(double t, const double *xn, double *fout, void *ctx);
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
 };
 
 // Parameter for EM field

--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -58,6 +58,15 @@ struct gkyl_moment_field {
   
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
 };
 
 // Choices of schemes to use in the fluid solver 

--- a/apps/mom_field.c
+++ b/apps/mom_field.c
@@ -157,6 +157,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
         case GKYL_FIELD_WEDGE:
           fld->upper_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_UPPER_EDGE, nghost, bc_copy, 0);
+          break;
 
         case GKYL_FIELD_FUNC:
           fld->upper_bc[dir] = gkyl_wv_apply_bc_new(

--- a/apps/mom_field.c
+++ b/apps/mom_field.c
@@ -140,7 +140,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
             &app->grid, maxwell, app->geom, dir, GKYL_LOWER_EDGE, nghost, bc_copy, 0);
           break;
 
-        case GKYL_SPECIES_FUNC:
+        case GKYL_FIELD_FUNC:
           fld->lower_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_LOWER_EDGE, nghost,
             bc_lower_func, mom_fld->ctx);
@@ -158,7 +158,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
           fld->upper_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_UPPER_EDGE, nghost, bc_copy, 0);
 
-        case GKYL_SPECIES_FUNC:
+        case GKYL_FIELD_FUNC:
           fld->upper_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_UPPER_EDGE, nghost,
             bc_upper_func, mom_fld->ctx);

--- a/apps/mom_field.c
+++ b/apps/mom_field.c
@@ -108,6 +108,23 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
       else
         bc = mom_fld->bcz;
 
+      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      if (dir == 0)
+        bc_lower_func = mom_fld->bcx_lower_func;
+      else if (dir == 1)
+        bc_lower_func = mom_fld->bcy_lower_func;
+      else
+        bc_lower_func = mom_fld->bcz_lower_func;
+
+      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      if (dir == 0)
+        bc_upper_func = mom_fld->bcx_upper_func;
+      else if (dir == 1)
+        bc_upper_func = mom_fld->bcy_upper_func;
+      else
+        bc_upper_func = mom_fld->bcz_upper_func;
+
+
       fld->lower_bct[dir] = bc[0];
       fld->upper_bct[dir] = bc[1];
 
@@ -122,6 +139,12 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
           fld->lower_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_LOWER_EDGE, nghost, bc_copy, 0);
           break;
+
+        case GKYL_SPECIES_FUNC:
+          fld->lower_bc[dir] = gkyl_wv_apply_bc_new(
+            &app->grid, maxwell, app->geom, dir, GKYL_LOWER_EDGE, nghost,
+            bc_lower_func, mom_fld->ctx);
+          break;
       }
 
       switch (bc[1]) {
@@ -134,6 +157,12 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
         case GKYL_FIELD_WEDGE:
           fld->upper_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, maxwell, app->geom, dir, GKYL_UPPER_EDGE, nghost, bc_copy, 0);
+
+        case GKYL_SPECIES_FUNC:
+          fld->upper_bc[dir] = gkyl_wv_apply_bc_new(
+            &app->grid, maxwell, app->geom, dir, GKYL_UPPER_EDGE, nghost,
+            bc_upper_func, mom_fld->ctx);
+          break;
       }
     }
   }

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -139,7 +139,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       else
         bc_upper_func = mom_sp->bcz_upper_func;
 
-      sp->upper_bct[dir] = bc[0];
+      sp->lower_bct[dir] = bc[0];
       sp->upper_bct[dir] = bc[1];
 
       // lower BCs

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -123,7 +123,23 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       else
         bc = mom_sp->bcz;
 
-      sp->lower_bct[dir] = bc[0];
+      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      if (dir == 0)
+        bc_lower_func = mom_sp->bcx_lower_func;
+      else if (dir == 1)
+        bc_lower_func = mom_sp->bcy_lower_func;
+      else
+        bc_lower_func = mom_sp->bcz_lower_func;
+
+      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      if (dir == 0)
+        bc_upper_func = mom_sp->bcx_upper_func;
+      else if (dir == 1)
+        bc_upper_func = mom_sp->bcy_upper_func;
+      else
+        bc_upper_func = mom_sp->bcz_upper_func;
+
+      sp->upper_bct[dir] = bc[0];
       sp->upper_bct[dir] = bc[1];
 
       // lower BCs
@@ -143,7 +159,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
         case GKYL_SPECIES_FUNC:
           sp->lower_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, mom_sp->equation, app->geom, dir, GKYL_LOWER_EDGE, nghost,
-            mom_sp->bc_lower_func, mom_sp->ctx);
+            bc_lower_func, mom_sp->ctx);
           break;
         
         case GKYL_SPECIES_COPY:
@@ -174,7 +190,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
         case GKYL_SPECIES_FUNC:
           sp->upper_bc[dir] = gkyl_wv_apply_bc_new(
             &app->grid, mom_sp->equation, app->geom, dir, GKYL_UPPER_EDGE, nghost,
-            mom_sp->bc_upper_func, mom_sp->ctx);
+            bc_upper_func, mom_sp->ctx);
           break;
           
         case GKYL_SPECIES_COPY:

--- a/inf/Moments.lua
+++ b/inf/Moments.lua
@@ -121,6 +121,7 @@ enum gkyl_field_bc_type {
   GKYL_FIELD_COPY = 0, // copy BCs
   GKYL_FIELD_PEC_WALL, // perfect electrical conductor (PEC) BCs
   GKYL_FIELD_WEDGE, // specialized "wedge" BCs for RZ-theta
+  GKYL_FIELD_FUNC, // Function boundary conditions
 };
 
 ]]

--- a/inf/Moments.lua
+++ b/inf/Moments.lua
@@ -356,13 +356,19 @@ struct gkyl_moment_species {
   void *ctx; // context for initial condition init function (and potentially other functions)
   // pointer to initialization function
   void (*init)(double t, const double *xn, double *fout, void *ctx);
-  // pointer to boundary condition functions
-  void (*bc_lower_func)(double t, int nc, const double *skin, double *  ghost, void *ctx);
-  void (*bc_upper_func)(double t, int nc, const double *skin, double *  ghost, void *ctx);
   // pointer to applied acceleration/forces function
   void (*app_accel_func)(double t, const double *xn, double *fout, void *ctx);
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
 };
 
 // Parameter for EM field
@@ -386,6 +392,15 @@ struct gkyl_moment_field {
   
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];
+  // pointer to boundary condition functions along x
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along y
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  // pointer to boundary condition functions along z
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
 };
 
 // Choices of schemes to use in the fluid solver 
@@ -758,6 +773,15 @@ local function gkyl_eval_applied(func)
    end
 end
 
+local function gkyl_eval_bc(func)
+   return function(t, nc, skin, ghost, ctx)
+      local ret = { func(t, nc, skin, ctx) } -- package return into table
+      for i=1,#ret do
+         ghost[i-1] = ret[i]
+      end
+   end
+end
+
 local function gkyl_eval_mapc2p(func)
    return function(t, xn, fout, ctx)
       local xnl = ffi.new("double[10]")
@@ -842,6 +866,26 @@ local species_mt = {
          s.bcz[0], s.bcz[1] = tbl.bcz[1], tbl.bcz[2]
       end
 
+      if tbl.bcx_lower_func then
+         s.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+      end
+      if tbl.bcy_lower_func then
+         s.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+      end
+      if tbl.bcz_lower_func then
+         s.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+      end
+
+      if tbl.bcx_upper_func then
+         s.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+      end
+      if tbl.bcy_upper_func then
+         s.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+      end
+      if tbl.bcz_upper_func then
+         s.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+      end
+
       return s
    end,
    __index = {
@@ -850,7 +894,8 @@ local species_mt = {
       bcWall = C.GKYL_SPECIES_REFLECT,
       bcCopy = C.GKYL_SPECIES_COPY,
       bcNoSlip = C.GKYL_SPECIES_NO_SLIP,
-      bcWedge = C.GKYL_SPECIES_WEDGE
+      bcWedge = C.GKYL_SPECIES_WEDGE,
+      bcFunc = C.GKYL_SPECIES_FUNC
    }
 }
 _M.Species = ffi.metatype(species_type, species_mt)
@@ -942,6 +987,26 @@ local field_mt = {
          f.bcz[0], f.bcz[1] = tbl.bcz[1], tbl.bcz[2]
       end
 
+      if tbl.bcx_lower_func then
+         f.bcx_lower_func = gkyl_eval_bc(tbl.bcx_lower_func)
+      end
+      if tbl.bcy_lower_func then
+         f.bcy_lower_func = gkyl_eval_bc(tbl.bcy_lower_func)
+      end
+      if tbl.bcz_lower_func then
+         f.bcz_lower_func = gkyl_eval_bc(tbl.bcz_lower_func)
+      end
+
+      if tbl.bcx_upper_func then
+         f.bcx_upper_func = gkyl_eval_bc(tbl.bcx_upper_func)
+      end
+      if tbl.bcy_upper_func then
+         f.bcy_upper_func = gkyl_eval_bc(tbl.bcy_upper_func)
+      end
+      if tbl.bcz_upper_func then
+         f.bcz_upper_func = gkyl_eval_bc(tbl.bcz_upper_func)
+      end
+
       return f
    end,
    __index = {
@@ -949,7 +1014,8 @@ local field_mt = {
       bcCopy = C.GKYL_FIELD_COPY,
       bcReflect = C.GKYL_FIELD_PEC_WALL,
       bcPEC = C.GKYL_FIELD_PEC_WALL,
-      bcWedge = C.GKYL_FIELD_WEDGE
+      bcWedge = C.GKYL_FIELD_WEDGE,
+      bcFunc = C.GKYL_FIELD_FUNC
    }
 }
 _M.Field = ffi.metatype(field_type, field_mt)


### PR DESCRIPTION
Associated G2's g0-merge PR: https://github.com/ammarhakim/gkyl/pull/117

Usage example in c:
```c
void bcx_lower_func(
  double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
{
  for (int c=0; c<8; ++c)
    ghost[c] = skin[c];
}

// ...

struct gkyl_moment app_inp = {
  // ...
  .field = {
    // ...
    .bcx = { GKYL_FIELD_FUNC, GKYL_FIELD_PEC_WALL },
    .bcx_lower_func = bcx_lower_func,
  },
  // ...
};
```
Usage example in lua:
```lua
function bc_upper_func(t, nc, skin, ctx)
   return rhoIn, rhoIn*uIn, 0.0, 0.0, erIn
end

fluid = Moments.Species {
   -- ...
   bcx = { Moments.Species.bcCopy, Moments.Species.bcFunc},
   bcx_upper_func = bc_upper_func,
   -- ...
}
```