### PR TITLE
Fix CUDA build

### DIFF
--- a/kernels/lbo/gkyl_mom_bcorr_lbo_gyrokinetic_kernels.h
+++ b/kernels/lbo/gkyl_mom_bcorr_lbo_gyrokinetic_kernels.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <math.h>
-#include <gkyl_mom_calc_bcorr.h>
+#include <gkyl_eqn_type.h>
 #include <gkyl_util.h>
 
 EXTERN_C_BEG 

--- a/kernels/lbo/gkyl_mom_bcorr_lbo_vlasov_kernels.h
+++ b/kernels/lbo/gkyl_mom_bcorr_lbo_vlasov_kernels.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <math.h>
-#include <gkyl_mom_calc_bcorr.h>
+#include <gkyl_eqn_type.h>
 #include <gkyl_util.h>
 
 EXTERN_C_BEG 

--- a/kernels/pkpm/gkyl_mom_bcorr_lbo_vlasov_pkpm_kernels.h
+++ b/kernels/pkpm/gkyl_mom_bcorr_lbo_vlasov_pkpm_kernels.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <math.h>
-#include <gkyl_mom_calc_bcorr.h>
+#include <gkyl_eqn_type.h>
 #include <gkyl_util.h>
 
 EXTERN_C_BEG 

--- a/zero/array_rio.c
+++ b/zero/array_rio.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <gkyl_array_rio.h>
+#include <gkyl_elem_type_priv.h>
 
 void
 gkyl_array_write(const struct gkyl_array *arr, FILE *fp)

--- a/zero/dynvec.c
+++ b/zero/dynvec.c
@@ -1,5 +1,6 @@
 #include <gkyl_alloc.h>
 #include <gkyl_dynvec.h>
+#include <gkyl_elem_type_priv.h>
 #include <gkyl_ref_count.h>
 #include <gkyl_util.h>
 

--- a/zero/gkyl_elem_type.h
+++ b/zero/gkyl_elem_type.h
@@ -9,33 +9,9 @@ enum gkyl_elem_type { GKYL_INT, GKYL_INT_64, GKYL_FLOAT, GKYL_DOUBLE, GKYL_USER 
 // Array reduce operators
 enum gkyl_array_op { GKYL_MIN, GKYL_MAX, GKYL_SUM };
 
-// code for array datatype for use in IO
-static const uint64_t gkyl_array_data_type[] = {
-  [GKYL_INT] = 0,
-  [GKYL_FLOAT] = 1,
-  [GKYL_DOUBLE] = 2,
-  [GKYL_INT_64] = 3,
-  [GKYL_USER] = 32,
-};
-
-// size in bytes for various data-types
-static const size_t gkyl_elem_type_size[] = {
-  [GKYL_INT] = sizeof(int),
-  [GKYL_FLOAT] = sizeof(float),
-  [GKYL_DOUBLE] = sizeof(double),
-  [GKYL_INT_64] = sizeof(int64_t),
-  [GKYL_USER] = 1,
-};
-
 // file types for raw IO of Gkeyll data
 enum gkyl_file_type {
   GKYL_FIELD_DATA_FILE,
   GKYL_DYNVEC_DATA_FILE,
   GKYL_MULTI_RANGE_DATA_FILE
-};
-
-static const uint64_t gkyl_file_type_int[] = {
-  [GKYL_FIELD_DATA_FILE] = 1,
-  [GKYL_DYNVEC_DATA_FILE] = 2,
-  [GKYL_MULTI_RANGE_DATA_FILE] = 3
 };

--- a/zero/gkyl_elem_type_priv.h
+++ b/zero/gkyl_elem_type_priv.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <gkyl_elem_type.h>
+
+
+// code for array datatype for use in IO
+static const uint64_t gkyl_array_data_type[] = {
+  [GKYL_INT] = 0,
+  [GKYL_FLOAT] = 1,
+  [GKYL_DOUBLE] = 2,
+  [GKYL_INT_64] = 3,
+  [GKYL_USER] = 32,
+};
+
+// size in bytes for various data-types
+static const size_t gkyl_elem_type_size[] = {
+  [GKYL_INT] = sizeof(int),
+  [GKYL_FLOAT] = sizeof(float),
+  [GKYL_DOUBLE] = sizeof(double),
+  [GKYL_INT_64] = sizeof(int64_t),
+  [GKYL_USER] = 1,
+};
+
+
+static const uint64_t gkyl_file_type_int[] = {
+  [GKYL_FIELD_DATA_FILE] = 1,
+  [GKYL_DYNVEC_DATA_FILE] = 2,
+  [GKYL_MULTI_RANGE_DATA_FILE] = 3
+};
+

--- a/zero/gkyl_eqn_type.h
+++ b/zero/gkyl_eqn_type.h
@@ -61,3 +61,9 @@ enum gkyl_quad_type {
   GKYL_GAUSS_QUAD, // Gauss-Legendre quadrature
   GKYL_GAUSS_LOBATTO_QUAD, // Gauss-Lobatto quadrature
 };
+
+/** Flags for indicating acting edge of velocity space */
+enum gkyl_vel_edge { 
+  GKYL_VX_LOWER, GKYL_VY_LOWER, GKYL_VZ_LOWER, 
+  GKYL_VX_UPPER, GKYL_VY_UPPER, GKYL_VZ_UPPER 
+};

--- a/zero/gkyl_mom_calc_bcorr.h
+++ b/zero/gkyl_mom_calc_bcorr.h
@@ -2,15 +2,10 @@
 
 #include <gkyl_array.h>
 #include <gkyl_basis.h>
+#include <gkyl_eqn_type.h>
 #include <gkyl_mom_type.h>
 #include <gkyl_range.h>
 #include <gkyl_rect_grid.h>
-
-/** Flags for indicating acting edge of velocity space */
-enum gkyl_vel_edge { 
-  GKYL_VX_LOWER, GKYL_VY_LOWER, GKYL_VZ_LOWER, 
-  GKYL_VX_UPPER, GKYL_VY_UPPER, GKYL_VZ_UPPER 
-};
 
 // Object type
 typedef struct gkyl_mom_calc_bcorr gkyl_mom_calc_bcorr;

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -5,7 +5,7 @@
 #include <gkyl_array_ops.h>
 #include <gkyl_array_rio.h>
 #include <gkyl_array_rio_format_desc.h>
-#include <gkyl_elem_type.h>
+#include <gkyl_elem_type_priv.h>
 #include <gkyl_mpi_comm.h>
 
 #include <errno.h>

--- a/zero/null_comm.c
+++ b/zero/null_comm.c
@@ -1,5 +1,6 @@
 #include <gkyl_alloc.h>
 #include <gkyl_array_rio.h>
+#include <gkyl_elem_type_priv.h>
 #include <gkyl_null_comm.h>
 
 #include <string.h>


### PR DESCRIPTION
gkyl_elem_type.h had some C-safe syntax that was not C++ safe. This would normally not matter except gkyl_elem_type.h was being included in a few places that were being compiled as CUDA kernels through some unsafe header proliferation.

We have split out the parts of gkyl_elem_type.h that C++ does not like into a private header that is included in the necessary C files that nvcc compiles with the host compiler and also fixed the header for the offending code in the kernels by moving the gkyl_vel_edge enum out of gkyl_mom_calc_bcorr.h into gkyl_eqn_type.h, the latter being a header file of exclusively enums that is safe to include in these places. 