### PR TITLE
Fix the ghost_surf_calc CUDA implementation (used for boundary fluxes…

### DIFF
--- a/zero/dg_updater_bflux_gyrokinetic.c
+++ b/zero/dg_updater_bflux_gyrokinetic.c
@@ -7,11 +7,11 @@
 #include <gkyl_dg_updater_bflux_gyrokinetic_priv.h>
 #include <gkyl_util.h>
 
-gkyl_dg_updater_bflux_gyrokinetic*
+struct gkyl_dg_updater_bflux_gyrokinetic*
 gkyl_dg_updater_bflux_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
   int cdim, const gkyl_dg_updater_gyrokinetic *gyrokinetic, bool use_gpu)
 {
-  gkyl_dg_updater_bflux_gyrokinetic *up = gkyl_malloc(sizeof(gkyl_dg_updater_bflux_gyrokinetic));
+  struct gkyl_dg_updater_bflux_gyrokinetic *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_bflux_gyrokinetic));
   up->slvr = gkyl_ghost_surf_calc_new(grid, gkyl_dg_updater_gyrokinetic_acquire_eqn(gyrokinetic), cdim, use_gpu);
   up->bflux_tm = 0.0;
   
@@ -19,7 +19,7 @@ gkyl_dg_updater_bflux_gyrokinetic_new(const struct gkyl_rect_grid *grid,
 }
 
 void
-gkyl_dg_updater_bflux_gyrokinetic_advance(gkyl_dg_updater_bflux_gyrokinetic *up,
+gkyl_dg_updater_bflux_gyrokinetic_advance(struct gkyl_dg_updater_bflux_gyrokinetic *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {
@@ -29,7 +29,7 @@ gkyl_dg_updater_bflux_gyrokinetic_advance(gkyl_dg_updater_bflux_gyrokinetic *up,
 }
 
 struct gkyl_dg_updater_bflux_gyrokinetic_tm
-OAgkyl_dg_updater_bflux_gyrokinetic_get_tm(const gkyl_dg_updater_bflux_gyrokinetic *up)
+OAgkyl_dg_updater_bflux_gyrokinetic_get_tm(const struct gkyl_dg_updater_bflux_gyrokinetic *up)
 {
   return (struct gkyl_dg_updater_bflux_gyrokinetic_tm) {
     .bflux_tm = up->bflux_tm,
@@ -37,7 +37,7 @@ OAgkyl_dg_updater_bflux_gyrokinetic_get_tm(const gkyl_dg_updater_bflux_gyrokinet
 }
 
 void
-gkyl_dg_updater_bflux_gyrokinetic_release(gkyl_dg_updater_bflux_gyrokinetic* up)
+gkyl_dg_updater_bflux_gyrokinetic_release(struct gkyl_dg_updater_bflux_gyrokinetic* up)
 {
   gkyl_ghost_surf_calc_release(up->slvr);
   gkyl_free(up);
@@ -46,7 +46,7 @@ gkyl_dg_updater_bflux_gyrokinetic_release(gkyl_dg_updater_bflux_gyrokinetic* up)
 #ifdef GKYL_HAVE_CUDA
 
 void
-gkyl_dg_updater_bflux_gyrokinetic_advance_cu(gkyl_dg_updater_bflux_gyrokinetic *up,
+gkyl_dg_updater_bflux_gyrokinetic_advance_cu(struct gkyl_dg_updater_bflux_gyrokinetic *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {
@@ -60,7 +60,7 @@ gkyl_dg_updater_bflux_gyrokinetic_advance_cu(gkyl_dg_updater_bflux_gyrokinetic *
 #ifndef GKYL_HAVE_CUDA
 
 void
-gkyl_dg_updater_bflux_gyrokinetic_advance_cu(gkyl_dg_updater_bflux_gyrokinetic *up,
+gkyl_dg_updater_bflux_gyrokinetic_advance_cu(struct gkyl_dg_updater_bflux_gyrokinetic *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {

--- a/zero/dg_updater_bflux_vlasov.c
+++ b/zero/dg_updater_bflux_vlasov.c
@@ -7,11 +7,11 @@
 #include <gkyl_dg_updater_bflux_vlasov_priv.h>
 #include <gkyl_util.h>
 
-gkyl_dg_updater_bflux_vlasov*
+struct gkyl_dg_updater_bflux_vlasov*
 gkyl_dg_updater_bflux_vlasov_new(const struct gkyl_rect_grid *grid, 
   int cdim, const gkyl_dg_updater_vlasov *vlasov, bool use_gpu)
 {
-  gkyl_dg_updater_bflux_vlasov *up = gkyl_malloc(sizeof(gkyl_dg_updater_bflux_vlasov));
+  struct gkyl_dg_updater_bflux_vlasov *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_bflux_vlasov));
   up->slvr = gkyl_ghost_surf_calc_new(grid, gkyl_dg_updater_vlasov_acquire_eqn(vlasov), cdim, use_gpu);
   up->bflux_tm = 0.0;
   
@@ -19,7 +19,7 @@ gkyl_dg_updater_bflux_vlasov_new(const struct gkyl_rect_grid *grid,
 }
 
 void
-gkyl_dg_updater_bflux_vlasov_advance(gkyl_dg_updater_bflux_vlasov *up,
+gkyl_dg_updater_bflux_vlasov_advance(struct gkyl_dg_updater_bflux_vlasov *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {
@@ -29,7 +29,7 @@ gkyl_dg_updater_bflux_vlasov_advance(gkyl_dg_updater_bflux_vlasov *up,
 }
 
 struct gkyl_dg_updater_bflux_vlasov_tm
-OAgkyl_dg_updater_bflux_vlasov_get_tm(const gkyl_dg_updater_bflux_vlasov *up)
+OAgkyl_dg_updater_bflux_vlasov_get_tm(const struct gkyl_dg_updater_bflux_vlasov *up)
 {
   return (struct gkyl_dg_updater_bflux_vlasov_tm) {
     .bflux_tm = up->bflux_tm,
@@ -37,7 +37,7 @@ OAgkyl_dg_updater_bflux_vlasov_get_tm(const gkyl_dg_updater_bflux_vlasov *up)
 }
 
 void
-gkyl_dg_updater_bflux_vlasov_release(gkyl_dg_updater_bflux_vlasov* up)
+gkyl_dg_updater_bflux_vlasov_release(struct gkyl_dg_updater_bflux_vlasov* up)
 {
   gkyl_ghost_surf_calc_release(up->slvr);
   gkyl_free(up);
@@ -46,7 +46,7 @@ gkyl_dg_updater_bflux_vlasov_release(gkyl_dg_updater_bflux_vlasov* up)
 #ifdef GKYL_HAVE_CUDA
 
 void
-gkyl_dg_updater_bflux_vlasov_advance_cu(gkyl_dg_updater_bflux_vlasov *up,
+gkyl_dg_updater_bflux_vlasov_advance_cu(struct gkyl_dg_updater_bflux_vlasov *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {
@@ -60,7 +60,7 @@ gkyl_dg_updater_bflux_vlasov_advance_cu(gkyl_dg_updater_bflux_vlasov *up,
 #ifndef GKYL_HAVE_CUDA
 
 void
-gkyl_dg_updater_bflux_vlasov_advance_cu(gkyl_dg_updater_bflux_vlasov *up,
+gkyl_dg_updater_bflux_vlasov_advance_cu(struct gkyl_dg_updater_bflux_vlasov *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs)
 {

--- a/zero/ghost_surf_calc_cu.cu
+++ b/zero/ghost_surf_calc_cu.cu
@@ -14,58 +14,37 @@ extern "C" {
 }
 
 __global__ static void
-gkyl_ghost_surf_calc_advance_cu_ker(const gkyl_ghost_surf_calc* gcalc,
+gkyl_ghost_surf_calc_advance_cu_ker(const struct gkyl_ghost_surf_calc *gcalc,
   int dir, int edge, struct gkyl_range edge_rng,
   const struct gkyl_array* fIn, struct gkyl_array* rhs)
 {
-  double xcc[GKYL_MAX_DIM], xcl[GKYL_MAX_DIM], xcr[GKYL_MAX_DIM];
-  int idxc[GKYL_MAX_DIM], idxl[GKYL_MAX_DIM], idxr[GKYL_MAX_DIM];
+  double xcg[GKYL_MAX_DIM], xcs[GKYL_MAX_DIM];
+  int idxg[GKYL_MAX_DIM], idxs[GKYL_MAX_DIM];
 
-  double* fBlank;
-  fBlank = (double*) gkyl_array_cfetch(fIn, 0);
-  for (int i=0; i<fIn->ncomp; ++i) {
-    fBlank[i] = 0.0;
-  }
-  
   for(unsigned long tid = threadIdx.x + blockIdx.x*blockDim.x;
       tid < edge_rng.volume; tid += blockDim.x*gridDim.x) {
-    gkyl_sub_range_inv_idx(&edge_rng, tid, idxc);
-    gkyl_copy_int_arr(edge_rng.ndim, idxc, idxl);
-    gkyl_copy_int_arr(edge_rng.ndim, idxc, idxr);
-    idxl[dir] = idxl[dir] - 1; idxr[dir] = idxr[dir] + 1;
+    gkyl_sub_range_inv_idx(&edge_rng, tid, idxg);
+    gkyl_copy_int_arr(edge_rng.ndim, idxg, idxs);
+    idxs[dir] -= edge;
 
-    gkyl_rect_grid_cell_center(&gcalc->grid, idxc, xcc);
-    gkyl_rect_grid_cell_center(&gcalc->grid, idxl, xcl);
-    gkyl_rect_grid_cell_center(&gcalc->grid, idxr, xcr);
+    gkyl_rect_grid_cell_center(&gcalc->grid, idxg, xcg);
+    gkyl_rect_grid_cell_center(&gcalc->grid, idxs, xcs);
 
-    long lincP = gkyl_range_idx(&edge_rng, idxc);
-    long linlP = gkyl_range_idx(&edge_rng, idxl);
-    long linrP = gkyl_range_idx(&edge_rng, idxr);
+    long lincg = gkyl_range_idx(&edge_rng, idxg);
+    long lincs = gkyl_range_idx(&edge_rng, idxs);
 
-    const double* fcptr = (const double*) gkyl_array_cfetch(fIn, lincP);
+    const double* fgptr = (const double*) gkyl_array_cfetch(fIn, lincg);
+    const double* fsptr = (const double*) gkyl_array_cfetch(fIn, lincs);
     
-    const double* flptr;
-    const double* frptr;
-    // const double* fcptr;
-
-    if (edge == 1) {
-      flptr = (const double*) gkyl_array_cfetch(fIn, linlP);
-      frptr = (const double*) fBlank;
-    } else {
-      flptr = (const double*) fBlank;
-      frptr = (const double*) gkyl_array_cfetch(fIn, linrP);
-    }
-
-    // reduce local f to local mom
-    gcalc->equation->surf_term(gcalc->equation,
-      dir, xcl, xcc, xcr, gcalc->grid.dx, gcalc->grid.dx, gcalc->grid.dx,
-      idxl, idxc, idxr, flptr, (const double*) fBlank, frptr, (double*) gkyl_array_fetch(rhs, lincP)
+    gcalc->equation->boundary_surf_term(gcalc->equation,
+      dir, xcs, xcg, gcalc->grid.dx, gcalc->grid.dx, idxs, idxg,
+      edge, fsptr, fgptr, (double*) gkyl_array_fetch(rhs, lincg)
     );
   }
 }
 
 void
-gkyl_ghost_surf_calc_advance_cu(gkyl_ghost_surf_calc *gcalc,
+gkyl_ghost_surf_calc_advance_cu(struct gkyl_ghost_surf_calc *gcalc,
   const struct gkyl_range *phase_rng,
   const struct gkyl_array *fIn, struct gkyl_array *rhs)
 {
@@ -79,9 +58,9 @@ gkyl_ghost_surf_calc_advance_cu(gkyl_ghost_surf_calc *gcalc,
   }
   
   for(int dir=0; dir<gcalc->cdim; ++dir) {
-    edge = 1;
-    clower_idx[dir] = phase_rng->upper[dir];
-    cupper_idx[dir] = phase_rng->upper[dir];
+    edge = -1;
+    clower_idx[dir] = phase_rng->lower[dir];
+    cupper_idx[dir] = phase_rng->lower[dir];
     gkyl_sub_range_init(&edge_rng, phase_rng, clower_idx, cupper_idx);
     nblocks = edge_rng.nblocks;
     nthreads = edge_rng.nthreads;
@@ -89,9 +68,9 @@ gkyl_ghost_surf_calc_advance_cu(gkyl_ghost_surf_calc *gcalc,
     gkyl_ghost_surf_calc_advance_cu_ker<<<nblocks, nthreads>>>(gcalc->on_dev, dir,
       edge, edge_rng, fIn->on_dev, rhs->on_dev);
 
-    edge = 0;
-    clower_idx[dir] = phase_rng->lower[dir];
-    cupper_idx[dir] = phase_rng->lower[dir];
+    edge = 1;
+    clower_idx[dir] = phase_rng->upper[dir];
+    cupper_idx[dir] = phase_rng->upper[dir];
     gkyl_sub_range_init(&edge_rng, phase_rng, clower_idx, cupper_idx);
     nblocks = edge_rng.nblocks;
     nthreads = edge_rng.nthreads;
@@ -105,11 +84,11 @@ gkyl_ghost_surf_calc_advance_cu(gkyl_ghost_surf_calc *gcalc,
   }
 }
 
-gkyl_ghost_surf_calc*
+struct gkyl_ghost_surf_calc*
 gkyl_ghost_surf_calc_cu_dev_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_dg_eqn *equation, int cdim)
 {
-  gkyl_ghost_surf_calc *up = (gkyl_ghost_surf_calc*) gkyl_malloc(sizeof(gkyl_ghost_surf_calc));
+  struct gkyl_ghost_surf_calc *up = (struct gkyl_ghost_surf_calc*) gkyl_malloc(sizeof(struct gkyl_ghost_surf_calc));
   up->grid = *grid;
   up->cdim = cdim;
   
@@ -119,8 +98,8 @@ gkyl_ghost_surf_calc_cu_dev_new(const struct gkyl_rect_grid *grid,
   up->flags = 0;
   GKYL_SET_CU_ALLOC(up->flags);
 
-  gkyl_ghost_surf_calc *up_cu = (gkyl_ghost_surf_calc*) gkyl_cu_malloc(sizeof(gkyl_ghost_surf_calc));
-  gkyl_cu_memcpy(up_cu, up, sizeof(gkyl_ghost_surf_calc), GKYL_CU_MEMCPY_H2D);
+  struct gkyl_ghost_surf_calc *up_cu = (struct gkyl_ghost_surf_calc*) gkyl_cu_malloc(sizeof(struct gkyl_ghost_surf_calc));
+  gkyl_cu_memcpy(up_cu, up, sizeof(struct gkyl_ghost_surf_calc), GKYL_CU_MEMCPY_H2D);
   up->on_dev = up_cu;
   
   up->equation = eqn;

--- a/zero/gkyl_dg_updater_bflux_gyrokinetic.h
+++ b/zero/gkyl_dg_updater_bflux_gyrokinetic.h
@@ -26,7 +26,7 @@ struct gkyl_dg_updater_bflux_gyrokinetic_tm {
  * 
  * @return New boundary flux updater object.
  */
-gkyl_dg_updater_bflux_gyrokinetic* gkyl_dg_updater_bflux_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
+struct gkyl_dg_updater_bflux_gyrokinetic* gkyl_dg_updater_bflux_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
   int cdim, const gkyl_dg_updater_gyrokinetic *gyrokinetic, bool use_gpu);
 
 /**
@@ -40,11 +40,11 @@ gkyl_dg_updater_bflux_gyrokinetic* gkyl_dg_updater_bflux_gyrokinetic_new(const s
  * @param fIn Input to updater.
  * @param rhs RHS output.
  */
-void gkyl_dg_updater_bflux_gyrokinetic_advance(gkyl_dg_updater_bflux_gyrokinetic *up,
+void gkyl_dg_updater_bflux_gyrokinetic_advance(struct gkyl_dg_updater_bflux_gyrokinetic *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs);
 
-void gkyl_dg_updater_bflux_gyrokinetic_advance_cu(gkyl_dg_updater_bflux_gyrokinetic *up,
+void gkyl_dg_updater_bflux_gyrokinetic_advance_cu(struct gkyl_dg_updater_bflux_gyrokinetic *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs);
 
@@ -54,11 +54,11 @@ void gkyl_dg_updater_bflux_gyrokinetic_advance_cu(gkyl_dg_updater_bflux_gyrokine
  * @param up Boundary flux updater.
  * @return timers
  */
-struct gkyl_dg_updater_bflux_gyrokinetic_tm gkyl_dg_updater_bflux_gyrokinetic_get_tm(const gkyl_dg_updater_bflux_gyrokinetic *up);
+struct gkyl_dg_updater_bflux_gyrokinetic_tm gkyl_dg_updater_bflux_gyrokinetic_get_tm(const struct gkyl_dg_updater_bflux_gyrokinetic *up);
 
 /**
  * Delete updater.
  *
  * @param up Boundary flux updater.
  */
-void gkyl_dg_updater_bflux_gyrokinetic_release(gkyl_dg_updater_bflux_gyrokinetic* up);
+void gkyl_dg_updater_bflux_gyrokinetic_release(struct gkyl_dg_updater_bflux_gyrokinetic *up);

--- a/zero/gkyl_dg_updater_bflux_vlasov.h
+++ b/zero/gkyl_dg_updater_bflux_vlasov.h
@@ -28,7 +28,7 @@ struct gkyl_dg_updater_bflux_vlasov_tm {
  * 
  * @return New boundary flux updater object.
  */
-gkyl_dg_updater_bflux_vlasov* gkyl_dg_updater_bflux_vlasov_new(const struct gkyl_rect_grid *grid, 
+struct gkyl_dg_updater_bflux_vlasov* gkyl_dg_updater_bflux_vlasov_new(const struct gkyl_rect_grid *grid, 
   int cdim, const gkyl_dg_updater_vlasov *vlasov, bool use_gpu);
 
 /**
@@ -42,11 +42,11 @@ gkyl_dg_updater_bflux_vlasov* gkyl_dg_updater_bflux_vlasov_new(const struct gkyl
  * @param fIn Input to updater.
  * @param rhs RHS output.
  */
-void gkyl_dg_updater_bflux_vlasov_advance(gkyl_dg_updater_bflux_vlasov *up,
+void gkyl_dg_updater_bflux_vlasov_advance(struct gkyl_dg_updater_bflux_vlasov *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs);
 
-void gkyl_dg_updater_bflux_vlasov_advance_cu(gkyl_dg_updater_bflux_vlasov *up,
+void gkyl_dg_updater_bflux_vlasov_advance_cu(struct gkyl_dg_updater_bflux_vlasov *up,
   const struct gkyl_range *update_rng,
   const struct gkyl_array* GKYL_RESTRICT fIn, struct gkyl_array* GKYL_RESTRICT rhs);
 
@@ -56,11 +56,11 @@ void gkyl_dg_updater_bflux_vlasov_advance_cu(gkyl_dg_updater_bflux_vlasov *up,
  * @param up Boundary flux updater.
  * @return timers
  */
-struct gkyl_dg_updater_bflux_vlasov_tm gkyl_dg_updater_bflux_vlasov_get_tm(const gkyl_dg_updater_bflux_vlasov *up);
+struct gkyl_dg_updater_bflux_vlasov_tm gkyl_dg_updater_bflux_vlasov_get_tm(const struct gkyl_dg_updater_bflux_vlasov *up);
 
 /**
  * Delete updater.
  *
  * @param up Boundary flux updater.
  */
-void gkyl_dg_updater_bflux_vlasov_release(gkyl_dg_updater_bflux_vlasov* up);
+void gkyl_dg_updater_bflux_vlasov_release(struct gkyl_dg_updater_bflux_vlasov *up);

--- a/zero/gkyl_ghost_surf_calc.h
+++ b/zero/gkyl_ghost_surf_calc.h
@@ -17,7 +17,7 @@ typedef struct gkyl_ghost_surf_calc gkyl_ghost_surf_calc;
  * @param equation Equation object
  * @param use_gpu bool to determine if on GPU
  */
-gkyl_ghost_surf_calc* gkyl_ghost_surf_calc_new(const struct gkyl_rect_grid *grid,
+struct gkyl_ghost_surf_calc* gkyl_ghost_surf_calc_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_dg_eqn *equation, int cdim, bool use_gpu);
 
 /**
@@ -26,7 +26,7 @@ gkyl_ghost_surf_calc* gkyl_ghost_surf_calc_new(const struct gkyl_rect_grid *grid
  * @param grid_cu Grid object (on device)
  * @param equation Equation object
  */
-gkyl_ghost_surf_calc* gkyl_ghost_surf_calc_cu_dev_new(const struct gkyl_rect_grid *grid,
+struct gkyl_ghost_surf_calc* gkyl_ghost_surf_calc_cu_dev_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_dg_eqn *equation, int cdim);
 
 /**


### PR DESCRIPTION
…). It was calling the surface instead of the boundary surf kernels. GPU boundary fluxes now look the same on 3x GK sim with CPU or with 1x1x1x1,2x1x1x1,1x1x2x1,1x1x1x2 GPUs.