### PR TITLE
Update configure

### DIFF
--- a/configure
+++ b/configure
@@ -157,11 +157,11 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       USE_MPI="$value"
       ;;       
-   --openmpi-inc)
+   --mpi-inc)
       [ -n "$value" ] || die "Missing value in flag $key."
       MPI_INC="$value"
       ;;
-   --openmpi-lib)
+   --mpi-lib)
       [ -n "$value" ] || die "Missing value in flag $key."
       MPI_LIB="$value"
       ;;   


### PR DESCRIPTION
Changing `configure` parameters from `--openmpi-inc` and `-lib` to `--mpi-inc` and `-lib` to match the variable names and the configure help