### PR TITLE
Add a test of gkyl_range_iter_init and gkyl_range_iter_next; this was…

### DIFF
--- a/unit/ctest_range.c
+++ b/unit/ctest_range.c
@@ -69,6 +69,41 @@ void test_range_shift()
   }
 }
 
+void test_range_iter_init_next()
+{
+  // Test 1D range
+  int lower1d[] = {1}, upper1d[] = {17};
+  struct gkyl_range range1d;
+  gkyl_range_init(&range1d, 1, lower1d, upper1d);
+
+  struct gkyl_range_iter iter1d;
+  gkyl_range_iter_init(&iter1d, &range1d);
+  int idx1d[] = {lower1d[0]-1};
+  while (gkyl_range_iter_next(&iter1d)) {
+    idx1d[0] += 1;
+    TEST_CHECK( iter1d.idx[0] == idx1d[0] );
+  }
+
+  // Test 2D range
+  int lower2d[] = {1,1}, upper2d[] = {17,6};
+  struct gkyl_range range2d;
+  gkyl_range_init(&range2d, 2, lower2d, upper2d);
+
+  struct gkyl_range_iter iter2d;
+  gkyl_range_iter_init(&iter2d, &range2d);
+  int linc = 0;
+  while (gkyl_range_iter_next(&iter2d)) {
+    // Assume row-major order.
+    int idx2d[2];
+    idx2d[0] = lower2d[0]+linc/(upper2d[1]-lower2d[1]+1);
+    idx2d[1] = linc+lower2d[1] - (idx2d[0]-1)*(upper2d[1]-lower2d[1]+1);
+    TEST_CHECK( iter2d.idx[0] == idx2d[0] );
+    TEST_CHECK( iter2d.idx[1] == idx2d[1] );
+    TEST_MSG("Expected: %d,%d | Got: %d,%d", iter2d.idx[0], iter2d.idx[1], idx2d[0], idx2d[1]);
+    linc += 1;
+  }
+}
+
 void test_sub_range()
 {
   int lower[] = {1, 1}, upper[] = {10, 20};
@@ -999,6 +1034,7 @@ TEST_LIST = {
   { "range_shift", test_range_shift },
   { "range_shape",  test_range_shape },
   { "sub_range",  test_sub_range },
+  { "range_iter_init_next", test_range_iter_init_next},
   { "sub_sub_range",  test_sub_sub_range },
   { "sub_range_inv_idx",  test_sub_range_inv_idx },
   { "shorten", test_shorten },


### PR DESCRIPTION
… indirectly tested in tests of other things but this is a dedicated test. It also allows us to expose one potential problem: in 1D if lower[0] > upper[0] (of the range) then the while loop doesn't execute and all is fine, in 2D if lower[0]>upper[0] all is fine too, but if lower[1]>upper[1] then a seg fault shows up. This is important for parallel sims where some MPI processes produce a range with lower>upper as a way to indicate that that process should not perform any operations in that range.

I'll mention this in an issue too.