### PR TITLE
Fixed memory leaks in fem_poisson

### DIFF
--- a/zero/fem_poisson.c
+++ b/zero/fem_poisson.c
@@ -51,7 +51,7 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
     gkyl_array_copy(kSq_ho, kSq);
   } else {
     up->ishelmholtz = false;
-    kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 1);
+    kSq_ho = gkyl_array_new(GKYL_DOUBLE, up->num_basis, 1);
     gkyl_array_clear(kSq_ho, 0.);
   }
 

--- a/zero/fem_poisson.c
+++ b/zero/fem_poisson.c
@@ -52,7 +52,6 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
   } else {
     up->ishelmholtz = false;
     kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 1);
-    //kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 10);
     gkyl_array_clear(kSq_ho, 0.);
   }
 

--- a/zero/fem_poisson.c
+++ b/zero/fem_poisson.c
@@ -52,6 +52,7 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
   } else {
     up->ishelmholtz = false;
     kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 1);
+    //kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 10);
     gkyl_array_clear(kSq_ho, 0.);
   }
 
@@ -314,7 +315,7 @@ void gkyl_fem_poisson_release(gkyl_fem_poisson *up)
 #endif
 
   gkyl_free(up->globalidx);
-  gkyl_free(up->brhs);
+  gkyl_array_release(up->brhs);
   gkyl_free(up->kernels);
   gkyl_free(up);
 }

--- a/zero/fem_poisson_perp.c
+++ b/zero/fem_poisson_perp.c
@@ -34,7 +34,7 @@ gkyl_fem_poisson_perp_new(const struct gkyl_range *solve_range, const struct gky
     gkyl_array_copy(kSq_ho, kSq);
   } else {
     up->ishelmholtz = false;
-    kSq_ho = gkyl_array_new(GKYL_DOUBLE, 1, 1);
+    kSq_ho = gkyl_array_new(GKYL_DOUBLE, up->num_basis, 1);
     gkyl_array_clear(kSq_ho, 0.);
   }
 
@@ -367,7 +367,7 @@ void gkyl_fem_poisson_perp_release(struct gkyl_fem_poisson_perp *up)
   gkyl_superlu_prob_release(up->prob);
 #endif
 
-  gkyl_free(up->brhs);
+  gkyl_array_release(up->brhs);
   gkyl_free(up->kernels);
   gkyl_free(up->perp_range);
   gkyl_free(up->globalidx);

--- a/zero/superlu_ops.c
+++ b/zero/superlu_ops.c
@@ -254,9 +254,11 @@ gkyl_superlu_prob_release(struct gkyl_superlu_prob *prob)
 {
   SUPERLU_FREE (prob->rhs);
   SUPERLU_FREE (prob->perm_c);
+  
   for (size_t k=0; k<prob->nprob; k++) {
     SUPERLU_FREE (prob->perm_r[k]);
     Destroy_CompCol_Matrix(prob->A[k]);
+    gkyl_free(prob->A[k]);
 
     if (prob->assigned_rhs)
       Destroy_SuperMatrix_Store(prob->B[k]);
@@ -265,6 +267,10 @@ gkyl_superlu_prob_release(struct gkyl_superlu_prob *prob)
       Destroy_SuperNode_Matrix(prob->L[k]);
       Destroy_CompCol_Matrix(prob->U[k]);
     }
+
+    gkyl_free(prob->B[k]);
+    gkyl_free(prob->L[k]);
+    gkyl_free(prob->U[k]);
   }
   StatFree(&prob->stat);
   gkyl_free(prob->A);


### PR DESCRIPTION
There were some memory leaks and misallocated arrays in fem_poisson and superlu_ops. These are fixed. The fem_poisson unit tests are now fully valgrind clean! All is good with the world again.