### PR TITLE
fem_poisson: take the solve_range as an input, and expect epsilon as a gkyl_array

### DIFF
--- a/unit/ctest_fem_poisson.c
+++ b/unit/ctest_fem_poisson.c
@@ -201,6 +201,14 @@ test_1x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
     phi_cu  = mkarr_cu(basis.num_basis, localRange_ext.volume);
   }
 
+  struct gkyl_array *epsilon = use_gpu? mkarr_cu(basis.num_basis, localRange_ext.volume)
+                                      : mkarr(basis.num_basis, localRange_ext.volume);
+  gkyl_array_clear(epsilon, 0.);
+  gkyl_array_shiftc(epsilon, epsilon_0*pow(sqrt(2.),dim), 0);
+
+  // Only used in the fully periodic case.
+  struct gkyl_array *rho_cellavg = use_gpu? mkarr_cu(1, localRange_ext.volume) : mkarr(1, localRange_ext.volume);
+
   // Project the right-side source on the basis.
   gkyl_proj_on_basis_advance(projob, 0.0, &localRange, rho);
   struct gkyl_array *perbuff = mkarr(basis.num_basis, skin_ghost.lower_skin[dim-1].volume);
@@ -210,7 +218,7 @@ test_1x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
   if (use_gpu) gkyl_array_copy(rho_cu, rho);
 
   // FEM poisson solver.
-  gkyl_fem_poisson *poisson = gkyl_fem_poisson_new(&grid, basis, &bcs, epsilon_0, NULL, NULL, use_gpu);
+  gkyl_fem_poisson *poisson = gkyl_fem_poisson_new(&localRange, &grid, basis, &bcs, epsilon, NULL, true, use_gpu);
 
   // Set the RHS source.
   if (use_gpu)
@@ -489,7 +497,9 @@ test_1x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
   gkyl_fem_poisson_release(poisson);
   gkyl_proj_on_basis_release(projob);
   gkyl_array_release(rho);
+  gkyl_array_release(rho_cellavg);
   gkyl_array_release(phi);
+  gkyl_array_release(epsilon);
   if (use_gpu) {
     gkyl_array_release(rho_cu);
     gkyl_array_release(phi_cu);
@@ -576,6 +586,14 @@ test_2x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
     phi_cu = mkarr_cu(basis.num_basis, localRange_ext.volume);
   }
 
+  struct gkyl_array *epsilon = use_gpu? mkarr_cu(basis.num_basis, localRange_ext.volume)
+                                      : mkarr(basis.num_basis, localRange_ext.volume);
+  gkyl_array_clear(epsilon, 0.);
+  gkyl_array_shiftc(epsilon, epsilon_0*pow(sqrt(2.),dim), 0);
+
+  // Only used in the fully periodic case.
+  struct gkyl_array *rho_cellavg = use_gpu? mkarr_cu(1, localRange_ext.volume) : mkarr(1, localRange_ext.volume);
+
   // Project the right-side source on the basis.
   gkyl_proj_on_basis_advance(projob, 0.0, &localRange, rho);
   struct gkyl_array *perbuff = mkarr(basis.num_basis, skin_ghost.lower_skin[dim-1].volume);
@@ -585,7 +603,7 @@ test_2x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
   if (use_gpu) gkyl_array_copy(rho_cu, rho);
 
   // FEM poisson solver.
-  gkyl_fem_poisson *poisson = gkyl_fem_poisson_new(&grid, basis, &bcs, epsilon_0, NULL, NULL, use_gpu);
+  gkyl_fem_poisson *poisson = gkyl_fem_poisson_new(&localRange, &grid, basis, &bcs, epsilon, NULL, true, use_gpu);
 
   // Set the RHS source.
   if (use_gpu)
@@ -2162,7 +2180,9 @@ test_2x(int poly_order, const int *cells, struct gkyl_poisson_bc bcs, bool use_g
   gkyl_fem_poisson_release(poisson);
   gkyl_proj_on_basis_release(projob);
   gkyl_array_release(rho);
+  gkyl_array_release(rho_cellavg);
   gkyl_array_release(phi);
+  gkyl_array_release(epsilon);
   if (use_gpu) {
     gkyl_array_release(rho_cu);
     gkyl_array_release(phi_cu);

--- a/unit/ctest_fem_poisson_perp.c
+++ b/unit/ctest_fem_poisson_perp.c
@@ -2648,6 +2648,7 @@ test_fem_poisson_perp_consteps(int poly_order, const int *cells, struct gkyl_poi
   gkyl_array_release(eps);
   gkyl_array_release(phi);
   gkyl_array_release(phisol);
+  gkyl_array_release(rho);
   if (use_gpu) {
     gkyl_array_release(rho_cu);
     gkyl_array_release(phi_cu);

--- a/zero/fem_poisson.c
+++ b/zero/fem_poisson.c
@@ -40,8 +40,8 @@ gkyl_fem_poisson_new(const struct gkyl_range *solve_range, const struct gkyl_rec
     double *eps_avg = (double*) gkyl_malloc(sizeof(double)); 
 #ifdef GKYL_HAVE_CUDA
     up->epsilon = up->use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, 1) : gkyl_array_new(GKYL_DOUBLE, 1, 1);
-    struct gkyl_array *eps_cellavg = up->use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, up->epsilon->size)
-                                                : gkyl_array_new(GKYL_DOUBLE, 1, up->epsilon->size);
+    struct gkyl_array *eps_cellavg = up->use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, epsilon->size)
+                                                : gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
     gkyl_dg_calc_average_range(up->basis, 0, eps_cellavg, 0, epsilon, *up->solve_range);
     if (up->use_gpu) {
       double *eps_avg_cu = (double*) gkyl_cu_malloc(sizeof(double));
@@ -53,7 +53,7 @@ gkyl_fem_poisson_new(const struct gkyl_range *solve_range, const struct gkyl_rec
     }
 #else
     up->epsilon = gkyl_array_new(GKYL_DOUBLE, 1, 1);
-    struct gkyl_array *eps_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->epsilon->size);
+    struct gkyl_array *eps_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
 
     gkyl_dg_calc_average_range(up->basis, 0, eps_cellavg, 0, epsilon, *up->solve_range);
     gkyl_array_reduce_range(eps_avg, eps_cellavg, GKYL_SUM, *up->solve_range);

--- a/zero/fem_poisson.c
+++ b/zero/fem_poisson.c
@@ -2,8 +2,8 @@
 #include <gkyl_fem_poisson_priv.h>
 
 struct gkyl_fem_poisson*
-gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis basis,
-  struct gkyl_poisson_bc *bcs, double epsilon_const, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool use_gpu)
+gkyl_fem_poisson_new(const struct gkyl_range *solve_range, const struct gkyl_rect_grid *grid, const struct gkyl_basis basis,
+  struct gkyl_poisson_bc *bcs, struct gkyl_array *epsilon, struct gkyl_array *kSq, bool is_epsilon_const, bool use_gpu)
 {
 
   struct gkyl_fem_poisson *up = gkyl_malloc(sizeof(struct gkyl_fem_poisson));
@@ -18,6 +18,7 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
   up->kernels_cu = up->kernels;
 #endif
 
+  up->solve_range = solve_range;
   up->ndim = grid->ndim;
   up->grid = *grid;
   up->num_basis =  basis.num_basis;
@@ -26,21 +27,43 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
   up->basis = basis;
   up->use_gpu = use_gpu;
 
-  if (epsilon_var) {
+  // Factor accounting for normalization when subtracting a constant from a
+  // DG field and the 1/N to properly compute the volume averaged RHS.
+  up->mavgfac = -pow(sqrt(2.),up->ndim)/up->solve_range->volume;
+
+  if (!is_epsilon_const) {
     up->isvareps = true;
-    up->epsilon  = epsilon_var;
+    up->epsilon  = epsilon;
   } else {
     up->isvareps = false;
-    // Create an array to hold epsilon.
+    // Create a small gkyl_array to hold the constant epsilon value.
+    double *eps_avg = (double*) gkyl_malloc(sizeof(double)); 
 #ifdef GKYL_HAVE_CUDA
     up->epsilon = up->use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, 1) : gkyl_array_new(GKYL_DOUBLE, 1, 1);
+    struct gkyl_array *eps_cellavg = up->use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, up->epsilon->size)
+                                                : gkyl_array_new(GKYL_DOUBLE, 1, up->epsilon->size);
+    gkyl_dg_calc_average_range(up->basis, 0, eps_cellavg, 0, epsilon, *up->solve_range);
+    if (up->use_gpu) {
+      double *eps_avg_cu = (double*) gkyl_cu_malloc(sizeof(double));
+      gkyl_array_reduce_range(eps_avg_cu, eps_cellavg, GKYL_SUM, *up->solve_range);
+      gkyl_cu_memcpy(eps_avg, eps_avg_cu, sizeof(double), GKYL_CU_MEMCPY_D2H);
+      gkyl_cu_free(eps_avg_cu);
+    } else {
+      gkyl_array_reduce_range(eps_avg, eps_cellavg, GKYL_SUM, *up->solve_range);
+    }
 #else
     up->epsilon = gkyl_array_new(GKYL_DOUBLE, 1, 1);
+    struct gkyl_array *eps_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->epsilon->size);
+
+    gkyl_dg_calc_average_range(up->basis, 0, eps_cellavg, 0, epsilon, *up->solve_range);
+    gkyl_array_reduce_range(eps_avg, eps_cellavg, GKYL_SUM, *up->solve_range);
 #endif
-    gkyl_array_shiftc(up->epsilon, epsilon_const, 0);
+    gkyl_array_shiftc(up->epsilon, eps_avg[0]/up->solve_range->volume, 0);
+    gkyl_array_release(eps_cellavg);
+    gkyl_free(eps_avg);
   }
 
-  // We assume epsilon_var and kSq live on the device, and we create a host-side
+  // We assume epsilon and kSq live on the device, and we create a host-side
   // copies temporarily to compute the LHS matrix. This also works for CPU solves.
   struct gkyl_array *epsilon_ho = gkyl_array_new(GKYL_DOUBLE, up->epsilon->ncomp, up->epsilon->size);
   gkyl_array_copy(epsilon_ho, up->epsilon);
@@ -57,19 +80,7 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
 
   up->globalidx = gkyl_malloc(sizeof(long[up->num_basis])); // global index, one for each basis in a cell.
 
-  // Local and local-ext ranges for whole-grid arrays.
-  int ghost[GKYL_MAX_DIM];
-  for (int d=0; d<up->ndim; d++) ghost[d] = 1;
-  gkyl_create_grid_ranges(grid, ghost, &up->local_range_ext, &up->local_range);
-  // Range of cells we'll solve Poisson in, as
-  // a sub-range of up->local_range_ext.
-  int sublower[GKYL_MAX_CDIM], subupper[GKYL_MAX_CDIM];
-  for (int d=0; d<up->ndim; d++) {
-    sublower[d] = up->local_range.lower[d];
-    subupper[d] = up->local_range.upper[d];
-  }
-  gkyl_sub_range_init(&up->solve_range, &up->local_range_ext, sublower, subupper);
-  for (int d=0; d<up->ndim; d++) up->num_cells[d] = up->solve_range.upper[d]-up->solve_range.lower[d]+1;
+  for (int d=0; d<up->ndim; d++) up->num_cells[d] = up->solve_range->upper[d]-up->solve_range->lower[d]+1;
 
   // Prepare for periodic domain case.
   for (int d=0; d<up->ndim; d++) {
@@ -84,19 +95,16 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
   if (up->isdomperiodic) {
 #ifdef GKYL_HAVE_CUDA
     if (up->use_gpu) {
-      up->rhs_cellavg = gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, up->local_range_ext.volume);
-      up->rhs_avg_cu = (double*) gkyl_cu_malloc(sizeof(double)); 
+      up->rhs_cellavg = gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, epsilon->size);
+      up->rhs_avg_cu = (double*) gkyl_cu_malloc(sizeof(double));
     } else {
-      up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->local_range_ext.volume);
+      up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
     }
 #else
-    up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->local_range_ext.volume);
+    up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
 #endif
     up->rhs_avg = (double*) gkyl_malloc(sizeof(double)); 
     gkyl_array_clear(up->rhs_cellavg, 0.0);
-    // Factor accounting for normalization when subtracting a constant from a
-    // DG field and the 1/N to properly compute the volume averaged RHS.
-    up->mavgfac = -pow(sqrt(2.),up->ndim)/up->solve_range.volume;
   }
 
   // Pack BC values into a single array for easier use in kernels.
@@ -168,10 +176,10 @@ gkyl_fem_poisson_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis 
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu) gkyl_mat_triples_set_rowmaj_order(tri[0]);
 #endif
-  gkyl_range_iter_init(&up->solve_iter, &up->solve_range);
+  gkyl_range_iter_init(&up->solve_iter, up->solve_range);
   int idx0[GKYL_MAX_CDIM];
   while (gkyl_range_iter_next(&up->solve_iter)) {
-    long linidx = gkyl_range_idx(&up->solve_range, up->solve_iter.idx);
+    long linidx = gkyl_range_idx(up->solve_range, up->solve_iter.idx);
 
     double *eps_p = up->isvareps? gkyl_array_fetch(epsilon_ho, linidx) : gkyl_array_fetch(epsilon_ho,0);
     double *kSq_p = up->ishelmholtz? gkyl_array_fetch(kSq_ho, linidx) : gkyl_array_fetch(kSq_ho,0);
@@ -209,16 +217,16 @@ gkyl_fem_poisson_set_rhs(gkyl_fem_poisson* up, struct gkyl_array *rhsin)
   if (up->isdomperiodic && !(up->ishelmholtz)) {
     // Subtract the volume averaged RHS from the RHS.
     gkyl_array_clear(up->rhs_cellavg, 0.0);
-    gkyl_dg_calc_average_range(up->basis, 0, up->rhs_cellavg, 0, rhsin, up->solve_range);
+    gkyl_dg_calc_average_range(up->basis, 0, up->rhs_cellavg, 0, rhsin, *up->solve_range);
 #ifdef GKYL_HAVE_CUDA
     if (up->use_gpu) {
-      gkyl_array_reduce_range(up->rhs_avg_cu, up->rhs_cellavg, GKYL_SUM, up->solve_range);
+      gkyl_array_reduce_range(up->rhs_avg_cu, up->rhs_cellavg, GKYL_SUM, *up->solve_range);
       gkyl_cu_memcpy(up->rhs_avg, up->rhs_avg_cu, sizeof(double), GKYL_CU_MEMCPY_D2H);
     } else {
-      gkyl_array_reduce_range(up->rhs_avg, up->rhs_cellavg, GKYL_SUM, up->solve_range);
+      gkyl_array_reduce_range(up->rhs_avg, up->rhs_cellavg, GKYL_SUM, *up->solve_range);
     }
 #else
-    gkyl_array_reduce_range(up->rhs_avg, up->rhs_cellavg, GKYL_SUM, up->solve_range);
+    gkyl_array_reduce_range(up->rhs_avg, up->rhs_cellavg, GKYL_SUM, *up->solve_range);
 #endif
     gkyl_array_shiftc(rhsin, up->mavgfac*up->rhs_avg[0], 0);
   }
@@ -235,11 +243,11 @@ gkyl_fem_poisson_set_rhs(gkyl_fem_poisson* up, struct gkyl_array *rhsin)
 
   gkyl_array_clear(up->brhs, 0.0);
 
-  gkyl_range_iter_init(&up->solve_iter, &up->solve_range);
+  gkyl_range_iter_init(&up->solve_iter, up->solve_range);
   int idx0[GKYL_MAX_CDIM];
   double *brhs_p = gkyl_array_fetch(up->brhs, 0);
   while (gkyl_range_iter_next(&up->solve_iter)) {
-    long linidx = gkyl_range_idx(&up->solve_range, up->solve_iter.idx);
+    long linidx = gkyl_range_idx(up->solve_range, up->solve_iter.idx);
 
     double *eps_p = up->isvareps? gkyl_array_fetch(up->epsilon, linidx) : gkyl_array_fetch(up->epsilon,0);
     double *rhsin_p = gkyl_array_fetch(rhsin, linidx);
@@ -273,9 +281,9 @@ gkyl_fem_poisson_solve(gkyl_fem_poisson* up, struct gkyl_array *phiout) {
   gkyl_array_clear(phiout, 0.0);
 
   int idx0[GKYL_MAX_CDIM];
-  gkyl_range_iter_init(&up->solve_iter, &up->solve_range);
+  gkyl_range_iter_init(&up->solve_iter, up->solve_range);
   while (gkyl_range_iter_next(&up->solve_iter)) {
-    long linidx = gkyl_range_idx(&up->solve_range, up->solve_iter.idx);
+    long linidx = gkyl_range_idx(up->solve_range, up->solve_iter.idx);
 
     double *phiout_p = gkyl_array_fetch(phiout, linidx);
 

--- a/zero/fem_poisson_cu.cu
+++ b/zero/fem_poisson_cu.cu
@@ -204,7 +204,7 @@ gkyl_fem_poisson_set_rhs_cu(gkyl_fem_poisson *up, struct gkyl_array *rhsin)
 {
   gkyl_cusolver_clear_rhs(up->prob_cu, 0);
   double *rhs_cu = gkyl_cusolver_get_rhs_ptr(up->prob_cu, 0);
-  gkyl_fem_poisson_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(up->epsilon->on_dev, up->isvareps, up->dx_cu, rhs_cu, rhsin->on_dev, up->solve_range, up->bcvals_cu, up->kernels_cu); 
+  gkyl_fem_poisson_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(up->epsilon->on_dev, up->isvareps, up->dx_cu, rhs_cu, rhsin->on_dev, *up->solve_range, up->bcvals_cu, up->kernels_cu); 
 }	
 
 void
@@ -215,6 +215,6 @@ gkyl_fem_poisson_solve_cu(gkyl_fem_poisson *up, struct gkyl_array *phiout)
 
   double *x_cu = gkyl_cusolver_get_sol_ptr(up->prob_cu, 0);
 
-  gkyl_fem_poisson_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev, x_cu, up->solve_range, up->kernels_cu); 
+  gkyl_fem_poisson_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev, x_cu, *up->solve_range, up->kernels_cu); 
 }
 

--- a/zero/fem_poisson_perp.c
+++ b/zero/fem_poisson_perp.c
@@ -82,13 +82,13 @@ gkyl_fem_poisson_perp_new(const struct gkyl_range *solve_range, const struct gky
   if (up->isdomperiodic) {
 #ifdef GKYL_HAVE_CUDA
     if (up->use_gpu) {
-      up->rhs_cellavg = gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, up->solve_range->volume);
+      up->rhs_cellavg = gkyl_array_cu_dev_new(GKYL_DOUBLE, 1, epsilon->size);
       up->rhs_avg_cu = (double*) gkyl_cu_malloc(sizeof(double));
     } else {
-      up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->solve_range->volume);
+      up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
     }
 #else
-    up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, up->solve_range->volume);
+    up->rhs_cellavg = gkyl_array_new(GKYL_DOUBLE, 1, epsilon->size);
 #endif
     up->rhs_avg = (double*) gkyl_malloc(sizeof(double));
     gkyl_array_clear(up->rhs_cellavg, 0.0);

--- a/zero/gkyl_fem_poisson.h
+++ b/zero/gkyl_fem_poisson.h
@@ -29,15 +29,16 @@ typedef struct gkyl_fem_poisson gkyl_fem_poisson;
  * @param grid Grid object
  * @param basis Basis functions of the DG field.
  * @param bcs Boundary conditions.
- * @param epsilon_const Constant scalar value of the permittivity.
- * @param epsilon_var Spatially varying permittivity tensor.
+ * @param epsilon Permittivity tensor. Defined over the extended range.
  * @param kSq Squared wave number (factor multiplying phi in Helmholtz eq).
+ * @param is_epsilon_const =true if permittivity is constant in space.
  * @param use_gpu boolean indicating whether to use the GPU.
  * @return New updater pointer.
  */
 struct gkyl_fem_poisson* gkyl_fem_poisson_new(
-  const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, struct gkyl_poisson_bc *bcs,
-  double epsilon_const, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool use_gpu);
+  const struct gkyl_range *solve_range, const struct gkyl_rect_grid *grid, const struct gkyl_basis basis,
+  struct gkyl_poisson_bc *bcs, struct gkyl_array *epsilon_var, struct gkyl_array *kSq, bool is_epsilon_const,
+  bool use_gpu);
 
 /**
  * Assign the right-side vector with the discontinuous (DG) source field.
@@ -47,16 +48,12 @@ struct gkyl_fem_poisson* gkyl_fem_poisson_new(
  */
 void gkyl_fem_poisson_set_rhs(gkyl_fem_poisson* up, struct gkyl_array *rhsin);
 
-void gkyl_fem_poisson_set_rhs_cu(gkyl_fem_poisson *up, struct gkyl_array *rhsin);
-
 /**
  * Solve the linear problem.
  *
  * @param up FEM project updater to run.
  */
 void gkyl_fem_poisson_solve(gkyl_fem_poisson* up, struct gkyl_array *phiout);
-
-void gkyl_fem_poisson_solve_cu(gkyl_fem_poisson* up, struct gkyl_array *phiout);
 
 /**
  * Delete updater.

--- a/zero/gkyl_fem_poisson_perp.h
+++ b/zero/gkyl_fem_poisson_perp.h
@@ -48,16 +48,12 @@ struct gkyl_fem_poisson_perp* gkyl_fem_poisson_perp_new(
  */
 void gkyl_fem_poisson_perp_set_rhs(gkyl_fem_poisson_perp* up, struct gkyl_array *rhsin);
 
-void gkyl_fem_poisson_perp_set_rhs_cu(gkyl_fem_poisson_perp *up, struct gkyl_array *rhsin);
-
 /**
  * Solve the linear problem.
  *
  * @param up FEM project updater to run.
  */
 void gkyl_fem_poisson_perp_solve(gkyl_fem_poisson_perp* up, struct gkyl_array *phiout);
-
-void gkyl_fem_poisson_perp_solve_cu(gkyl_fem_poisson_perp* up, struct gkyl_array *phiout);
 
 /**
  * Delete updater.

--- a/zero/gkyl_fem_poisson_perp_priv.h
+++ b/zero/gkyl_fem_poisson_perp_priv.h
@@ -511,3 +511,20 @@ fem_poisson_perp_choose_sol_kernels(const struct gkyl_basis* basis)
       break;
   }
 }
+
+#ifdef GKYL_HAVE_CUDA
+/**
+ * Assign the right-side vector on the device.
+ *
+ * @param up FEM poisson updater to run.
+ * @param rhsin DG field to set as RHS source.
+ */
+void gkyl_fem_poisson_perp_set_rhs_cu(gkyl_fem_poisson_perp* up, struct gkyl_array *rhsin);
+
+/**
+ * Solve the linear problemon the device.
+ *
+ * @param up FEM project updater to run.
+ */
+void gkyl_fem_poisson_perp_solve_cu(gkyl_fem_poisson_perp* up, struct gkyl_array *phiout);
+#endif

--- a/zero/gkyl_fem_poisson_priv.h
+++ b/zero/gkyl_fem_poisson_priv.h
@@ -867,9 +867,8 @@ fem_poisson_choose_sol_kernels(const struct gkyl_basis* basis)
  *
  * @param up FEM poisson updater to run.
  * @param rhsin DG field to set as RHS source.
- * @param rhsin_cellavg Array w/ 1 component, same size as rhsin.
  */
-void gkyl_fem_poisson_set_rhs_cu(gkyl_fem_poisson* up, struct gkyl_array *rhsin, struct gkyl_array *rhsin_cellavg);
+void gkyl_fem_poisson_set_rhs_cu(gkyl_fem_poisson* up, struct gkyl_array *rhsin);
 
 /**
  * Solve the linear problem on the device.

--- a/zero/gkyl_fem_poisson_priv.h
+++ b/zero/gkyl_fem_poisson_priv.h
@@ -659,8 +659,7 @@ struct gkyl_fem_poisson {
   double bcvals[GKYL_MAX_CDIM*2*3]; // BC values, bc[0]*phi+bc[1]*d(phi)/dx=phi[3] at each boundary.
   double *bcvals_cu; // BC values, bc[0]*phi+bc[1]*d(phi)/dx=phi[3] at each boundary.
 
-  struct gkyl_range local_range, local_range_ext;
-  struct gkyl_range solve_range;
+  const struct gkyl_range *solve_range;
   struct gkyl_range_iter solve_iter;
 
   int numnodes_local;
@@ -861,3 +860,21 @@ fem_poisson_choose_sol_kernels(const struct gkyl_basis* basis)
       break;
   }
 }
+
+#ifdef GKYL_HAVE_CUDA
+/**
+ * Assign the right-side vector on the device.
+ *
+ * @param up FEM poisson updater to run.
+ * @param rhsin DG field to set as RHS source.
+ * @param rhsin_cellavg Array w/ 1 component, same size as rhsin.
+ */
+void gkyl_fem_poisson_set_rhs_cu(gkyl_fem_poisson* up, struct gkyl_array *rhsin, struct gkyl_array *rhsin_cellavg);
+
+/**
+ * Solve the linear problem on the device.
+ *
+ * @param up FEM project updater to run.
+ */
+void gkyl_fem_poisson_solve_cu(gkyl_fem_poisson* up, struct gkyl_array *phiout);
+#endif


### PR DESCRIPTION
1. Make fem_poisson take solve_range as an input, rather than constructing it inside. It is better to have the driver program define the ranges in which operations are performed. This was done in fem_poisson_perp and fem_parproj to allow parallel operations; it is strictly not necessary for fem_poisson since this operation always happens on the whole grid, but it keeps this updater in line with the others.
2. Change the signature so that epsilon is specified as a gkyl_array. In the case of constant epsilon, we expect that the gkyl_array contains the DG representation of that constant value. We later do other things inside to make it efficient and not deal with the a whole-grid DG field (in the constant epsilon case).