### PR TITLE
rename local to local_range to avoid syntax error when set from lua

### DIFF
--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -82,7 +82,7 @@ enum gkyl_moment_scheme {
 // use MPI or other parallel mechanism.
 struct gkyl_moment_low_inp {
   // local range over which App operates
-  struct gkyl_range local;
+  struct gkyl_range local_range;
 };
 
 // Top-level app parameters

--- a/apps/moment.c
+++ b/apps/moment.c
@@ -37,7 +37,7 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
 
   if (mom->has_low_inp) {
     // create local and local_ext from user-supplied local range
-    gkyl_create_ranges(&mom->low_inp.local, ghost, &app->local_ext, &app->local);
+    gkyl_create_ranges(&mom->low_inp.local_range, ghost, &app->local_ext, &app->local);
   }
   else {
     // global and local ranges are same, and so just copy


### PR DESCRIPTION
Following code would give an error:
```lua
vm.low_inp.local = grid._localRange
```
The following is OK:

```lua
vm.low_inp.local_range = grid._localRange
```