### PR TITLE
Array integrate operator

### DIFF
--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -62,24 +62,35 @@ void test_1x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
 
   // create distribution function array
   struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
-  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
     gkyl_array_scale(distf, -1.);
 
   // integrate distribution function.
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
-  double fint[nc];
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
   gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
-  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  gkyl_free(fint);
 }
 
 void evalFunc_1x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -128,26 +139,37 @@ void test_1x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
 
   // create distribution function array
   struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
   gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
     gkyl_array_scale(distf, -1.);
 
   // integrate distribution function.
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
-  double fint[nc];
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
   gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
-  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
-  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint[1], 1e-12) );
-  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint[2], 1e-12) );
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint_ho[1], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint_ho[2], 1e-12) );
 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  gkyl_free(fint);
 }
 
 void evalFunc_2x_nc1_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -192,24 +214,35 @@ void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
 
   // create distribution function array
   struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
   gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
     gkyl_array_scale(distf, -1.);
 
   // integrate distribution function.
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
-  double fint[nc];
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
   gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
-  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  gkyl_free(fint);
 }
 
 void evalFunc_2x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -258,29 +291,40 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
 
   // create distribution function array
   struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
   gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
     gkyl_array_scale(distf, -1.);
 
   // integrate distribution function.
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
-  double fint[nc];
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
   gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
-  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
-  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint[1], 1e-12) );
-  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint[2], 1e-12) );
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint_ho[1], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint_ho[2], 1e-12) );
 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  gkyl_free(fint);
 }
 
-void test_1x()
+void test_1x_cpu()
 {
   // p=1
   test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
@@ -301,7 +345,7 @@ void test_1x()
   test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
 }
 
-void test_2x()
+void test_2x_cpu()
 {
   // p=1
   test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
@@ -322,12 +366,56 @@ void test_2x()
   test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
 }
 
-TEST_LIST = {
-  { "test_1x", test_1x },
-  { "test_2x", test_2x },
 #ifdef GKYL_HAVE_CUDA
-//  { "test_1x_gpu", test_1x_gpu },
-//  { "test_2x_gpu", test_2x_gpu },
+void test_1x_gpu()
+{
+  // p=1
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, true);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, true);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, true);
+
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, true);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, true);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, true);
+
+  // p=2
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, true);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, true);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, true);
+
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, true);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, true);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, true);
+}
+
+void test_2x_gpu()
+{
+  // p=1
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, true);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, true);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, true);
+
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, true);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, true);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, true);
+
+  // p=2
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, true);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, true);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, true);
+
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, true);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, true);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, true);
+}
+#endif
+
+TEST_LIST = {
+  { "test_1x_cpu", test_1x_cpu },
+  { "test_2x_cpu", test_2x_cpu },
+#ifdef GKYL_HAVE_CUDA
+  { "test_1x_gpu", test_1x_gpu },
+  { "test_2x_gpu", test_2x_gpu },
 #endif
   { NULL, NULL },
 };

--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -1,0 +1,333 @@
+// Test integration of a gkyl_array over a range.
+//
+
+#include <acutest.h>
+#include <gkyl_rect_grid.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_decomp.h>
+#include <gkyl_array.h>
+#include <gkyl_array_ops.h>
+#include <gkyl_proj_on_basis.h>
+#include <gkyl_array_integrate.h>
+#include <math.h>
+
+// allocate array (filled with zeros)
+static struct gkyl_array*
+mkarr(long nc, long size, bool use_gpu)
+{
+  struct gkyl_array *a = use_gpu? gkyl_array_cu_dev_new(GKYL_DOUBLE, nc, size)
+                                : gkyl_array_new(GKYL_DOUBLE, nc, size);
+  return a;
+}
+
+void evalFunc_1x_nc1_op_none(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {-6.0}, upper[] = {6.0}; // Has to match the test below.
+  fout[0] = 1./(upper[0]-lower[0]);
+}
+
+void evalFunc_1x_nc1_op_sq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {-6.0}, upper[] = {6.0}; // Has to match the test below.
+  fout[0] = 1./sqrt(upper[0]-lower[0]);
+}
+
+void test_1x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool use_gpu)
+{
+  double lower[] = {-6.0}, upper[] = {6.0};
+  int cells[] = {16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 1;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf;
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ)
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_1x_nc1_op_sq, NULL);
+  else
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_1x_nc1_op_none, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
+    gkyl_array_scale(distf, -1.);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
+
+  double fint[nc];
+  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+}
+
+void evalFunc_1x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {-6.0}, upper[] = {6.0}; // Has to match the test below.
+  fout[0] = 1./(upper[0]-lower[0]);
+  fout[1] = 1.5/(upper[0]-lower[0]);
+  fout[2] = 2.5/(upper[0]-lower[0]);
+}
+
+void evalFunc_1x_nc3_op_sq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {-6.0}, upper[] = {6.0}; // Has to match the test below.
+  fout[0] = 1./sqrt(upper[0]-lower[0]);
+  fout[1] = 1.5/sqrt(upper[0]-lower[0]);
+  fout[2] = 2.5/sqrt(upper[0]-lower[0]);
+}
+
+void test_1x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool use_gpu)
+{
+  double lower[] = {-6.0}, upper[] = {6.0};
+  int cells[] = {16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 3;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf;
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ)
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_1x_nc3_op_sq, NULL);
+  else
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_1x_nc3_op_none, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
+    gkyl_array_scale(distf, -1.);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
+
+  double fint[nc];
+  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint[1], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint[2], 1e-12) );
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+}
+
+void evalFunc_2x_nc1_op_none(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0}; // Has to match the test below.
+  fout[0] = 1./((upper[0]-lower[0])*(upper[1]-lower[1]));
+}
+
+void evalFunc_2x_nc1_op_sq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0}; // Has to match the test below.
+  fout[0] = 1./sqrt((upper[0]-lower[0])*(upper[1]-lower[1]));
+}
+
+void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool use_gpu)
+{
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0};
+  int cells[] = {6, 16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 1;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 0 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf;
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ)
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_2x_nc1_op_sq, NULL);
+  else
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_2x_nc1_op_none, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
+    gkyl_array_scale(distf, -1.);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
+
+  double fint[nc];
+  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+}
+
+void evalFunc_2x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0}; // Has to match the test below.
+  fout[0] = 1./((upper[0]-lower[0])*(upper[1]-lower[1]));
+  fout[1] = 1.5/((upper[0]-lower[0])*(upper[1]-lower[1]));
+  fout[2] = 2.5/((upper[0]-lower[0])*(upper[1]-lower[1]));
+}
+
+void evalFunc_2x_nc3_op_sq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0}; // Has to match the test below.
+  fout[0] = 1./sqrt((upper[0]-lower[0])*(upper[1]-lower[1]));
+  fout[1] = 1.5/sqrt((upper[0]-lower[0])*(upper[1]-lower[1]));
+  fout[2] = 2.5/sqrt((upper[0]-lower[0])*(upper[1]-lower[1]));
+}
+
+void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool use_gpu)
+{
+  double lower[] = {0., -6.0}, upper[] = {2., 6.0};
+  int cells[] = {6, 16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 3;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 0 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf;
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ)
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_2x_nc3_op_sq, NULL);
+  else
+    projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_2x_nc3_op_none, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
+    gkyl_array_scale(distf, -1.);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
+
+  double fint[nc];
+  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  TEST_CHECK( gkyl_compare( 1.0, fint[0], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint[1], 1e-12) );
+  TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint[2], 1e-12) );
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+}
+
+void test_1x()
+{
+  // p=1
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, false);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, false);
+
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, false);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, false);
+
+  // p=2
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, false);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, false);
+  test_1x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
+
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, false);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, false);
+  test_1x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
+}
+
+void test_2x()
+{
+  // p=1
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, false);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, false);
+
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 1, false);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 1, false);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 1, false);
+
+  // p=2
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, false);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, false);
+  test_2x_nc1_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
+
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_NONE, 2, false);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, false);
+  test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
+}
+
+TEST_LIST = {
+  { "test_1x", test_1x },
+  { "test_2x", test_2x },
+#ifdef GKYL_HAVE_CUDA
+//  { "test_1x_gpu", test_1x_gpu },
+//  { "test_2x_gpu", test_2x_gpu },
+#endif
+  { NULL, NULL },
+};

--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -414,8 +414,8 @@ TEST_LIST = {
   { "test_1x_cpu", test_1x_cpu },
   { "test_2x_cpu", test_2x_cpu },
 #ifdef GKYL_HAVE_CUDA
-  { "test_1x_gpu", test_1x_gpu },
-  { "test_2x_gpu", test_2x_gpu },
+//  { "test_1x_gpu", test_1x_gpu },
+//  { "test_2x_gpu", test_2x_gpu },
 #endif
   { NULL, NULL },
 };

--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -90,7 +90,10 @@ void test_1x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
-  gkyl_free(fint);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
 }
 
 void evalFunc_1x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -142,7 +145,7 @@ void test_1x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
-  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
   if (use_gpu) gkyl_array_copy(distf, distf_ho);
 
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
@@ -169,7 +172,10 @@ void test_1x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
-  gkyl_free(fint);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
 }
 
 void evalFunc_2x_nc1_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -217,7 +223,7 @@ void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
-  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
   if (use_gpu) gkyl_array_copy(distf, distf_ho);
 
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
@@ -242,7 +248,10 @@ void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
-  gkyl_free(fint);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
 }
 
 void evalFunc_2x_nc3_op_none(double t, const double *xn, double* restrict fout, void *ctx)
@@ -294,7 +303,7 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
 
   // project distribution function on basis
-  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf);
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
   if (use_gpu) gkyl_array_copy(distf, distf_ho);
 
   if (integ_op == GKYL_ARRAY_INTEGRATE_OP_ABS)
@@ -321,7 +330,10 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
-  gkyl_free(fint);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
 }
 
 void test_1x_cpu()
@@ -414,8 +426,8 @@ TEST_LIST = {
   { "test_1x_cpu", test_1x_cpu },
   { "test_2x_cpu", test_2x_cpu },
 #ifdef GKYL_HAVE_CUDA
-//  { "test_1x_gpu", test_1x_gpu },
-//  { "test_2x_gpu", test_2x_gpu },
+  { "test_1x_gpu", test_1x_gpu },
+  { "test_2x_gpu", test_2x_gpu },
 #endif
   { NULL, NULL },
 };

--- a/zero/array_integrate.c
+++ b/zero/array_integrate.c
@@ -1,0 +1,82 @@
+#include <gkyl_array_integrate.h>
+#include <gkyl_array_integrate_priv.h>
+#include <gkyl_alloc.h>
+#include <assert.h>
+
+struct gkyl_array_integrate*
+gkyl_array_integrate_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *basis,
+  int num_comp, enum gkyl_array_integrate_op op, bool use_gpu)
+{
+  // Allocate space for new updater.
+  struct gkyl_array_integrate *up = gkyl_malloc(sizeof(struct gkyl_array_integrate));
+
+  up->num_basis = basis->num_basis;
+  up->num_comp = num_comp;
+  up->use_gpu = use_gpu;
+
+  int ndim = basis->ndim;
+  up->vol = 1.0;
+  if (basis->poly_order > 0) {
+    for (unsigned d=0; d<ndim; ++d)
+      up->vol *= op == GKYL_ARRAY_INTEGRATE_OP_SQ? grid->dx[d]/2.0 : grid->dx[d]/sqrt(2.0);
+  } else {
+    // for polyOrder = 0 no normalization is applied.
+    for (unsigned d=0; d<ndim; ++d)
+      up->vol *= grid->dx[d];
+  }
+
+  // Choose the kernel that performs the desired operation within the integral.
+  up->kernels = gkyl_malloc(sizeof(struct gkyl_array_integrate_kernels));
+#ifdef GKYL_HAVE_CUDA
+  if (use_gpu) {
+    up->kernels_cu = gkyl_cu_malloc(sizeof(struct gkyl_array_integrate_kernels));
+    gkyl_array_integrate_choose_kernel_cu(op, up->kernels_cu);
+  } else {
+    gkyl_array_integrate_choose_kernel(op, up->kernels);
+    assert(up->kernels->intker);
+    up->kernels_cu = up->kernels;
+  }
+#else
+  gkyl_array_integrate_choose_kernel(op, up->kernels);
+  assert(up->kernels->intker);
+  up->kernels_cu = up->kernels;
+#endif
+
+  return up;
+}
+
+void gkyl_array_integrate_advance(gkyl_array_integrate *up, const struct gkyl_array *arr,
+  double weight, const struct gkyl_range *range, double *out)
+{
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu) {
+    gkyl_array_integrate_advance_cu(up, arr, weight, out);
+    return;
+  }
+#endif
+
+  for (int k=0; k<up->num_comp; k++) out[k] = 0;
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, range);
+  while (gkyl_range_iter_next(&iter)) {
+
+    long linidx = gkyl_range_idx(range, iter.idx);
+    const double *arr_d = (const double*) gkyl_array_cfetch(arr, linidx);
+
+    up->kernels->intker(up->vol, up->num_comp, up->num_basis, arr_d, out);
+  }
+
+  for (int k=0; k<up->num_comp; k++) out[k] *= weight;
+}
+
+void gkyl_array_integrate_release(gkyl_array_integrate *up)
+{
+  // Release memory associated with this updater.
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    gkyl_cu_free(up->kernels_cu);
+#endif
+  gkyl_free(up->kernels);
+  gkyl_free(up);
+}

--- a/zero/array_integrate_cu.cu
+++ b/zero/array_integrate_cu.cu
@@ -88,7 +88,7 @@ array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up,
 void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *arr,
   double weight, const struct gkyl_range *range, double *out)
 {
-  for (int k=0; k<up->num_comp; k++) out[k] = 0;
+  gkyl_cu_memset(out, 0, up->num_comp*sizeof(double));
 
   const int nthreads = GKYL_DEFAULT_NUM_THREADS;
   int nblocks = gkyl_int_div_up(range->volume, nthreads);

--- a/zero/array_integrate_cu.cu
+++ b/zero/array_integrate_cu.cu
@@ -1,0 +1,98 @@
+/* -*- c++ -*- */
+
+// CUB for reductions.
+#include <cub/cub.cuh>
+
+extern "C" {
+#include <gkyl_alloc.h>
+#include <gkyl_util.h>
+#include <gkyl_array_integrate.h>
+#include <gkyl_array_integrate_priv.h>
+}
+
+__global__ static void
+gkyl_array_integrate_set_ker_cu(struct gkyl_array_integrate *up, enum gkyl_array_integrate_op op)
+{
+  up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+}
+
+struct gkyl_array_integrate*
+gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *basis,
+  int num_comp, enum gkyl_array_integrate_op op)
+{
+  // Allocate space for new updater.
+  struct gkyl_array_integrate *up = (struct gkyl_array_integrate*) gkyl_malloc(sizeof(struct gkyl_array_integrate));
+
+  up->num_basis = basis->num_basis;
+  up->num_comp = num_comp;
+  up->use_gpu = true;
+
+  int ndim = basis->ndim;
+  up->vol = 1.0;
+  if (basis->poly_order > 0) {
+    for (unsigned d=0; d<ndim; ++d)
+      up->vol *= op == GKYL_ARRAY_INTEGRATE_OP_SQ? grid->dx[d]/2.0 : grid->dx[d]/sqrt(2.0);
+  } else {
+    // For polyOrder = 0 no normalization is applied.
+    for (unsigned d=0; d<ndim; ++d)
+      up->vol *= grid->dx[d];
+  }
+
+  // Copy struct to device.
+  struct gkyl_array_integrate *up_cu = (struct gkyl_array_integrate*) gkyl_cu_malloc(sizeof(struct gkyl_array_integrate));
+  gkyl_cu_memcpy(up_cu, up, sizeof(struct gkyl_array_integrate), GKYL_CU_MEMCPY_H2D);
+
+  // Set the kernel.
+  gkyl_array_integrate_set_ker_cu<<<1,1>>>(up_cu, op);
+
+  up->on_dev = up_cu;
+
+  return up;
+}
+
+template <unsigned int BLOCKSIZE>
+__global__ void
+array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up,
+  const struct gkyl_array *inp, double weight, const struct gkyl_range range, double *out)
+{
+  unsigned long linc = blockIdx.x*blockDim.x + threadIdx.x;
+
+  // Specialize BlockReduce for type double.
+  typedef cub::BlockReduce<double, BLOCKSIZE> BlockReduceT;
+
+  // Allocate temporary storage in shared memory.
+  __shared__ typename BlockReduceT::TempStorage temp;
+
+  int idx[GKYL_MAX_DIM];
+  gkyl_sub_range_inv_idx(&range, linc, idx);
+  long start = gkyl_range_idx(&range, idx);
+  const double *fptr = (const double*) gkyl_array_cfetch(inp, start);
+
+  double outLocal[10]; // Set to max of 10 (e.g. heat flux tensor).
+  for (unsigned int k=0; k<up->num_comp; ++k)
+    outLocal[k] = 0.0;
+
+  // Integrate in this cell
+  up->kernel(up->vol*weight, up->num_comp, up->num_basis, fptr, outLocal);
+
+  for (size_t k = 0; k < up->num_comp; ++k) {
+    double f = 0;
+    if (linc < range.volume) f = outLocal[k];
+    double bResult = 0;
+    bResult = BlockReduceT(temp).Reduce(f, cub::Sum());
+    if (threadIdx.x == 0)
+      atomicAdd(&out[k], bResult);
+  }
+}
+
+void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *arr,
+  double weight, const struct gkyl_range *range, double *out)
+{
+  for (int k=0; k<up->num_comp; k++) out[k] = 0;
+
+  const int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(range->volume, nthreads);
+  array_integrate_blockRedAtomic_cub<nthreads><<<nblocks, nthreads>>>(up->on_dev, arr->on_dev, weight, *range, out);
+  // device synchronize required because out may be host pinned memory
+  cudaDeviceSynchronize();
+}

--- a/zero/gkyl_array_integrate.h
+++ b/zero/gkyl_array_integrate.h
@@ -35,7 +35,7 @@ gkyl_array_integrate_new(const struct gkyl_rect_grid* grid, const struct gkyl_ba
  * @param arr Input gkyl_array.
  * @param weight Factor to multiply by.
  * @param range Range we'll integrate over.
- * @return out Output integral result(s).
+ * @return out Output integral result(s). On device memory if use_gpu=true.
  */
 void gkyl_array_integrate_advance(gkyl_array_integrate *up, const struct gkyl_array *arr,
   double weight, const struct gkyl_range *range, double *out);

--- a/zero/gkyl_array_integrate.h
+++ b/zero/gkyl_array_integrate.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gkyl_array.h>
+#include <gkyl_basis.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_grid.h>
+
+// Object type
+typedef struct gkyl_array_integrate gkyl_array_integrate;
+
+enum gkyl_array_integrate_op {
+  GKYL_ARRAY_INTEGRATE_OP_NONE = 0,
+  GKYL_ARRAY_INTEGRATE_OP_ABS,
+  GKYL_ARRAY_INTEGRATE_OP_SQ,
+};
+
+/**
+ * Create a new updater that integrates a gkyl_array, with an option to perform
+ * additional operations during the integration (e.g. square, abs, etc). *
+ *
+ * @param grid Grid array is defined on.
+ * @param basis Basis array is defined on.
+ * @param num_comp Number of (vector) components in the array).
+ * @param op Additional operator to apply in very cell.
+ * @param use_gpu Indicate whether to perform integral on the device.
+ */
+struct gkyl_array_integrate*
+gkyl_array_integrate_new(const struct gkyl_rect_grid* grid, const struct gkyl_basis* basis,
+  int num_comp, enum gkyl_array_integrate_op op, bool use_gpu);
+
+/**
+ * Compute the array integral.
+ *
+ * @param up array_integrate updater.
+ * @param arr Input gkyl_array.
+ * @param weight Factor to multiply by.
+ * @param range Range we'll integrate over.
+ * @return out Output integral result(s).
+ */
+void gkyl_array_integrate_advance(gkyl_array_integrate *up, const struct gkyl_array *arr,
+  double weight, const struct gkyl_range *range, double *out);
+
+/**
+ * Release memory associated with this updater.
+ *
+ * @param up array_integrate updater.
+ */
+void gkyl_array_integrate_release(gkyl_array_integrate *up);

--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -7,19 +7,19 @@
 #include <gkyl_array_integrate.h>
 #include <assert.h>
 
-GKYL_CU_DH void gkyl_array_integrate_op_none(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH void gkyl_array_integrate_op_none_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c)
     out[c] += arr[c*num_basis]*vol;
 }
 
-GKYL_CU_DH void gkyl_array_integrate_op_abs(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH void gkyl_array_integrate_op_abs_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c)
     out[c] += fabs(arr[c*num_basis])*vol;
 }
 
-GKYL_CU_DH void gkyl_array_integrate_op_sq(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH void gkyl_array_integrate_op_sq_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c) {
     for (unsigned b=0; b<num_basis; ++b)
@@ -36,14 +36,10 @@ typedef struct { array_integrate_t kernels[3]; } array_integrate_kern_list;  // 
 GKYL_CU_D
 static const array_integrate_kern_list gkyl_array_integrate_ker_list = {
   .kernels = {
-    gkyl_array_integrate_op_none,
-    gkyl_array_integrate_op_abs,
-    gkyl_array_integrate_op_sq,
+    gkyl_array_integrate_op_none_ker,
+    gkyl_array_integrate_op_abs_ker,
+    gkyl_array_integrate_op_sq_ker,
   }
-};
-
-struct gkyl_array_integrate_kernels {
-  array_integrate_t intker;  // single cell integration kernel.
 };
 
 // Primary struct in this updater.
@@ -51,13 +47,20 @@ struct gkyl_array_integrate {
   int num_basis, num_comp;
   bool use_gpu;
   double vol;  // Single-cell volume factor.
-  struct gkyl_array_integrate_kernels *kernels;  // Single-cell integration kernel.
-  struct gkyl_array_integrate_kernels *kernels_cu;  // device copy.
+  array_integrate_t kernel;  // Single cell integration kernel.
+  struct gkyl_array_integrate *on_dev;  // Pointer to itself on device.
 };
 
-void gkyl_array_integrate_choose_kernel_cu(enum gkyl_array_integrate_op op, struct gkyl_array_integrate_kernels *kers);
-
-void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, struct gkyl_array_integrate_kernels *kers)
+GKYL_CU_D
+void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, struct gkyl_array_integrate *up)
 {
-  kers->intker = gkyl_array_integrate_ker_list.kernels[op];
+  up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+  assert(up->kernel);
 }
+
+struct gkyl_array_integrate*
+gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *basis,
+  int num_comp, enum gkyl_array_integrate_op op);
+
+void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *arr,
+  double weight, const struct gkyl_range *range, double *out);

--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -7,19 +7,19 @@
 #include <gkyl_array_integrate.h>
 #include <assert.h>
 
-GKYL_CU_DH void gkyl_array_integrate_op_none_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH static void gkyl_array_integrate_op_none_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c)
     out[c] += arr[c*num_basis]*vol;
 }
 
-GKYL_CU_DH void gkyl_array_integrate_op_abs_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH static void gkyl_array_integrate_op_abs_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c)
     out[c] += fabs(arr[c*num_basis])*vol;
 }
 
-GKYL_CU_DH void gkyl_array_integrate_op_sq_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
+GKYL_CU_DH static void gkyl_array_integrate_op_sq_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
 {
   for (unsigned c=0; c<num_comp; ++c) {
     for (unsigned b=0; b<num_basis; ++b)
@@ -51,7 +51,7 @@ struct gkyl_array_integrate {
   struct gkyl_array_integrate *on_dev;  // Pointer to itself on device.
 };
 
-GKYL_CU_D
+GKYL_CU_D static
 void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, struct gkyl_array_integrate *up)
 {
   up->kernel = gkyl_array_integrate_ker_list.kernels[op];

--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// Private header for array_integrate updater, not for direct use by user.
+
+#include <gkyl_util.h>
+#include <math.h>
+#include <gkyl_array_integrate.h>
+#include <assert.h>
+
+GKYL_CU_DH void gkyl_array_integrate_op_none(double vol, int num_comp, int num_basis, const double *arr, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c)
+    out[c] += arr[c*num_basis]*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_abs(double vol, int num_comp, int num_basis, const double *arr, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c)
+    out[c] += fabs(arr[c*num_basis])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_sq(double vol, int num_comp, int num_basis, const double *arr, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c) {
+    for (unsigned b=0; b<num_basis; ++b)
+      out[c] += pow(arr[c*num_basis+b],2)*vol;
+  }
+}
+
+// Function pointer type for array_integrate kernels.
+typedef void (*array_integrate_t)(double vol, int num_comp, int num_basis,
+  const double *arr, double *out);
+
+typedef struct { array_integrate_t kernels[3]; } array_integrate_kern_list;  // For use in kernel tables.
+
+GKYL_CU_D
+static const array_integrate_kern_list gkyl_array_integrate_ker_list = {
+  .kernels = {
+    gkyl_array_integrate_op_none,
+    gkyl_array_integrate_op_abs,
+    gkyl_array_integrate_op_sq,
+  }
+};
+
+struct gkyl_array_integrate_kernels {
+  array_integrate_t intker;  // single cell integration kernel.
+};
+
+// Primary struct in this updater.
+struct gkyl_array_integrate {
+  int num_basis, num_comp;
+  bool use_gpu;
+  double vol;  // Single-cell volume factor.
+  struct gkyl_array_integrate_kernels *kernels;  // Single-cell integration kernel.
+  struct gkyl_array_integrate_kernels *kernels_cu;  // device copy.
+};
+
+void gkyl_array_integrate_choose_kernel_cu(enum gkyl_array_integrate_op op, struct gkyl_array_integrate_kernels *kers);
+
+void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, struct gkyl_array_integrate_kernels *kers)
+{
+  kers->intker = gkyl_array_integrate_ker_list.kernels[op];
+}

--- a/zero/gkyl_bc_sheath_gyrokinetic.h
+++ b/zero/gkyl_bc_sheath_gyrokinetic.h
@@ -27,10 +27,7 @@ struct gkyl_bc_sheath_gyrokinetic* gkyl_bc_sheath_gyrokinetic_new(int dir, enum 
   const struct gkyl_rect_grid *grid, int cdim, double q2Dm, bool use_gpu);
 
 /**
- * Create new updater to apply basic BCs to a field
- * in a gkyl_array. Basic BCs are those in which the
- * ghost cell depends solely on the skin cell next to it
- * via a function of type array_copy_func_t (e.g. absorb, reflect).
+ * Apply the sheath BC with the bc_sheath_gyrokinetic object.
  *
  * @param up BC updater.
  * @param phi Electrostatic potential.


### PR DESCRIPTION
This operator integrates a gkyl_array performing some simple operations within the integral (e.g. none, abs, sq). This is similar to what CartFieldIntegratedQuantCalc did in g2 and will be wrapped by such.