### PR TITLE
Enhance mpi_comm object with ability to send/recv gkyl_arrays, and split a comm

### DIFF
--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -373,7 +373,7 @@ test_n1_per_sync_2d()
 }
 
 void
-test_n2_array_send_recv_1d()
+test_n2_array_send_irecv_1d()
 {
   int m_sz;
   MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
@@ -423,6 +423,72 @@ test_n2_array_send_recv_1d()
   }
 
   gkyl_comm_state_release(comm, cstate);
+  gkyl_array_release(arrA);
+  gkyl_array_release(arrB);
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+}
+
+void
+test_n2_array_isend_irecv_2d()
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 2) return;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  struct gkyl_range range;
+  gkyl_range_init(&range, 2, (int[]) { 1, 1 }, (int[]) { 10, 20 });
+
+  int cuts[] = { 1, m_sz };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(range.ndim, cuts, &range);
+
+  struct gkyl_comm *comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = decomp,
+      .sync_corners = false,
+    }
+  );
+
+  double sendval = rank==0? 20005. : 30005.;
+  double recvval = rank==0? 30005. : 20005.;
+
+  // Assume the range is not decomposed. 
+  struct gkyl_array *arrA = gkyl_array_new(GKYL_DOUBLE, 1, range.volume);
+  struct gkyl_array *arrB = gkyl_array_new(GKYL_DOUBLE, 1, range.volume);
+  gkyl_array_clear(arrA, sendval*(1-rank));
+  gkyl_array_clear(arrB, sendval*rank);
+
+  struct gkyl_array *recvbuff = rank==0? arrB : arrA;
+  struct gkyl_array *sendbuff = rank==0? arrA : arrB;
+
+  struct gkyl_comm_state *cstate_s = gkyl_comm_state_new(comm);
+  struct gkyl_comm_state *cstate_r = gkyl_comm_state_new(comm);
+  int tag = 13;
+  // Post irecv before send.
+  gkyl_comm_array_irecv(comm, recvbuff, (rank+1) % 2, tag, cstate_r);
+  gkyl_comm_array_isend(comm, sendbuff, (rank+1) % 2, tag, cstate_s);
+
+  // Do some other unnecessary work.
+  struct gkyl_array *tmp_arr = gkyl_array_new(GKYL_DOUBLE, 3, range.volume);
+  gkyl_array_clear(tmp_arr, 13.);
+
+  gkyl_comm_state_wait(comm, cstate_r);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &range);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&range, iter.idx);
+    const double *f = gkyl_array_cfetch(recvbuff, idx);
+    TEST_CHECK( f[0] == recvval );
+  }
+
+  gkyl_comm_state_wait(comm, cstate_s);
+
+  gkyl_comm_state_release(comm, cstate_s);
+  gkyl_comm_state_release(comm, cstate_r);
   gkyl_array_release(arrA);
   gkyl_array_release(arrB);
   gkyl_rect_decomp_release(decomp);
@@ -542,7 +608,8 @@ TEST_LIST = {
     {"test_n4_sync_2d_use_corner", test_n4_sync_2d_use_corner},
     {"test_n2_sync_1x1v", test_n4_sync_1x1v },
     {"test_n1_per_sync_2d", test_n1_per_sync_2d },
-    {"test_n2_array_send_recv_1d", test_n2_array_send_recv_1d},
+    {"test_n2_array_send_irecv_1d", test_n2_array_send_irecv_1d},
+    {"test_n2_array_isend_irecv_2d", test_n2_array_isend_irecv_2d},
     {"test_n4_multicomm_2d", test_n4_multicomm_2d},
     {NULL, NULL},
 };

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -429,6 +429,111 @@ test_n2_array_send_recv_1d()
   gkyl_comm_release(comm);
 }
 
+void
+test_n4_multicomm_2d()
+{
+  // Test the use of two gkyl_comm objects simultaneously, mimicing the case
+  // where one is used to decompose space and the other species.
+  // We sync across the conf communicator, and send/recv across the species
+  // comm.
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 4) return;
+
+  struct gkyl_range range;
+  gkyl_range_init(&range, 2, (int[]) { 1, 1 }, (int[]) { 10, 20 });
+
+  int confcuts[] = { 2, 1 };
+  struct gkyl_rect_decomp *confdecomp = gkyl_rect_decomp_new_from_cuts(2, confcuts, &range);  
+  
+  struct gkyl_comm *worldcomm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = confdecomp,  // MF 2023/07/28: I think decomp doesn't matter
+                             // for worldcomm.
+    }
+  );
+
+  int worldrank;
+  gkyl_comm_get_rank(worldcomm, &worldrank);
+
+  int confcolor = floor(worldrank/confdecomp->ndecomp);
+  struct gkyl_comm *confcomm = gkyl_comm_split_comm(worldcomm, confcolor, confdecomp);
+  int confrank;
+  gkyl_comm_get_rank(confcomm, &confrank);
+
+  int speciescolor = worldrank % confdecomp->ndecomp;
+  struct gkyl_comm *speciescomm = gkyl_comm_split_comm(worldcomm, speciescolor, confdecomp);
+  int speciesrank;
+  gkyl_comm_get_rank(speciescomm, &speciesrank);
+
+  int nghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&confdecomp->ranges[confrank], nghost, &local_ext, &local);
+
+  struct gkyl_array *arrA = gkyl_array_new(GKYL_DOUBLE, 2, local_ext.volume);
+  struct gkyl_array *arrB = gkyl_array_new(GKYL_DOUBLE, 2, local_ext.volume);
+  gkyl_array_clear(arrA, 0.);
+  gkyl_array_clear(arrB, 0.);
+  struct gkyl_array *recvbuff = speciesrank==0? arrB : arrA;
+  struct gkyl_array *sendbuff = speciesrank==0? arrA : arrB;
+
+  gkyl_comm_barrier(worldcomm);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&local, iter.idx);
+    double *f = gkyl_array_fetch(sendbuff, idx);
+    f[0] = iter.idx[0]; f[1] = iter.idx[1];
+  }
+
+  // Sync sendbuff array and check results.
+  gkyl_comm_array_sync(confcomm, &local, &local_ext, sendbuff);
+
+  struct gkyl_range in_range; // interior, including ghost cells
+  gkyl_sub_range_intersect(&in_range, &local_ext, &range);
+  struct gkyl_range local_x, local_ext_x, local_y, local_ext_y;
+  gkyl_create_ranges(&confdecomp->ranges[confrank], (int[]) {1, 0}, &local_ext_x, &local_x);
+  gkyl_create_ranges(&confdecomp->ranges[confrank], (int[]) { 0, 1 }, &local_ext_y, &local_y);
+  gkyl_range_iter_init(&iter, &in_range);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&in_range, iter.idx);
+    const double *f = gkyl_array_cfetch(sendbuff, idx);
+    // exclude corners
+    if (gkyl_range_contains_idx(&local_ext_x, iter.idx) || gkyl_range_contains_idx(&local_ext_y, iter.idx)) {
+      TEST_CHECK( iter.idx[0] == f[0] );
+      TEST_CHECK( iter.idx[1] == f[1] );
+    }
+  }
+
+  // Now send/recv across species communicator and check results.
+  struct gkyl_comm_state *cstate = gkyl_comm_state_new(speciescomm);
+  int tag = 13;
+  // Post irecv before send.
+  gkyl_comm_array_irecv(speciescomm, recvbuff, (speciesrank+1) % 2, tag, cstate);
+  gkyl_comm_array_send(speciescomm, sendbuff, (speciesrank+1) % 2, tag);
+  gkyl_comm_state_wait(speciescomm, cstate);
+
+  gkyl_range_iter_init(&iter, &in_range);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&in_range, iter.idx);
+    const double *f = gkyl_array_cfetch(recvbuff, idx);
+    // exclude corners
+    if (gkyl_range_contains_idx(&local_ext_x, iter.idx) || gkyl_range_contains_idx(&local_ext_y, iter.idx)) {
+      TEST_CHECK( iter.idx[0] == f[0] );
+      TEST_CHECK( iter.idx[1] == f[1] );
+    }
+  }
+
+  gkyl_comm_state_release(speciescomm, cstate);
+  gkyl_array_release(arrA);
+  gkyl_array_release(arrB);
+  gkyl_rect_decomp_release(confdecomp);
+  gkyl_comm_release(speciescomm);
+  gkyl_comm_release(confcomm);
+  gkyl_comm_release(worldcomm);
+}
+  
 TEST_LIST = {
     {"test_1", test_1},
     {"test_n2", test_n2},
@@ -438,6 +543,7 @@ TEST_LIST = {
     {"test_n2_sync_1x1v", test_n4_sync_1x1v },
     {"test_n1_per_sync_2d", test_n1_per_sync_2d },
     {"test_n2_array_send_recv_1d", test_n2_array_send_recv_1d},
+    {"test_n4_multicomm_2d", test_n4_multicomm_2d},
     {NULL, NULL},
 };
 

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -422,6 +422,8 @@ test_n2_array_send_irecv_1d()
     TEST_CHECK( f[0] == recvval );
   }
 
+  gkyl_comm_barrier(comm);
+
   gkyl_comm_state_release(comm, cstate);
   gkyl_array_release(arrA);
   gkyl_array_release(arrB);

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -425,8 +425,8 @@ test_n2_array_send_recv_1d()
   gkyl_comm_state_release(comm, cstate);
   gkyl_array_release(arrA);
   gkyl_array_release(arrB);
-  gkyl_comm_release(comm);
   gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
 }
 
 TEST_LIST = {

--- a/zero/gkyl_comm.h
+++ b/zero/gkyl_comm.h
@@ -30,6 +30,10 @@ typedef int (*gkyl_array_send_t)(struct gkyl_array *array, int dest, int tag,
 typedef int (*gkyl_array_isend_t)(struct gkyl_array *array, int dest, int tag,
   struct gkyl_comm *comm, struct gkyl_comm_state *state);
 
+// Blocking receive @a array from @a src process using @a tag.
+typedef int (*gkyl_array_recv_t)(struct gkyl_array *array, int src, int tag,
+  struct gkyl_comm *comm);
+
 // Nonblocking receive @a array from @a src process using @a tag, and
 // store the status of this comm in @a state.
 typedef int (*gkyl_array_irecv_t)(struct gkyl_array *array, int src, int tag,
@@ -85,6 +89,7 @@ struct gkyl_comm {
   get_size_t get_size; // get number of ranks
   gkyl_array_send_t gkyl_array_send; // blocking send array.
   gkyl_array_isend_t gkyl_array_isend; // nonblocking send array.
+  gkyl_array_recv_t gkyl_array_recv; // blocking recv array.
   gkyl_array_irecv_t gkyl_array_irecv; // nonblocking recv array.
   all_reduce_t all_reduce; // all reduce function
   gkyl_array_sync_t gkyl_array_sync; // sync array
@@ -157,6 +162,21 @@ gkyl_comm_array_isend(struct gkyl_comm *comm, struct gkyl_array *array,
   int dest, int tag, struct gkyl_comm_state *state)
 {
   return comm->gkyl_array_isend(array, dest, tag, comm, state);
+}
+
+/**
+ * Blocking recv a gkyl array from another process.
+ * @param comm Communicator.
+ * @param array Array to receive into.
+ * @param src MPI rank we are receiving from. 
+ * @param tag MPI tag.
+ * @return error code: 0 for success
+ */
+static int
+gkyl_comm_array_recv(struct gkyl_comm *comm, struct gkyl_array *array,
+  int src, int tag)
+{
+  return comm->gkyl_array_recv(array, src, tag, comm);
 }
 
 /**

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -115,6 +115,15 @@ array_send(struct gkyl_array *array, int dest, int tag, struct gkyl_comm *comm)
 }
 
 static int
+array_isend(struct gkyl_array *array, int dest, int tag, struct gkyl_comm *comm, struct gkyl_comm_state *state)
+{
+  size_t vol = array->esznc*array->size;
+  struct mpi_comm *mpi = container_of(comm, struct mpi_comm, base);  
+  int ret = MPI_Isend(array->data, vol, g2_mpi_datatype[array->type], dest, tag, mpi->mcomm, &state->req); 
+  return ret == MPI_SUCCESS ? 0 : 1;
+}
+
+static int
 array_irecv(struct gkyl_array *array, int src, int tag, struct gkyl_comm *comm, struct gkyl_comm_state *state)
 {
   size_t vol = array->esznc*array->size;
@@ -569,6 +578,7 @@ gkyl_mpi_comm_new(const struct gkyl_mpi_comm_inp *inp)
   mpi->base.get_size = get_size;
   mpi->base.barrier = barrier;
   mpi->base.gkyl_array_send = array_send;
+  mpi->base.gkyl_array_isend = array_isend;
   mpi->base.gkyl_array_irecv = array_irecv;
   mpi->base.all_reduce = all_reduce;
   mpi->base.gkyl_array_sync = array_sync;

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -40,6 +40,11 @@ struct comm_buff_stat {
   gkyl_mem_buff buff;
 };
 
+struct gkyl_comm_state {
+  MPI_Request req;
+  MPI_Status stat;
+};
+
 // Private struct wrapping MPI-specific code
 struct mpi_comm {
   struct gkyl_comm base; // base communicator
@@ -98,6 +103,24 @@ get_size(struct gkyl_comm *comm, int *sz)
   struct mpi_comm *mpi = container_of(comm, struct mpi_comm, base);
   MPI_Comm_size(mpi->mcomm, sz);
   return 0;
+}
+
+static int
+array_send(struct gkyl_array *array, int dest, int tag, struct gkyl_comm *comm)
+{
+  size_t vol = array->esznc*array->size;
+  struct mpi_comm *mpi = container_of(comm, struct mpi_comm, base);  
+  int ret = MPI_Send(array->data, vol, g2_mpi_datatype[array->type], dest, tag, mpi->mcomm); 
+  return ret == MPI_SUCCESS ? 0 : 1;
+}
+
+static int
+array_irecv(struct gkyl_array *array, int src, int tag, struct gkyl_comm *comm, struct gkyl_comm_state *state)
+{
+  size_t vol = array->esznc*array->size;
+  struct mpi_comm *mpi = container_of(comm, struct mpi_comm, base);  
+  int ret = MPI_Irecv(array->data, vol, g2_mpi_datatype[array->type], src, tag, mpi->mcomm, &state->req); 
+  return ret == MPI_SUCCESS ? 0 : 1;
 }
 
 static int
@@ -472,6 +495,22 @@ extend_comm(const struct gkyl_comm *comm, const struct gkyl_range *erange)
   return ext_comm;
 }
 
+static struct gkyl_comm_state* comm_state_new()
+{
+  struct gkyl_comm_state *state = gkyl_malloc(sizeof *state);
+  return state;
+}
+
+static void comm_state_release(struct gkyl_comm_state *state)
+{
+  gkyl_free(state);
+}
+
+void comm_state_wait(struct gkyl_comm_state *state)
+{
+  MPI_Wait(&state->req, &state->stat);
+}
+
 struct gkyl_comm*
 gkyl_mpi_comm_new(const struct gkyl_mpi_comm_inp *inp)
 {
@@ -511,12 +550,16 @@ gkyl_mpi_comm_new(const struct gkyl_mpi_comm_inp *inp)
   mpi->base.get_rank = get_rank;
   mpi->base.get_size = get_size;
   mpi->base.barrier = barrier;
+  mpi->base.gkyl_array_send = array_send;
+  mpi->base.gkyl_array_irecv = array_irecv;
   mpi->base.all_reduce = all_reduce;
   mpi->base.gkyl_array_sync = array_sync;
   mpi->base.gkyl_array_per_sync = array_per_sync;
   mpi->base.gkyl_array_write = array_write;
   mpi->base.extend_comm = extend_comm;
-
+  mpi->base.comm_state_new = comm_state_new;
+  mpi->base.comm_state_release = comm_state_release;
+  mpi->base.comm_state_wait = comm_state_wait;
   mpi->base.ref_count = gkyl_ref_count_init(comm_free);
 
   return &mpi->base;


### PR DESCRIPTION
Add functions that allow us to send and recv whole gkyl_arrays. This is intended to send moments across the species communicator. Also add a method to split a gkyl_comm. However, I have some doubts as to what precise flow we wish people to follow to create other gkyl_comm objects. There are two options (only option 1 is implemented here):
1. Use gkyl_comm_split_comm, which takes in a parent gkyl_comm, a color, and a decomp. This calls MPI_Comm_split inside.
2. Call MPI_Comm_split to get a new MPI_Comm, then pass that to gkyl_mpi_comm_new.

Submitting this PR for review to hear comments on this structure.