### PR TITLE
moment.c: init ext_em in apply_ic_field

### DIFF
--- a/apps/moment.c
+++ b/apps/moment.c
@@ -171,6 +171,16 @@ gkyl_moment_app_apply_ic_field(gkyl_moment_app* app, double t0)
   gkyl_fv_proj_advance(proj, t0, &app->local, app->field.fcurr);
   gkyl_fv_proj_release(proj);
 
+  if (app->field.proj_ext_em) {
+    gkyl_fv_proj_advance(
+        app->field.proj_ext_em, t0, &app->local, app->field.ext_em);
+
+    if (app->field.is_ext_em_static)
+      app->field.was_ext_em_computed = true;
+    else
+      app->field.was_ext_em_computed = false;
+  }
+
   moment_field_apply_bc(app, t0, &app->field, app->field.fcurr);
 }
 


### PR DESCRIPTION
Previously, the first time the `ext_em` was initialized was in `moment_coupling_update`, which happens after the first data output, thus the file `ext_em_field_0.gkyl` has zero values.

Initializing `ext_em` within apply_ic_field fills the first output `ext_em_field_0.gkyl`.

PS: What about `app_current`, which is part of the `moment_field` and not set unless the first call of `moment_coupling_update`? It is not part of the output, though.