### PR TITLE
Fixing null_comm to work with GPUs

### DIFF
--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -108,7 +108,8 @@ gkyl_vlasov_app_new(struct gkyl_vm *vm)
         gkyl_rect_decomp_new_from_cuts(cdim, cuts, &app->global);
       
       app->comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-          .decomp = rect_decomp
+          .decomp = rect_decomp,
+          .use_gpu = app->use_gpu
         }
       );
 
@@ -125,7 +126,8 @@ gkyl_vlasov_app_new(struct gkyl_vm *vm)
       gkyl_rect_decomp_new_from_cuts(cdim, cuts, &app->global);
     
     app->comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = rect_decomp
+        .decomp = rect_decomp,
+        .use_gpu = app->use_gpu
       }
     );
     

--- a/regression/rt_esshock.c
+++ b/regression/rt_esshock.c
@@ -142,12 +142,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu
     }
   );
 #endif

--- a/regression/rt_esshock_lbo.c
+++ b/regression/rt_esshock_lbo.c
@@ -154,12 +154,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
     }
   );
 #endif

--- a/regression/rt_mhd_ot.c
+++ b/regression/rt_mhd_ot.c
@@ -136,12 +136,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu
     }
   );
 #endif

--- a/regression/rt_pulsar_atm_sr_1d.c
+++ b/regression/rt_pulsar_atm_sr_1d.c
@@ -214,12 +214,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
     }
   );
 #endif

--- a/regression/rt_vlasov_ot_5d.c
+++ b/regression/rt_vlasov_ot_5d.c
@@ -273,12 +273,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
     }
   );
 #endif

--- a/regression/rt_vlasov_ot_6d.c
+++ b/regression/rt_vlasov_ot_6d.c
@@ -316,12 +316,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
     }
   );
 #endif

--- a/regression/rt_weibel_4d.c
+++ b/regression/rt_weibel_4d.c
@@ -169,12 +169,14 @@ main(int argc, char **argv)
   }
   else
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
       }
     );
 #else
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
     }
   );
 #endif

--- a/zero/gkyl_alloc.h
+++ b/zero/gkyl_alloc.h
@@ -100,6 +100,9 @@ typedef struct gkyl_mem_buff_tag* gkyl_mem_buff;
 /** Allocate new memory buffer with count bytes */
 gkyl_mem_buff gkyl_mem_buff_new(size_t count);
 
+/** Allocate new memory buffer on GPU with count bytes */
+gkyl_mem_buff gkyl_mem_buff_cu_new(size_t count);
+
 /** Resize the mem_buff */
 gkyl_mem_buff gkyl_mem_buff_resize(gkyl_mem_buff mem, size_t count);
 

--- a/zero/gkyl_null_comm.h
+++ b/zero/gkyl_null_comm.h
@@ -6,13 +6,14 @@
 
 // input to create new MPI communicator
 struct gkyl_null_comm_inp {
+  bool use_gpu; // flag to use if this communicator is on GPUs  
   const struct gkyl_rect_decomp *decomp; // pre-computed decomposition
   bool sync_corners; // should we sync corners?
 };
 
 /**
  * Return a new "null" communicator, i.e. a communicator for a single
- * core calculation. The communicator returned by this funciton can't
+ * core calculation. The communicator returned by this function can't
  * be used to perform periodic sync operatons on arrays.
  *
  * @return New communicator


### PR DESCRIPTION
Now the membuff is allocated on GPUs if needed. This makes the null_comm just work on GPUs as expected. I believe I have fixed all Vlasov regression tests that use null_comm to set the use_gpu flag. However, @JunoRavin should check that this is indeed the case.

It is possible that with some work the mpi_comm can also work on GPUs with CUDA aware MPI. I will look into this and add this feature so we can then compare with nccl based communicator when we work on that during the hackathon.