### PR TITLE
Fix of gradient-based closure: now parallelized and correct ranges. 

### DIFF
--- a/regression/rt_10m_par_firehose.c
+++ b/regression/rt_10m_par_firehose.c
@@ -1,57 +1,64 @@
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include <gkyl_alloc.h>
 #include <gkyl_moment.h>
 #include <gkyl_util.h>
 #include <gkyl_wv_ten_moment.h>
+
+#include <gkyl_null_comm.h>
+
+#ifdef GKYL_HAVE_MPI
+#include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#endif
+
 #include <rt_arg_parse.h>
+
+struct par_firehose_ctx {
+  // Fundamental constants
+  double epsilon0; // permittivity of free space
+  double mu0; // permeability of free space
+  double chargeElc; // electron charge
+  double massElc; // electron mass
+  double chargeIon; // ion charge
+  double massIon; // ion mass
+  double n0; // reference density
+  double B0; // reference magnetic field strength
+  double TiPar; // parallel ion temperature
+  double TiPerp; // perpendicular ion temperature
+  double Te; // electron temperature
+  double k0_elc; // closure parameter for electrons
+  double k0_ion; // closure parameter for ions
+  double noise_amp; // amplitude of perturbation
+  int k_init; // initial wavenumber to perturb
+  int k_final; // final wavenumber to perturb
+  double Lx; // size of the box
+  double tend; // end time of the simulation
+};
 
 void
 evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
-  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
-  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
-  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
-  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
-  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+  double massElc = app->massElc;
+  double Te = app->Te;
+  double n0 = app->n0;
 
-  double vtElc = vAe*sqrt(beta);
-  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
-  double elcTemp = vtElc*vtElc/2.0;
-
-  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
-  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
-
-  double rhoe = elcMass*n0;
+  double rhoe = massElc*n0;
   double momxe = 0.0;
   double momye = 0.0;
   double momze = 0.0;
-  double pxxe = n0*elcTemp + momxe*momxe/rhoe;
+  double pxxe = n0*Te + momxe*momxe/rhoe;
   double pxye = momxe*momye/rhoe;
   double pxze = momxe*momze/rhoe;
-  double pyye = n0*elcTemp + momye*momye/rhoe;
+  double pyye = n0*Te + momye*momye/rhoe;
   double pyze = momye*momye/rhoe;
-  double pzze = n0*elcTemp + momze*momze/rhoe;
+  double pzze = n0*Te + momze*momze/rhoe;
 
   fout[0] = rhoe;
   fout[1] = momxe; fout[2] = momye; fout[3] = momze;
@@ -63,47 +70,23 @@ void
 evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
-  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
-  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
-  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
-  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
-  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+  double massIon = app->massIon;
+  double TiPar = app->TiPar;
+  double TiPerp = app->TiPerp;
+  double n0 = app->n0;
 
-  double vtElc = vAe*sqrt(beta);
-  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
-  double elcTemp = vtElc*vtElc/2.0;
-
-  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
-  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
-
-  double rhoi = ionMass*n0;
+  double rhoi = massIon*n0;
   double momxi = 0.0;
   double momyi = 0.0;
   double momzi = 0.0;
-  double pxxi = n0*ionTempPar + momxi*momxi/rhoi;
+  double pxxi = n0*TiPar + momxi*momxi/rhoi;
   double pxyi = momxi*momyi/rhoi;
   double pxzi = momxi*momzi/rhoi;
-  double pyyi = n0*ionTempPerp + momyi*momyi/rhoi;
+  double pyyi = n0*TiPerp + momyi*momyi/rhoi;
   double pyzi = momyi*momyi/rhoi;
-  double pzzi = n0*ionTempPerp + momzi*momzi/rhoi;
+  double pzzi = n0*TiPerp + momzi*momzi/rhoi;
 
   fout[0] = rhoi;
   fout[1] = momxi; fout[2] = momyi; fout[3] = momzi;
@@ -115,35 +98,19 @@ void
 evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
   pcg64_random_t rng = gkyl_pcg64_init(0);
 
-  double Bx = B0;
+  double Bx = app->B0;
   double By = 0.0, Bz = 0.0;
 
-  double alpha = 1.0e-6*B0;
-  double Lx = 12845.57;
-  double kx = 2.0*pi/Lx;
-  for (int i=0; i<48; ++i) {
-    By -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
-    Bz -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
+  double alpha = app->noise_amp*Bx;
+  double Lx = app->Lx;
+  double kx = 2.0*M_PI/Lx;
+  for (int i = app->k_init; i < app->k_final; ++i) {
+    By -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*M_PI*gkyl_pcg64_rand_double(&rng));
+    Bz -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*M_PI*gkyl_pcg64_rand_double(&rng));
   }
 
   // electric field
@@ -153,6 +120,78 @@ evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT f
 
   // correction potentials
   fout[6] = 0.0; fout[7] = 0.0;
+}
+
+struct par_firehose_ctx
+create_ctx(void)
+{
+  double epsilon0 = 1.0; // permittivity of free space
+  double mu0 = 1.0; // pemiability of free space
+  double lightSpeed = 1.0/sqrt(epsilon0*mu0);
+
+  double massElc = 1.0; // electron mass
+  double chargeElc = -1.0; // electron charge
+  double massIon = 1836.0; // ion mass
+  double chargeIon = 1.0; // ion charge
+
+  // Ion and electron temperature assumed equal, Ti/Te = 1.0
+  double n0 = 1.0; // initial number density
+  double vAe = 0.0125;
+  double B0 = vAe*sqrt(mu0*n0*massElc);
+  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
+  double beta = 300.0/M_PI; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
+  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
+  double betaPar = beta + 2.0*dbeta/3.0; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
+  double betaPerp = beta - dbeta/3.0; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+
+  double vtElc = vAe*sqrt(beta);
+  double Te = vtElc*vtElc*massElc/2.0;
+
+  double TiPar = vAe*vAe*(betaPar*massElc/2.0);
+  double TiPerp = vAe*vAe*(betaPerp*massElc/2.0);
+
+  // frequencies, skin depths, and Debye length
+  double omegaCi = chargeIon*B0/massIon;
+  double wpe = sqrt(n0*chargeElc*chargeElc/(epsilon0*massElc));
+  double de = lightSpeed/wpe;
+  double wpi = sqrt(n0*chargeIon*chargeIon/(epsilon0*massIon));
+  double di = lightSpeed/wpi;
+  double lambdaD = vtElc/wpe;
+
+  // noise levels for perturbation
+  double noise_amp = 1.0e-6*B0;
+  int k_init = 1;   // first wave mode to perturb with noise, 1 correspond to box size
+  int k_final = 48; // last wave mode to perturb with noise
+
+  // k0 for closure
+  double k0_elc = 0.1/de; // rho_e ~ 10, k0e = 1.0/rho_e ~ 0.1
+  double k0_ion = 0.1/di; // rho_i ~ 420, k0e = 1.0/rho_i ~ 0.002
+
+  // domain size and simulation time
+  double Lx = 300.0*di;
+  double tend = 100.0/omegaCi;
+
+  struct par_firehose_ctx ctx = {
+    .epsilon0 = epsilon0,
+    .mu0 = mu0,
+    .chargeElc = chargeElc,
+    .massElc = massElc,
+    .chargeIon = chargeIon,
+    .massIon = massIon,
+    .n0 = n0,
+    .B0 = B0,
+    .noise_amp = noise_amp,
+    .k_init = k_init,
+    .k_final = k_final,
+    .Te = vtElc,
+    .TiPar = TiPar,
+    .TiPerp = TiPerp, 
+    .k0_elc = k0_elc, 
+    .k0_ion = k0_ion, 
+    .Lx = Lx,
+    .tend = tend,
+  };
+  return ctx;
 }
 
 void
@@ -167,6 +206,11 @@ main(int argc, char **argv)
 {
   struct gkyl_app_args app_args = parse_app_args(argc, argv);
 
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Init(&argc, &argv);
+#endif  
+
   int NX = APP_ARGS_CHOOSE(app_args.xcells[0], 560);
 
   if (app_args.trace_mem) {
@@ -174,27 +218,86 @@ main(int argc, char **argv)
     gkyl_mem_debug_set(true);
   }
 
-  double elc_k0 = 0.001; // rho_e ~ 10, k0e = 0.01/rho_e ~ 0.001
-  double ion_k0 = 0.00002; // rho_i ~ 420, k0e = 0.01/rho_e ~ 0.00002
+  struct par_firehose_ctx ctx = create_ctx(); // context for init functions
   
   // electron/ion equations
-  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(elc_k0);
-  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(ion_k0);
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(ctx.k0_elc);
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(ctx.k0_ion);
 
   struct gkyl_moment_species elc = {
     .name = "elc",
-    .charge = -1.0, .mass = 1.0,
+    .charge = ctx.chargeElc, .mass = ctx.massElc,
     .equation = elc_ten_moment,
     .evolve = 1,
     .init = evalElcInit,
+    .ctx = &ctx,
   };
   struct gkyl_moment_species ion = {
     .name = "ion",
-    .charge = 1.0, .mass = 1836.0,
+    .charge = ctx.chargeIon, .mass = ctx.massIon,
     .equation = ion_ten_moment,
     .evolve = 1,
     .init = evalIonInit,
+    .ctx = &ctx,
   };  
+
+  int nrank = 1; // number of processors in simulation
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Comm_size(MPI_COMM_WORLD, &nrank);
+#endif  
+
+  // create global range
+  int cells[] = { NX };
+  struct gkyl_range globalr;
+  gkyl_create_global_range(1, cells, &globalr);
+  
+  // create decomposition
+  int cuts[] = { 1 };
+#ifdef GKYL_HAVE_MPI  
+  if (app_args.use_mpi) {
+    cuts[0] = app_args.cuts[0];
+  }
+#endif 
+    
+  struct gkyl_rect_decomp *decomp =
+    gkyl_rect_decomp_new_from_cuts(1, cuts, &globalr);
+
+  // construct communcator for use in app
+  struct gkyl_comm *comm;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) {
+    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+  }
+  else
+    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
+      }
+    );
+#else
+  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
+    }
+  );
+#endif
+
+  int my_rank;
+  gkyl_comm_get_rank(comm, &my_rank);
+  int comm_sz;
+  gkyl_comm_get_size(comm, &comm_sz);
+
+  int ncuts = cuts[0];
+  if (ncuts != comm_sz) {
+    if (my_rank == 0)
+      fprintf(stderr, "*** Number of ranks, %d, do not match total cuts, %d!\n", comm_sz, ncuts);
+    goto mpifinalize;
+  }
 
   // VM app
   struct gkyl_moment app_inp = {
@@ -202,8 +305,7 @@ main(int argc, char **argv)
 
     .ndim = 1,
     .lower = { 0.0 },
-    // Lx = 300 di ~ 12845.7
-    .upper = { 12845.57 }, 
+    .upper = { ctx.Lx }, 
     .cells = { NX },
 
     .num_periodic_dir = 1,
@@ -214,11 +316,18 @@ main(int argc, char **argv)
     .species = { elc, ion },
 
     .field = {
-      .epsilon0 = 1.0, .mu0 = 1.0,
+      .epsilon0 = ctx.epsilon0, .mu0 = ctx.mu0,
       .mag_error_speed_fact = 1.0,
       
       .evolve = 1,
       .init = evalFieldInit,
+      .ctx = &ctx,
+    }, 
+
+    .has_low_inp = true,
+    .low_inp = {
+      .local_range = decomp->ranges[my_rank],
+      .comm = comm
     }
   };
 
@@ -226,8 +335,7 @@ main(int argc, char **argv)
   gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
 
   // start, end and initial time-step
-  // Omega_ci^{-1} ~ 1e5
-  double tcurr = 0.0, tend = 1.0e7;
+  double tcurr = 0.0, tend = ctx.tend;
   int nframe = 100;
   // create trigger for IO
   struct gkyl_tm_trigger io_trig = { .dt = tend/nframe };
@@ -235,18 +343,26 @@ main(int argc, char **argv)
   // initialize simulation
   gkyl_moment_app_apply_ic(app, tcurr);
   write_data(&io_trig, app, tcurr);
+  gkyl_moment_app_calc_field_energy(app, tcurr);
+  gkyl_moment_app_calc_integrated_mom(app, tcurr);  
 
   // compute estimate of maximum stable time-step
   double dt = gkyl_moment_app_max_dt(app);
 
   long step = 1;
   while ((tcurr < tend) && (step <= app_args.num_steps)) {
-    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    gkyl_moment_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, tcurr);
     struct gkyl_update_status status = gkyl_moment_update(app, dt);
-    printf(" dt = %g\n", status.dt_actual);
+    gkyl_moment_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
+
+    // Only calculate the integrated moments and field energy every 100 steps
+    if (step % 100 == 0) {
+      gkyl_moment_app_calc_field_energy(app, tcurr);
+      gkyl_moment_app_calc_integrated_mom(app, tcurr);
+    }
     
     if (!status.success) {
-      printf("** Update method failed! Aborting simulation ....\n");
+      gkyl_moment_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
       break;
     }
     tcurr += status.dt_actual;
@@ -257,22 +373,37 @@ main(int argc, char **argv)
     step += 1;
   }
 
+  gkyl_moment_app_calc_field_energy(app, tcurr);
+  gkyl_moment_app_calc_integrated_mom(app, tcurr);
+  gkyl_moment_app_write_field_energy(app);
+  gkyl_moment_app_write_integrated_mom(app);
+    
   gkyl_moment_app_stat_write(app);
 
   struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
-
-  printf("\n");
-  printf("Number of update calls %ld\n", stat.nup);
-  printf("Number of failed time-steps %ld\n", stat.nfail);
-  printf("Species updates took %g secs\n", stat.species_tm);
-  printf("Field updates took %g secs\n", stat.field_tm);
-  printf("Source updates took %g secs\n", stat.sources_tm);
-  printf("Total updates took %g secs\n", stat.total_tm);
+  gkyl_moment_app_cout(app, stdout, "\n");
+  gkyl_moment_app_cout(app, stdout, "Number of update calls %ld\n", stat.nup);
+  gkyl_moment_app_cout(
+    app, stdout, "Number of failed time-steps %ld\n", stat.nfail);
+  gkyl_moment_app_cout(
+    app, stdout, "Species updates took %g secs\n", stat.species_tm);
+  gkyl_moment_app_cout(
+    app, stdout, "Field updates took %g secs\n", stat.field_tm);
+  gkyl_moment_app_cout(
+    app, stdout, "Total updates took %g secs\n", stat.total_tm);
 
   // simulation complete, free resources
   gkyl_wv_eqn_release(elc_ten_moment);
   gkyl_wv_eqn_release(ion_ten_moment);
-  gkyl_moment_app_release(app);  
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_moment_app_release(app);
+
+mpifinalize:;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Finalize();
+#endif
   
   return 0;
 }

--- a/regression/rt_10m_par_firehose_grad_closure.c
+++ b/regression/rt_10m_par_firehose_grad_closure.c
@@ -1,57 +1,64 @@
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include <gkyl_alloc.h>
 #include <gkyl_moment.h>
 #include <gkyl_util.h>
 #include <gkyl_wv_ten_moment.h>
+
+#include <gkyl_null_comm.h>
+
+#ifdef GKYL_HAVE_MPI
+#include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#endif
+
 #include <rt_arg_parse.h>
+
+struct par_firehose_ctx {
+  // Fundamental constants
+  double epsilon0; // permittivity of free space
+  double mu0; // permeability of free space
+  double chargeElc; // electron charge
+  double massElc; // electron mass
+  double chargeIon; // ion charge
+  double massIon; // ion mass
+  double n0; // reference density
+  double B0; // reference magnetic field strength
+  double TiPar; // parallel ion temperature
+  double TiPerp; // perpendicular ion temperature
+  double Te; // electron temperature
+  double k0_elc; // closure parameter for electrons
+  double k0_ion; // closure parameter for ions
+  double noise_amp; // amplitude of perturbation
+  int k_init; // initial wavenumber to perturb
+  int k_final; // final wavenumber to perturb
+  double Lx; // size of the box
+  double tend; // end time of the simulation
+};
 
 void
 evalElcInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
-  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
-  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
-  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
-  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
-  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+  double massElc = app->massElc;
+  double Te = app->Te;
+  double n0 = app->n0;
 
-  double vtElc = vAe*sqrt(beta);
-  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
-  double elcTemp = vtElc*vtElc/2.0;
-
-  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
-  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
-
-  double rhoe = elcMass*n0;
+  double rhoe = massElc*n0;
   double momxe = 0.0;
   double momye = 0.0;
   double momze = 0.0;
-  double pxxe = n0*elcTemp + momxe*momxe/rhoe;
+  double pxxe = n0*Te + momxe*momxe/rhoe;
   double pxye = momxe*momye/rhoe;
   double pxze = momxe*momze/rhoe;
-  double pyye = n0*elcTemp + momye*momye/rhoe;
+  double pyye = n0*Te + momye*momye/rhoe;
   double pyze = momye*momye/rhoe;
-  double pzze = n0*elcTemp + momze*momze/rhoe;
+  double pzze = n0*Te + momze*momze/rhoe;
 
   fout[0] = rhoe;
   fout[1] = momxe; fout[2] = momye; fout[3] = momze;
@@ -63,47 +70,23 @@ void
 evalIonInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
-  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
-  double beta = 300.0/pi; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
-  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
-  double betaPar = beta + 2.*dbeta/3.; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
-  double betaPerp = beta - dbeta/3.; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+  double massIon = app->massIon;
+  double TiPar = app->TiPar;
+  double TiPerp = app->TiPerp;
+  double n0 = app->n0;
 
-  double vtElc = vAe*sqrt(beta);
-  double vtIon = vtElc/sqrt(ionMass*Te_Ti/elcMass);
-  double elcTemp = vtElc*vtElc/2.0;
-
-  double ionTempPar = vAe*vAe*(betaPar*elcMass/2);
-  double ionTempPerp = vAe*vAe*(betaPerp*elcMass/2);
-
-  double rhoi = ionMass*n0;
+  double rhoi = massIon*n0;
   double momxi = 0.0;
   double momyi = 0.0;
   double momzi = 0.0;
-  double pxxi = n0*ionTempPar + momxi*momxi/rhoi;
+  double pxxi = n0*TiPar + momxi*momxi/rhoi;
   double pxyi = momxi*momyi/rhoi;
   double pxzi = momxi*momzi/rhoi;
-  double pyyi = n0*ionTempPerp + momyi*momyi/rhoi;
+  double pyyi = n0*TiPerp + momyi*momyi/rhoi;
   double pyzi = momyi*momyi/rhoi;
-  double pzzi = n0*ionTempPerp + momzi*momzi/rhoi;
+  double pzzi = n0*TiPerp + momzi*momzi/rhoi;
 
   fout[0] = rhoi;
   fout[1] = momxi; fout[2] = momyi; fout[3] = momzi;
@@ -115,35 +98,19 @@ void
 evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   double x = xn[0];
-  double pi = 3.141592653589793238462643383279502884;
-  // Physical constants (using normalized code units).
-  double gasGamma = 5.0/3.0;
-  double epsilon0 = 1.0; // Permittivity of free space.
-  double mu0 = 1.0; // Permiability of free space.
-  double lightSpeed = 1/sqrt(mu0*epsilon0); // Speed of light.
-  double ionMass = 1836.0; // Proton mass.
-  double ionCharge = 1.0; // Proton charge.
-  double elcMass = 1.0; // Electron mass.
-  double elcCharge = -1.0; // Electron charge.
-  double Te_Ti = 1.0; // Ratio of electron to proton temperature
-  double vAe = 0.0125; // Electron Alfven speed (how non-relativistic the system is).
-  double vAi = vAe/sqrt(ionMass/elcMass); // Proton Alfven speed.
-  double n0 = 1.0; // Initial reference number density.
-  double B0 = vAe*sqrt(mu0*n0*elcMass);
-  double wpi = sqrt(n0*ionCharge*ionCharge/(epsilon0*ionMass));
-  double di = lightSpeed/wpi;
+  struct par_firehose_ctx *app = ctx;
 
   pcg64_random_t rng = gkyl_pcg64_init(0);
 
-  double Bx = B0;
+  double Bx = app->B0;
   double By = 0.0, Bz = 0.0;
 
-  double alpha = 1.0e-6*B0;
-  double Lx = 12845.57;
-  double kx = 2.0*pi/Lx;
-  for (int i=0; i<48; ++i) {
-    By -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
-    Bz -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*pi*gkyl_pcg64_rand_double(&rng));
+  double alpha = app->noise_amp*Bx;
+  double Lx = app->Lx;
+  double kx = 2.0*M_PI/Lx;
+  for (int i = app->k_init; i < app->k_final; ++i) {
+    By -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*M_PI*gkyl_pcg64_rand_double(&rng));
+    Bz -= alpha*gkyl_pcg64_rand_double(&rng)*sin(i*kx*x + 2.0*M_PI*gkyl_pcg64_rand_double(&rng));
   }
 
   // electric field
@@ -153,6 +120,78 @@ evalFieldInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT f
 
   // correction potentials
   fout[6] = 0.0; fout[7] = 0.0;
+}
+
+struct par_firehose_ctx
+create_ctx(void)
+{
+  double epsilon0 = 1.0; // permittivity of free space
+  double mu0 = 1.0; // pemiability of free space
+  double lightSpeed = 1.0/sqrt(epsilon0*mu0);
+
+  double massElc = 1.0; // electron mass
+  double chargeElc = -1.0; // electron charge
+  double massIon = 1836.0; // ion mass
+  double chargeIon = 1.0; // ion charge
+
+  // Ion and electron temperature assumed equal, Ti/Te = 1.0
+  double n0 = 1.0; // initial number density
+  double vAe = 0.0125;
+  double B0 = vAe*sqrt(mu0*n0*massElc);
+  // Parallel firehose unstable for betaPerp - betaPar + 2 < 0.
+  double beta = 300.0/M_PI; // Trace proton plasma beta = 2 mu0 ni Ti/B0^2 = (betaPar + 2 betaPerp)/3
+  double dbeta = 100.0; // dbeta = beta_parallel - beta_perp
+  double betaPar = beta + 2.0*dbeta/3.0; // parallel proton plasma beta = 2 mu0 ni T_paralleli/B0^2
+  double betaPerp = beta - dbeta/3.0; // perp proton plasma beta = 2 mu0 ni T_perpi/B0^2  
+
+  double vtElc = vAe*sqrt(beta);
+  double Te = vtElc*vtElc*massElc/2.0;
+
+  double TiPar = vAe*vAe*(betaPar*massElc/2.0);
+  double TiPerp = vAe*vAe*(betaPerp*massElc/2.0);
+
+  // frequencies, skin depths, and Debye length
+  double omegaCi = chargeIon*B0/massIon;
+  double wpe = sqrt(n0*chargeElc*chargeElc/(epsilon0*massElc));
+  double de = lightSpeed/wpe;
+  double wpi = sqrt(n0*chargeIon*chargeIon/(epsilon0*massIon));
+  double di = lightSpeed/wpi;
+  double lambdaD = vtElc/wpe;
+
+  // noise levels for perturbation
+  double noise_amp = 1.0e-6*B0;
+  int k_init = 1;   // first wave mode to perturb with noise, 1 correspond to box size
+  int k_final = 48; // last wave mode to perturb with noise
+
+  // k0 for closure
+  double k0_elc = 0.1/de; // rho_e ~ 10, k0e = 1.0/rho_e ~ 0.1
+  double k0_ion = 0.1/di; // rho_i ~ 420, k0e = 1.0/rho_i ~ 0.002
+
+  // domain size and simulation time
+  double Lx = 300.0*di;
+  double tend = 100.0/omegaCi;
+
+  struct par_firehose_ctx ctx = {
+    .epsilon0 = epsilon0,
+    .mu0 = mu0,
+    .chargeElc = chargeElc,
+    .massElc = massElc,
+    .chargeIon = chargeIon,
+    .massIon = massIon,
+    .n0 = n0,
+    .B0 = B0,
+    .noise_amp = noise_amp,
+    .k_init = k_init,
+    .k_final = k_final,
+    .Te = vtElc,
+    .TiPar = TiPar,
+    .TiPerp = TiPerp, 
+    .k0_elc = k0_elc, 
+    .k0_ion = k0_ion, 
+    .Lx = Lx,
+    .tend = tend,
+  };
+  return ctx;
 }
 
 void
@@ -167,6 +206,11 @@ main(int argc, char **argv)
 {
   struct gkyl_app_args app_args = parse_app_args(argc, argv);
 
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Init(&argc, &argv);
+#endif  
+
   int NX = APP_ARGS_CHOOSE(app_args.xcells[0], 560);
 
   if (app_args.trace_mem) {
@@ -174,29 +218,88 @@ main(int argc, char **argv)
     gkyl_mem_debug_set(true);
   }
 
-  double elc_k0 = 0.1; // rho_e ~ 10, k0e = 1.0/rho_e ~ 0.1
-  double ion_k0 = 0.002; // rho_i ~ 420, k0e = 1.0/rho_i ~ 0.002
+  struct par_firehose_ctx ctx = create_ctx(); // context for init functions
   
   // electron/ion equations
-  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(elc_k0);
-  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(ion_k0);
+  struct gkyl_wv_eqn *elc_ten_moment = gkyl_wv_ten_moment_new(ctx.k0_elc);
+  struct gkyl_wv_eqn *ion_ten_moment = gkyl_wv_ten_moment_new(ctx.k0_ion);
 
   struct gkyl_moment_species elc = {
     .name = "elc",
-    .charge = -1.0, .mass = 1.0,
+    .charge = ctx.chargeElc, .mass = ctx.massElc,
     .equation = elc_ten_moment,
     .has_grad_closure = true,
     .evolve = 1,
     .init = evalElcInit,
+    .ctx = &ctx,
   };
   struct gkyl_moment_species ion = {
     .name = "ion",
-    .charge = 1.0, .mass = 1836.0,
+    .charge = ctx.chargeIon, .mass = ctx.massIon,
     .equation = ion_ten_moment,
     .has_grad_closure = true,
     .evolve = 1,
     .init = evalIonInit,
+    .ctx = &ctx,
   };  
+
+  int nrank = 1; // number of processors in simulation
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Comm_size(MPI_COMM_WORLD, &nrank);
+#endif  
+
+  // create global range
+  int cells[] = { NX };
+  struct gkyl_range globalr;
+  gkyl_create_global_range(1, cells, &globalr);
+  
+  // create decomposition
+  int cuts[] = { 1 };
+#ifdef GKYL_HAVE_MPI  
+  if (app_args.use_mpi) {
+    cuts[0] = app_args.cuts[0];
+  }
+#endif 
+    
+  struct gkyl_rect_decomp *decomp =
+    gkyl_rect_decomp_new_from_cuts(1, cuts, &globalr);
+
+  // construct communcator for use in app
+  struct gkyl_comm *comm;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) {
+    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+  }
+  else
+    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu        
+      }
+    );
+#else
+  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu      
+    }
+  );
+#endif
+
+  int my_rank;
+  gkyl_comm_get_rank(comm, &my_rank);
+  int comm_sz;
+  gkyl_comm_get_size(comm, &comm_sz);
+
+  int ncuts = cuts[0];
+  if (ncuts != comm_sz) {
+    if (my_rank == 0)
+      fprintf(stderr, "*** Number of ranks, %d, do not match total cuts, %d!\n", comm_sz, ncuts);
+    goto mpifinalize;
+  }
 
   // VM app
   struct gkyl_moment app_inp = {
@@ -204,9 +307,8 @@ main(int argc, char **argv)
 
     .ndim = 1,
     .lower = { 0.0 },
-    // Lx = 300 di ~ 12845.7
-    .upper = { 12845.57 }, 
-    .cells = { 560 },
+    .upper = { ctx.Lx }, 
+    .cells = { NX },
 
     .num_periodic_dir = 1,
     .periodic_dirs = { 0 },
@@ -216,11 +318,18 @@ main(int argc, char **argv)
     .species = { elc, ion },
 
     .field = {
-      .epsilon0 = 1.0, .mu0 = 1.0,
+      .epsilon0 = ctx.epsilon0, .mu0 = ctx.mu0,
       .mag_error_speed_fact = 1.0,
       
       .evolve = 1,
       .init = evalFieldInit,
+      .ctx = &ctx,
+    }, 
+
+    .has_low_inp = true,
+    .low_inp = {
+      .local_range = decomp->ranges[my_rank],
+      .comm = comm
     }
   };
 
@@ -228,8 +337,7 @@ main(int argc, char **argv)
   gkyl_moment_app *app = gkyl_moment_app_new(&app_inp);
 
   // start, end and initial time-step
-  // Omega_ci^{-1} ~ 1e5
-  double tcurr = 0.0, tend = 1.0e7;
+  double tcurr = 0.0, tend = ctx.tend;
   int nframe = 100;
   // create trigger for IO
   struct gkyl_tm_trigger io_trig = { .dt = tend/nframe };
@@ -237,18 +345,26 @@ main(int argc, char **argv)
   // initialize simulation
   gkyl_moment_app_apply_ic(app, tcurr);
   write_data(&io_trig, app, tcurr);
+  gkyl_moment_app_calc_field_energy(app, tcurr);
+  gkyl_moment_app_calc_integrated_mom(app, tcurr);  
 
   // compute estimate of maximum stable time-step
   double dt = gkyl_moment_app_max_dt(app);
 
   long step = 1;
   while ((tcurr < tend) && (step <= app_args.num_steps)) {
-    printf("Taking time-step %ld at t = %g ...", step, tcurr);
+    gkyl_moment_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, tcurr);
     struct gkyl_update_status status = gkyl_moment_update(app, dt);
-    printf(" dt = %g\n", status.dt_actual);
+    gkyl_moment_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
+
+    // Only calculate the integrated moments and field energy every 100 steps
+    if (step % 100 == 0) {
+      gkyl_moment_app_calc_field_energy(app, tcurr);
+      gkyl_moment_app_calc_integrated_mom(app, tcurr);
+    }
     
     if (!status.success) {
-      printf("** Update method failed! Aborting simulation ....\n");
+      gkyl_moment_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
       break;
     }
     tcurr += status.dt_actual;
@@ -259,22 +375,37 @@ main(int argc, char **argv)
     step += 1;
   }
 
+  gkyl_moment_app_calc_field_energy(app, tcurr);
+  gkyl_moment_app_calc_integrated_mom(app, tcurr);
+  gkyl_moment_app_write_field_energy(app);
+  gkyl_moment_app_write_integrated_mom(app);
+    
   gkyl_moment_app_stat_write(app);
 
   struct gkyl_moment_stat stat = gkyl_moment_app_stat(app);
-
-  printf("\n");
-  printf("Number of update calls %ld\n", stat.nup);
-  printf("Number of failed time-steps %ld\n", stat.nfail);
-  printf("Species updates took %g secs\n", stat.species_tm);
-  printf("Field updates took %g secs\n", stat.field_tm);
-  printf("Source updates took %g secs\n", stat.sources_tm);
-  printf("Total updates took %g secs\n", stat.total_tm);
+  gkyl_moment_app_cout(app, stdout, "\n");
+  gkyl_moment_app_cout(app, stdout, "Number of update calls %ld\n", stat.nup);
+  gkyl_moment_app_cout(
+    app, stdout, "Number of failed time-steps %ld\n", stat.nfail);
+  gkyl_moment_app_cout(
+    app, stdout, "Species updates took %g secs\n", stat.species_tm);
+  gkyl_moment_app_cout(
+    app, stdout, "Field updates took %g secs\n", stat.field_tm);
+  gkyl_moment_app_cout(
+    app, stdout, "Total updates took %g secs\n", stat.total_tm);
 
   // simulation complete, free resources
   gkyl_wv_eqn_release(elc_ten_moment);
   gkyl_wv_eqn_release(ion_ten_moment);
-  gkyl_moment_app_release(app);  
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_moment_app_release(app);
+
+mpifinalize:;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Finalize();
+#endif
   
   return 0;
 }


### PR DESCRIPTION
Via some testing this weekend, I realized that the gradient-based closure was not actually parallelized, defaulting to always looping over the global range ro compute the heat flux, even if the local range for the app was still utilized to construct the final update to the pressure.

In the process I realized this whole time the gradient-based closure had a significant error: the non-ideal variable range wasn't actually being used for updating the pressure tensor, so the div(q) was wrong in the final right-most cell. This error of course affects simulations performed, though perhaps only quantitatively and not qualitatively (the parallel firehose run still grows a mode with basically the same wavelength). More testing is required.

For right now, I use the create_ranges method from rect_decomp which is used based on the input range from the user-side. What this does is create a local range for the non-ideal variables with one extra "cell" on each side so that the non-ideal variables still correspond to vertex values, we are just doing one extra operation than needed (we only need one extra "cell" not one extra cell on each side; since the ranges are employed consistently we do in fact still get the same answer, we just do a tiny bit more work).