### PR TITLE
Fixing CUDAMATH_LIBDIR in perlmutter configure

### DIFF
--- a/machines/configure.perlmutter.dev.sh
+++ b/machines/configure.perlmutter.dev.sh
@@ -1,5 +1,5 @@
 module load cudatoolkit/11.7
-module unload darshan
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft --lapack-inc=${HOME}/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft/superlu/include --superlu-lib=${HOME}/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/math_libs/11.7/lib64;
+#module unload darshan
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/g0g2-gpu/gkylsoft --lapack-inc=${HOME}/g0g2-gpu/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/g0g2-gpu/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/g0g2-gpu/gkylsoft/superlu/include --superlu-lib=${HOME}/g0g2-gpu/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.7/math_libs/11.7/lib64;
 
 

--- a/machines/configure.perlmutter.dev.sh
+++ b/machines/configure.perlmutter.dev.sh
@@ -1,5 +1,5 @@
 module load cudatoolkit/11.7
-#module unload darshan
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/g0g2-gpu/gkylsoft --lapack-inc=${HOME}/g0g2-gpu/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/g0g2-gpu/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/g0g2-gpu/gkylsoft/superlu/include --superlu-lib=${HOME}/g0g2-gpu/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.7/math_libs/11.7/lib64;
+module unload darshan
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft --lapack-inc=${HOME}/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft/superlu/include --superlu-lib=${HOME}/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.7/math_libs/11.7/lib64;
 
 


### PR DESCRIPTION
version 22.5 no longer exists. switching it for 22.7 works.