### PR TITLE
Add is_zero_flux_dir argument to vlasov and gyrokinetic dg_updaters, …

### DIFF
--- a/apps/vm_fluid_species.c
+++ b/apps/vm_fluid_species.c
@@ -174,8 +174,10 @@ vm_fluid_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm
       gkyl_array_release(diffD_host);
     }
 
+    const bool is_zero_flux[GKYL_MAX_CDIM] = {false};
+
     f->diff_slvr = gkyl_dg_updater_diffusion_fluid_new(&app->grid, &app->confBasis,
-      true, num_eqn, NULL, f->info.diffusion.order, &app->local, app->use_gpu);
+      true, num_eqn, NULL, f->info.diffusion.order, &app->local, is_zero_flux, app->use_gpu);
   }
 
   // array for storing integrated moments in each cell

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -197,9 +197,12 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
 
     struct gkyl_dg_vlasov_sr_auxfields aux_inp = {.qmem = s->qmem, 
       .p_over_gamma = s->p_over_gamma};
+
+    const bool is_zero_flux[GKYL_MAX_DIM] = {false};
+
     // create solver
     s->slvr = gkyl_dg_updater_vlasov_new(&s->grid, &app->confBasis, &app->basis, 
-      &app->local, &s->local_vel, &s->local, s->model_id, s->field_id, &aux_inp, app->use_gpu);
+      &app->local, &s->local_vel, &s->local, is_zero_flux, s->model_id, s->field_id, &aux_inp, app->use_gpu);
   }
   else if (s->model_id  == GKYL_MODEL_PKPM) {
     // Get pointer to fluid species object for coupling
@@ -274,16 +277,22 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
       .max_b = app->field->max_b, .pkpm_lax = s->pkpm_lax, 
       .div_b = app->field->div_b, .pkpm_accel_vars = s->pkpm_accel, 
       .g_dist_source = s->g_dist_source};
+
+    const bool is_zero_flux[GKYL_MAX_DIM] = {false};
+
     // create solver
     s->slvr = gkyl_dg_updater_vlasov_new(&s->grid, &app->confBasis, &app->basis, 
-      &app->local, &s->local_vel, &s->local, s->model_id, s->field_id, &aux_inp, app->use_gpu);
+      &app->local, &s->local_vel, &s->local, is_zero_flux, s->model_id, s->field_id, &aux_inp, app->use_gpu);
   }
   else {
     struct gkyl_dg_vlasov_auxfields aux_inp = {.field = s->qmem, 
       .cot_vec = 0, .alpha_geo = 0};
+
+    const bool is_zero_flux[GKYL_MAX_DIM] = {false};
+
     // create solver
     s->slvr = gkyl_dg_updater_vlasov_new(&s->grid, &app->confBasis, &app->basis, 
-      &app->local, &s->local_vel, &s->local, s->model_id, s->field_id, &aux_inp, app->use_gpu);
+      &app->local, &s->local_vel, &s->local, is_zero_flux, s->model_id, s->field_id, &aux_inp, app->use_gpu);
   }
 
   // acquire equation object

--- a/unit/ctest_dg_gyrokinetic_kern_tm.c
+++ b/unit/ctest_dg_gyrokinetic_kern_tm.c
@@ -53,8 +53,10 @@ test_3x2v_p1(bool use_gpu)
   }
   gkyl_cart_modal_serendip(&confBasis, cdim, poly_order);
 
+  const bool is_zero_flux[GKYL_MAX_DIM] = {false};
+
   struct gkyl_dg_updater_gyrokinetic* up;
-  up = gkyl_dg_updater_gyrokinetic_new(&phaseGrid, &confBasis, &basis, &confRange, &phaseRange, 0, 1.0, 1.0, use_gpu);
+  up = gkyl_dg_updater_gyrokinetic_new(&phaseGrid, &confBasis, &basis, &confRange, is_zero_flux, 0, 1.0, 1.0, use_gpu);
 
   // initialize arrays
   struct gkyl_array *fin, *rhs, *cflrate, *bmag, *jacobtot_inv, *cmag, *b_i, *phi, *apar, *apardot;

--- a/zero/dg_updater_diffusion_fluid.c
+++ b/zero/dg_updater_diffusion_fluid.c
@@ -19,7 +19,8 @@ gkyl_dg_updater_diffusion_fluid_acquire_eqn(const struct gkyl_dg_updater_diffusi
 struct gkyl_dg_updater_diffusion_fluid*
 gkyl_dg_updater_diffusion_fluid_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_basis *basis, bool is_diff_const, int num_equations,
-  bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range, bool use_gpu)
+  const bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range,
+  const bool *is_zero_flux_dir, bool use_gpu)
 {
   struct gkyl_dg_updater_diffusion_fluid *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_diffusion_fluid));
 
@@ -37,8 +38,9 @@ gkyl_dg_updater_diffusion_fluid_new(const struct gkyl_rect_grid *grid,
   int linc = 0;
   for (int d=0; d<ndim; ++d) {
     if (is_dir_diffusive[d]) up_dirs[linc] = d;
-    zero_flux_flags[d] = 0;
     linc += 1;
+
+    zero_flux_flags[d] = is_zero_flux_dir[d]? 1 : 0;
   }
 
   up->hyperdg = gkyl_hyper_dg_new(grid, basis, up->dgeqn, num_up_dirs, up_dirs, zero_flux_flags, 1, up->use_gpu);

--- a/zero/dg_updater_diffusion_gyrokinetic.c
+++ b/zero/dg_updater_diffusion_gyrokinetic.c
@@ -19,7 +19,8 @@ gkyl_dg_updater_diffusion_gyrokinetic_acquire_eqn(const struct gkyl_dg_updater_d
 struct gkyl_dg_updater_diffusion_gyrokinetic*
 gkyl_dg_updater_diffusion_gyrokinetic_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const, 
-  bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range, bool use_gpu)
+  const bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range,
+  const bool *is_zero_flux_dir, bool use_gpu)
 {
   struct gkyl_dg_updater_diffusion_gyrokinetic *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_diffusion_gyrokinetic));
 
@@ -37,8 +38,9 @@ gkyl_dg_updater_diffusion_gyrokinetic_new(const struct gkyl_rect_grid *grid,
   int linc = 0;
   for (int d=0; d<cdim; ++d) {
     if (is_dir_diffusive[d]) up_dirs[linc] = d;
-    zero_flux_flags[d] = 0;
     linc += 1;
+
+    zero_flux_flags[d] = is_zero_flux_dir[d]? 1 : 0;
   }
 
   up->hyperdg = gkyl_hyper_dg_new(grid, basis, up->dgeqn, num_up_dirs, up_dirs, zero_flux_flags, 1, up->use_gpu);

--- a/zero/dg_updater_diffusion_vlasov.c
+++ b/zero/dg_updater_diffusion_vlasov.c
@@ -19,7 +19,8 @@ gkyl_dg_updater_diffusion_vlasov_acquire_eqn(const struct gkyl_dg_updater_diffus
 struct gkyl_dg_updater_diffusion_vlasov*
 gkyl_dg_updater_diffusion_vlasov_new(const struct gkyl_rect_grid *grid,
   const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const,
-  bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range, bool use_gpu)
+  const bool *diff_in_dir, int diff_order, const struct gkyl_range *diff_range,
+  const bool *is_zero_flux_dir, bool use_gpu)
 {
   struct gkyl_dg_updater_diffusion_vlasov *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_diffusion_vlasov));
 
@@ -37,8 +38,9 @@ gkyl_dg_updater_diffusion_vlasov_new(const struct gkyl_rect_grid *grid,
   int linc = 0;
   for (int d=0; d<cdim; ++d) {
     if (is_dir_diffusive[d]) up_dirs[linc] = d;
-    zero_flux_flags[d] = 0;
     linc += 1;
+
+    zero_flux_flags[d] = is_zero_flux_dir[d]? 1 : 0;
   }
 
   up->hyperdg = gkyl_hyper_dg_new(grid, basis, up->dgeqn, num_up_dirs, up_dirs, zero_flux_flags, 1, up->use_gpu);

--- a/zero/dg_updater_gyrokinetic.c
+++ b/zero/dg_updater_gyrokinetic.c
@@ -18,7 +18,7 @@ gkyl_dg_updater_gyrokinetic_acquire_eqn(const gkyl_dg_updater_gyrokinetic* gyrok
 struct gkyl_dg_updater_gyrokinetic*
 gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
   const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
-  const struct gkyl_range *conf_range, const struct gkyl_range *vel_range,
+  const struct gkyl_range *conf_range, const bool *is_zero_flux_dir,
   enum gkyl_gkeqn_id eqn_id, double charge, double mass, bool use_gpu)
 {
   struct gkyl_dg_updater_gyrokinetic *up = gkyl_malloc(sizeof(struct gkyl_dg_updater_gyrokinetic));
@@ -38,6 +38,8 @@ gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid,
   for (int d=0; d<num_up_dirs; ++d) up_dirs[d] = d;
 
   int zero_flux_flags[GKYL_MAX_DIM] = {0};
+  for (int d=0; d<cdim; ++d)
+    zero_flux_flags[d] = is_zero_flux_dir[d]? 1 : 0;
   for (int d=cdim; d<pdim; ++d)
     zero_flux_flags[d] = 1; // zero-flux BCs in vel-space
 

--- a/zero/dg_updater_vlasov.c
+++ b/zero/dg_updater_vlasov.c
@@ -22,7 +22,7 @@ gkyl_dg_updater_vlasov*
 gkyl_dg_updater_vlasov_new(const struct gkyl_rect_grid *grid, 
   const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
   const struct gkyl_range *conf_range, const struct gkyl_range *vel_range, const struct gkyl_range *phase_range,
-  enum gkyl_model_id model_id, enum gkyl_field_id field_id, void *aux_inp, bool use_gpu)
+  const bool *is_zero_flux_dir, enum gkyl_model_id model_id, enum gkyl_field_id field_id, void *aux_inp, bool use_gpu)
 {
   gkyl_dg_updater_vlasov *up = gkyl_malloc(sizeof(gkyl_dg_updater_vlasov));
   up->model_id = model_id;
@@ -49,7 +49,7 @@ gkyl_dg_updater_vlasov_new(const struct gkyl_rect_grid *grid,
   int up_dirs[GKYL_MAX_DIM], zero_flux_flags[GKYL_MAX_DIM];
   for (int d=0; d<cdim; ++d) {
     up_dirs[d] = d;
-    zero_flux_flags[d] = 0;
+    zero_flux_flags[d] = is_zero_flux_dir[d]? 1 : 0;
   }
   int num_up_dirs = cdim;
   // update velocity space only when field is present (or pkpm model, which always has force update)

--- a/zero/gkyl_dg_updater_diffusion_fluid.h
+++ b/zero/gkyl_dg_updater_diffusion_fluid.h
@@ -24,12 +24,13 @@ struct gkyl_dg_updater_diffusion_fluid_tm {
  * @param diff_in_dir Whether to apply diffusion in each direction.
  * @param diff_order Diffusion order.
  * @param diff_range Range object to index the diffusion coefficient.
+ * @param is_zero_flux_dir True in directions with (lower and upper) zero flux BCs.
  * @param use_gpu Whether to run on host or device.
  * @return New diff updater object
  */
 struct gkyl_dg_updater_diffusion_fluid* gkyl_dg_updater_diffusion_fluid_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_basis *basis, bool is_diff_const, int num_equations, bool *diff_in_dir,
-  int diff_order, const struct gkyl_range *diff_range, bool use_gpu);
+  const struct gkyl_basis *basis, bool is_diff_const, int num_equations, const bool *diff_in_dir,
+  int diff_order, const struct gkyl_range *diff_range, const bool *is_zero_flux_dir, bool use_gpu);
 
 /**
  * Compute RHS of DG update. The update_rng MUST be a sub-range of the

--- a/zero/gkyl_dg_updater_diffusion_gyrokinetic.h
+++ b/zero/gkyl_dg_updater_diffusion_gyrokinetic.h
@@ -24,12 +24,13 @@ struct gkyl_dg_updater_diffusion_gyrokinetic_tm {
  * @param diff_in_dir Whether to apply diffusion in each direction.
  * @param diff_order Diffusion order.
  * @param diff_range Range object to index the diffusion coefficient.
+ * @param is_zero_flux_dir True in directions with (lower and upper) zero flux BCs.
  * @param use_gpu Whether to run on host or device.
  * @return New diff updater object
  */
 struct gkyl_dg_updater_diffusion_gyrokinetic* gkyl_dg_updater_diffusion_gyrokinetic_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const, bool *diff_in_dir,
-  int diff_order, const struct gkyl_range *diff_range, bool use_gpu);
+  const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const, const bool *diff_in_dir,
+  int diff_order, const struct gkyl_range *diff_range, const bool *is_zero_flux_dir, bool use_gpu);
 
 /**
  * Compute RHS of DG update. The update_rng MUST be a sub-range of the

--- a/zero/gkyl_dg_updater_diffusion_vlasov.h
+++ b/zero/gkyl_dg_updater_diffusion_vlasov.h
@@ -24,12 +24,13 @@ struct gkyl_dg_updater_diffusion_vlasov_tm {
  * @param diff_in_dir Whether to apply diffusion in each direction.
  * @param diff_order Diffusion order.
  * @param diff_range Range object to index the diffusion coefficient.
+ * @param is_zero_flux_dir True in directions with (lower and upper) zero flux BCs.
  * @param use_gpu Whether to run on host or device.
  * @return New diff updater object
  */
 struct gkyl_dg_updater_diffusion_vlasov* gkyl_dg_updater_diffusion_vlasov_new(const struct gkyl_rect_grid *grid,
-  const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const, bool *diff_in_dir,
-  int diff_order, const struct gkyl_range *diff_range, bool use_gpu);
+  const struct gkyl_basis *basis, const struct gkyl_basis *cbasis, bool is_diff_const, const bool *diff_in_dir,
+  int diff_order, const struct gkyl_range *diff_range, const bool *is_zero_flux_dir, bool use_gpu);
 
 /**
  * Compute RHS of DG update. The update_rng MUST be a sub-range of the

--- a/zero/gkyl_dg_updater_gyrokinetic.h
+++ b/zero/gkyl_dg_updater_gyrokinetic.h
@@ -22,14 +22,14 @@ enum gkyl_gkeqn_id {
  * @param cbasis Configuration space basis functions
  * @param pbasis Phase-space basis function
  * @param conf_range Config space range
- * @param vel_range Velocity space range
- * @param field_id Enum identifier for field type (see gkyl_eqn_type.h)
+ * @param is_zero_flux_dir True in directions with (lower and upper) zero flux BCs.
+ * @param gkyl_gkeqn_id Enum identifier for gyrokinetic equation type.
  * 
  * @return New gyrokinetic updater object
  */
 gkyl_dg_updater_gyrokinetic* gkyl_dg_updater_gyrokinetic_new(const struct gkyl_rect_grid *grid, 
   const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
-  const struct gkyl_range *conf_range, const struct gkyl_range *vel_range,
+  const struct gkyl_range *conf_range, const bool *is_zero_flux_dir,
   enum gkyl_gkeqn_id eqn_id, double charge, double mass, bool use_gpu);
 
 /**

--- a/zero/gkyl_dg_updater_vlasov.h
+++ b/zero/gkyl_dg_updater_vlasov.h
@@ -25,6 +25,7 @@ struct gkyl_dg_updater_vlasov_tm {
  * @param conf_range Config space range
  * @param vel_range Velocity space range
  * @param phase_range Phase space range
+ * @param is_zero_flux_dir True in directions with (lower and upper) zero flux BCs.
  * @param model_id Enum identifier for model type (e.g., SR, General Geometry, PKPM, see gkyl_eqn_type.h)
  * @param field_id Enum identifier for field type (e.g., Maxwell's, Poisson, see gkyl_eqn_type.h)
  * @param aux_inp Void pointer to auxiliary fields. Void to be flexible to different auxfields structs
@@ -35,7 +36,7 @@ struct gkyl_dg_updater_vlasov_tm {
 gkyl_dg_updater_vlasov* gkyl_dg_updater_vlasov_new(const struct gkyl_rect_grid *grid, 
   const struct gkyl_basis *cbasis, const struct gkyl_basis *pbasis, 
   const struct gkyl_range *conf_range, const struct gkyl_range *vel_range, const struct gkyl_range *phase_range,
-  enum gkyl_model_id model_id, enum gkyl_field_id field_id, void *aux_inp, bool use_gpu);
+  const bool *is_zero_flux_dir, enum gkyl_model_id model_id, enum gkyl_field_id field_id, void *aux_inp, bool use_gpu);
 
 /**
  * Acquire Vlasov equation object


### PR DESCRIPTION
…and to diffusion dg_updaters. This way the apps can tell the equation objects when to apply zero flux BCs (currently it was hardcoded to never). Also remove vel_range from gyrokinetic updater, never used.