### PR TITLE
Remove harcoded $HOME in build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,18 @@ PREFIX ?= ${HOME}/gkylsoft
 UNAME = $(shell uname)
 
 # Default lapack include and libraries: we prefer linking to static library
-LAPACK_INC = ${HOME}/gkylsoft/OpenBLAS/include
-LAPACK_LIB_DIR = ${HOME}/gkylsoft/OpenBLAS/lib
+LAPACK_INC = $(PREFIX)/OpenBLAS/include
+LAPACK_LIB_DIR = $(PREFIX)/OpenBLAS/lib
 LAPACK_LIB = -lopenblas
 
 # SuperLU includes and librararies
-SUPERLU_INC = ${HOME}/gkylsoft/superlu/include
+SUPERLU_INC = $(PREFIX)/superlu/include
 ifeq ($(UNAME_S),Linux)
-	SUPERLU_LIB_DIR = ${HOME}/gkylsoft/superlu/lib64
-	SUPERLU_LIB = ${HOME}/gkylsoft/superlu/lib64/libsuperlu.a
+	SUPERLU_LIB_DIR = $(PREFIX)/superlu/lib64
+	SUPERLU_LIB = $(PREFIX)/superlu/lib64/libsuperlu.a
 else
-	SUPERLU_LIB_DIR = ${HOME}/gkylsoft/superlu/lib
-	SUPERLU_LIB = ${HOME}/gkylsoft/superlu/lib/libsuperlu.a
+	SUPERLU_LIB_DIR = $(PREFIX)/superlu/lib
+	SUPERLU_LIB = $(PREFIX)/superlu/lib/libsuperlu.a
 endif
 
 # Include config.mak file (if it exists) to overide defaults above

--- a/configure
+++ b/configure
@@ -9,25 +9,25 @@ ARCH_FLAGS=-march=native
 CUDA_ARCH=70
 
 # Default lapack include and libraries: we prefer linking to static library
-LAPACK_INC=${HOME}/gkylsoft/OpenBLAS/include
-LAPACK_LIB=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a
+LAPACK_INC=$PREFIX/OpenBLAS/include
+LAPACK_LIB=$PREFIX/OpenBLAS/lib/libopenblas.a
 
 # MPI specific paths and flags
 USE_MPI=
-MPI_INC=${HOME}/gkylsoft/openmpi/include
-MPI_LIB=${HOME}/gkylsoft/openmpi/lib/
+MPI_INC=$PREFIX/openmpi/include
+MPI_LIB=$PREFIX/openmpi/lib/
 
 OSTYPE=`uname -o`
 MACHINE=`uname -n`
 USER=`whoami`
 echo "# OS type is $OSTYPE on $MACHINE user $USER"
 # SuperLU includes and librararies
-SUPERLU_INC=${HOME}/gkylsoft/superlu/include
+SUPERLU_INC=$PREFIX/superlu/include
 if [ "$OSTYPE" = "linux-gnu"* ]
 then
-    SUPERLU_LIB=${HOME}/gkylsoft/superlu/lib64/libsuperlu.a;
+    SUPERLU_LIB=$PREFIX/superlu/lib64/libsuperlu.a;
 else
-    SUPERLU_LIB=${HOME}/gkylsoft/superlu/lib/libsuperlu.a;
+    SUPERLU_LIB=$PREFIX/superlu/lib/libsuperlu.a;
 fi
 
 # Location of CUDA math libraries

--- a/machines/configure.perlmutter.dev.sh
+++ b/machines/configure.perlmutter.dev.sh
@@ -1,5 +1,6 @@
 module load cudatoolkit/11.7
 module unload darshan
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft --lapack-inc=${HOME}/gkylsoft/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft/superlu/include --superlu-lib=${HOME}/gkylsoft/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.7/math_libs/11.7/lib64;
+export GKYLSOFT=$HOME/gkylsoft
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$GKYLSOFT --lapack-inc=$GKYLSOFT/OpenBLAS/include --lapack-lib=$GKYLSOFT/OpenBLAS/lib/libopenblas.a --superlu-inc=$GKYLSOFT/superlu/include --superlu-lib=$GKYLSOFT/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/22.7/math_libs/11.7/lib64;
 
 

--- a/machines/configure.stellar.dev.sh
+++ b/machines/configure.stellar.dev.sh
@@ -1,3 +1,4 @@
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft-amd --lapack-inc=${HOME}/gkylsoft-amd/OpenBLAS/include --lapack-lib=${HOME}/gkylsoft-amd/OpenBLAS/lib/libopenblas.a --superlu-inc=${HOME}/gkylsoft-amd/superlu/include --superlu-lib=${HOME}/gkylsoft-amd/superlu/lib/libsuperlu.a;
+export GKYLSOFT=$HOME/gkylsoft-amd
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$HOME/gkylsoft-amd --lapack-inc=$GKYLSOFT/OpenBLAS/include --lapack-lib=$GKYLSOFT/OpenBLAS/lib/libopenblas.a --superlu-inc=$GKYLSOFT/superlu/include --superlu-lib=$GKYLSOFT/superlu/lib/libsuperlu.a;
 
 

--- a/machines/configure.stellar.host.sh
+++ b/machines/configure.stellar.host.sh
@@ -1,1 +1,2 @@
-./configure CC=cc
+export GKYLSOFT=$HOME/gkylsoft
+./configure CC=cc --prefix=$GKYLSOFT

--- a/machines/mkdeps.stellar.host.sh
+++ b/machines/mkdeps.stellar.host.sh
@@ -1,2 +1,2 @@
 cd install-deps
-./mkdeps.sh --build-openblas=yes --build-superlu=yes
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$HOME/gkylsoft-amd/


### PR DESCRIPTION
Previously installing gkyl in a different directory required more changes. Now, with this change, the user just has to change PREFIX and GKYLSOFT in the machine files.