### PR TITLE
Extend array integrate to include eps_gradperp_sq needed for GK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,10 @@ $(BUILD_DIR)/kernels/ambi_bolt_potential/%.c.o : kernels/ambi_bolt_potential/%.c
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCLUDES) -c $< -o $@
 
+$(BUILD_DIR)/kernels/array_integrate/%.c.o : kernels/array_integrate/%.c
+	$(MKDIR_P) $(dir $@)
+	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCLUDES) -c $< -o $@
+
 endif
 
 ## GkylZero Library 

--- a/kernels/array_integrate/array_integrate_op_int.c
+++ b/kernels/array_integrate/array_integrate_op_int.c
@@ -1,0 +1,160 @@
+#include <gkyl_array_integrate_kernels.h>
+
+GKYL_CU_DH void gkyl_array_integrate_op_none_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c)
+    out[c] += fIn[c*num_basis]*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_abs_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c)
+    out[c] += fabs(fIn[c*num_basis])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_sq_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  for (unsigned c=0; c<num_comp; ++c) {
+    for (unsigned b=0; b<num_basis; ++b)
+      out[c] += pow(fIn[c*num_basis+b],2)*vol;
+  }
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_1x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += (fIn[1]*fIn[1])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_1x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += (5.0*fIn[2]*fIn[2]+fIn[1]*fIn[1])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_2x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += ((dxSq[1]+dxSq[0])*fIn[3]*fIn[3]+dxSq[0]*fIn[2]*fIn[2]+dxSq[1]*fIn[1]*fIn[1])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_2x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += ((dxSq[1]+5*dxSq[0])*fIn[7]*fIn[7]+(5*dxSq[1]+dxSq[0])*fIn[6]*fIn[6]+5*dxSq[0]*fIn[5]*fIn[5]+5*dxSq[1]*fIn[4]*fIn[4]+(dxSq[1]+dxSq[0])*fIn[3]*fIn[3]+dxSq[0]*fIn[2]*fIn[2]+dxSq[1]*fIn[1]*fIn[1])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += (((dxSq[1]+dxSq[0])*dxSq[2]+dxSq[0]*dxSq[1])*fIn[7]*fIn[7]+(dxSq[0]*dxSq[2]+dxSq[0]*dxSq[1])*fIn[6]*fIn[6]+(dxSq[1]*dxSq[2]+dxSq[0]*dxSq[1])*fIn[5]*fIn[5]+(dxSq[1]+dxSq[0])*dxSq[2]*fIn[4]*fIn[4]+dxSq[0]*dxSq[1]*fIn[3]*fIn[3]+dxSq[0]*dxSq[2]*fIn[2]*fIn[2]+dxSq[1]*fIn[1]*fIn[1]*dxSq[2])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += ((dxSq[1]+dxSq[0])*fIn[7]*fIn[7]+dxSq[0]*fIn[6]*fIn[6]+dxSq[1]*fIn[5]*fIn[5]+(dxSq[1]+dxSq[0])*fIn[4]*fIn[4]+dxSq[0]*fIn[2]*fIn[2]+dxSq[1]*fIn[1]*fIn[1])*vol;
+}
+
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_3x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  out[0] += ((dxSq[1]+dxSq[0])*fIn[19]*fIn[19]+(dxSq[1]+5*dxSq[0])*fIn[18]*fIn[18]+(5*dxSq[1]+dxSq[0])*fIn[17]*fIn[17]+dxSq[0]*fIn[16]*fIn[16]+dxSq[1]*fIn[15]*fIn[15]+5*dxSq[0]*fIn[14]*fIn[14]+5*dxSq[1]*fIn[13]*fIn[13]+(dxSq[1]+5*dxSq[0])*fIn[12]*fIn[12]+(5*dxSq[1]+dxSq[0])*fIn[11]*fIn[11]+(dxSq[1]+dxSq[0])*fIn[10]*fIn[10]+5*dxSq[0]*fIn[8]*fIn[8]+5*dxSq[1]*fIn[7]*fIn[7]+dxSq[0]*fIn[6]*fIn[6]+dxSq[1]*fIn[5]*fIn[5]+(dxSq[1]+dxSq[0])*fIn[4]*fIn[4]+dxSq[0]*fIn[2]*fIn[2]+dxSq[1]*fIn[1]*fIn[1])*vol;
+}
+
+void gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  double dfdx0Sq[4] = {0.};
+  dfdx0Sq[0] = (6.0*(fIn[3]*fIn[3])+6.0*(fIn[1]*fIn[1]))/dxSq[0];
+  dfdx0Sq[2] = (12.0*fIn[1]*fIn[3])/dxSq[0];
+
+  double dfdx1Sq[4] = {0.};
+  dfdx1Sq[0] = (6.0*(fIn[3]*fIn[3])+6.0*(fIn[2]*fIn[2]))/dxSq[1];
+  dfdx1Sq[1] = (12.0*fIn[2]*fIn[3])/dxSq[1];
+
+  out[0] += (dfdx0Sq[2]*weight[2]+dfdx1Sq[1]*weight[1]+(dfdx1Sq[0]+dfdx0Sq[0])*weight[0])*vol;
+}
+
+void gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  double dfdx0Sq[8] = {0.};
+  dfdx0Sq[0] = (6.0*(fIn[7]*fIn[7])+30.0*(fIn[6]*fIn[6])+30.0*(fIn[4]*fIn[4])+6.0*(fIn[3]*fIn[3])+6.0*(fIn[1]*fIn[1]))/dxSq[0];
+  dfdx0Sq[1] = (26.83281572999747*fIn[3]*fIn[6]+26.83281572999748*fIn[1]*fIn[4])/dxSq[0];
+  dfdx0Sq[2] = (0.2*(53.66563145999495*fIn[3]*fIn[7]+300.0000000000001*fIn[4]*fIn[6]+60.0*fIn[1]*fIn[3]))/dxSq[0];
+  dfdx0Sq[3] = (24.0*fIn[6]*fIn[7]+26.83281572999747*fIn[1]*fIn[6]+26.83281572999748*fIn[3]*fIn[4])/dxSq[0];
+  dfdx0Sq[4] = (26.83281572999748*(fIn[6]*fIn[6])+26.83281572999748*(fIn[4]*fIn[4]))/dxSq[0];
+  dfdx0Sq[5] = (0.02857142857142857*(134.1640786499874*(fIn[7]*fIn[7])+420.0000000000001*fIn[1]*fIn[7]+939.1485505499119*(fIn[6]*fIn[6])+187.8297101099823*(fIn[3]*fIn[3])))/dxSq[0];
+  dfdx0Sq[6] = (53.66563145999496*fIn[4]*fIn[6])/dxSq[0];
+  dfdx0Sq[7] = (26.83281572999748*fIn[4]*fIn[7]+24.0*fIn[3]*fIn[6])/dxSq[0];
+
+  double dfdx1Sq[8] = {0.};
+  dfdx1Sq[0] = (30.0*(fIn[7]*fIn[7])+6.0*(fIn[6]*fIn[6])+30.0*(fIn[5]*fIn[5])+6.0*(fIn[3]*fIn[3])+6.0*(fIn[2]*fIn[2]))/dxSq[1];
+  dfdx1Sq[1] = (0.2*(300.0000000000001*fIn[5]*fIn[7]+53.66563145999495*fIn[3]*fIn[6]+60.0*fIn[2]*fIn[3]))/dxSq[1];
+  dfdx1Sq[2] = (26.83281572999747*fIn[3]*fIn[7]+26.83281572999748*fIn[2]*fIn[5])/dxSq[1];
+  dfdx1Sq[3] = ((24.0*fIn[6]+26.83281572999747*fIn[2])*fIn[7]+26.83281572999748*fIn[3]*fIn[5])/dxSq[1];
+  dfdx1Sq[4] = (0.02857142857142857*(939.1485505499119*(fIn[7]*fIn[7])+134.1640786499874*(fIn[6]*fIn[6])+420.0000000000001*fIn[2]*fIn[6]+187.8297101099823*(fIn[3]*fIn[3])))/dxSq[1];
+  dfdx1Sq[5] = (26.83281572999748*(fIn[7]*fIn[7])+26.83281572999748*(fIn[5]*fIn[5]))/dxSq[1];
+  dfdx1Sq[6] = (24.0*fIn[3]*fIn[7]+26.83281572999748*fIn[5]*fIn[6])/dxSq[1];
+  dfdx1Sq[7] = (53.66563145999496*fIn[5]*fIn[7])/dxSq[1];
+
+  out[0] += ((dfdx1Sq[7]+dfdx0Sq[7])*weight[7]+(dfdx1Sq[6]+dfdx0Sq[6])*weight[6]+(dfdx1Sq[5]+dfdx0Sq[5])*weight[5]+(dfdx1Sq[4]+dfdx0Sq[4])*weight[4]+(dfdx1Sq[3]+dfdx0Sq[3])*weight[3]+(dfdx1Sq[2]+dfdx0Sq[2])*weight[2]+(dfdx1Sq[1]+dfdx0Sq[1])*weight[1]+(dfdx1Sq[0]+dfdx0Sq[0])*weight[0])*vol;
+}
+
+void gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  double dfdx0Sq[8] = {0.};
+  dfdx0Sq[0] = (4.242640687119286*(fIn[7]*fIn[7])+4.242640687119286*(fIn[5]*fIn[5])+4.242640687119286*(fIn[4]*fIn[4])+4.242640687119286*(fIn[1]*fIn[1]))/dxSq[0];
+  dfdx0Sq[2] = (8.485281374238571*fIn[5]*fIn[7]+8.485281374238571*fIn[1]*fIn[4])/dxSq[0];
+  dfdx0Sq[3] = (8.485281374238571*fIn[4]*fIn[7]+8.485281374238571*fIn[1]*fIn[5])/dxSq[0];
+  dfdx0Sq[6] = (8.485281374238571*fIn[1]*fIn[7]+8.485281374238571*fIn[4]*fIn[5])/dxSq[0];
+
+  double dfdx1Sq[8] = {0.};
+  dfdx1Sq[0] = (4.242640687119286*(fIn[7]*fIn[7])+4.242640687119286*(fIn[6]*fIn[6])+4.242640687119286*(fIn[4]*fIn[4])+4.242640687119286*(fIn[2]*fIn[2]))/dxSq[1];
+  dfdx1Sq[1] = (8.485281374238571*fIn[6]*fIn[7]+8.485281374238571*fIn[2]*fIn[4])/dxSq[1];
+  dfdx1Sq[3] = (8.485281374238571*fIn[4]*fIn[7]+8.485281374238571*fIn[2]*fIn[6])/dxSq[1];
+  dfdx1Sq[5] = (8.485281374238571*fIn[2]*fIn[7]+8.485281374238571*fIn[4]*fIn[6])/dxSq[1];
+
+  out[0] += (dfdx0Sq[6]*weight[6]+dfdx1Sq[5]*weight[5]+(dfdx1Sq[3]+dfdx0Sq[3])*weight[3]+dfdx0Sq[2]*weight[2]+dfdx1Sq[1]*weight[1]+(dfdx1Sq[0]+dfdx0Sq[0])*weight[0])*vol;
+}
+
+void gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out)
+{
+  double dfdx0Sq[20] = {0.};
+  dfdx0Sq[0] = (4.242640687119286*(fIn[19]*fIn[19])+4.242640687119286*(fIn[18]*fIn[18])+21.21320343559643*(fIn[17]*fIn[17])+4.242640687119286*(fIn[15]*fIn[15])+21.21320343559643*(fIn[13]*fIn[13])+4.242640687119286*(fIn[12]*fIn[12])+21.21320343559643*(fIn[11]*fIn[11])+4.242640687119286*(fIn[10]*fIn[10])+21.21320343559643*(fIn[7]*fIn[7])+4.242640687119286*(fIn[5]*fIn[5])+4.242640687119286*(fIn[4]*fIn[4])+4.242640687119286*(fIn[1]*fIn[1]))/dxSq[0];
+  dfdx0Sq[1] = (18.97366596101028*fIn[10]*fIn[17]+18.97366596101028*fIn[5]*fIn[13]+18.97366596101028*fIn[4]*fIn[11]+18.97366596101028*fIn[1]*fIn[7])/dxSq[0];
+  dfdx0Sq[2] = (0.2*(42.42640687119286*fIn[15]*fIn[19]+37.94733192202057*fIn[10]*fIn[18]+212.1320343559643*fIn[13]*fIn[17]+37.94733192202057*fIn[4]*fIn[12]+212.1320343559643*fIn[7]*fIn[11]+42.42640687119286*fIn[5]*fIn[10]+42.42640687119286*fIn[1]*fIn[4]))/dxSq[0];
+  dfdx0Sq[3] = (0.2*(37.94733192202057*fIn[10]*fIn[19]+42.42640687119286*fIn[12]*fIn[18]+212.1320343559643*fIn[11]*fIn[17]+37.94733192202057*fIn[5]*fIn[15]+212.1320343559643*fIn[7]*fIn[13]+42.42640687119286*fIn[4]*fIn[10]+42.42640687119286*fIn[1]*fIn[5]))/dxSq[0];
+  dfdx0Sq[4] = (16.97056274847715*fIn[17]*fIn[18]+18.97366596101028*fIn[5]*fIn[17]+18.97366596101028*fIn[10]*fIn[13]+16.97056274847715*fIn[11]*fIn[12]+18.97366596101028*fIn[1]*fIn[11]+18.97366596101028*fIn[4]*fIn[7])/dxSq[0];
+  dfdx0Sq[5] = (16.97056274847715*fIn[17]*fIn[19]+18.97366596101028*fIn[4]*fIn[17]+16.97056274847715*fIn[13]*fIn[15]+18.97366596101028*fIn[1]*fIn[13]+18.97366596101028*fIn[10]*fIn[11]+18.97366596101028*fIn[5]*fIn[7])/dxSq[0];
+  dfdx0Sq[6] = (0.2*((33.9411254969543*fIn[18]+37.94733192202057*fIn[5])*fIn[19]+37.94733192202057*fIn[4]*fIn[18]+212.1320343559643*fIn[7]*fIn[17]+37.94733192202057*fIn[10]*fIn[15]+212.1320343559643*fIn[11]*fIn[13]+37.94733192202057*fIn[10]*fIn[12]+42.42640687119286*fIn[1]*fIn[10]+42.42640687119286*fIn[4]*fIn[5]))/dxSq[0];
+  dfdx0Sq[7] = (0.7071067811865475*(26.83281572999748*(fIn[17]*fIn[17])+26.83281572999748*(fIn[13]*fIn[13])+26.83281572999748*(fIn[11]*fIn[11])+26.83281572999748*(fIn[7]*fIn[7])))/dxSq[0];
+  dfdx0Sq[8] = (0.02020305089104421*(187.8297101099823*(fIn[19]*fIn[19])+134.1640786499874*(fIn[18]*fIn[18])+420.0*fIn[5]*fIn[18]+939.1485505499119*(fIn[17]*fIn[17])+134.1640786499874*(fIn[12]*fIn[12])+420.0000000000001*fIn[1]*fIn[12]+939.1485505499119*(fIn[11]*fIn[11])+187.8297101099823*(fIn[10]*fIn[10])+187.8297101099823*(fIn[4]*fIn[4])))/dxSq[0];
+  dfdx0Sq[9] = (0.02020305089104421*(134.1640786499874*(fIn[19]*fIn[19])+420.0*fIn[4]*fIn[19]+187.8297101099823*(fIn[18]*fIn[18])+939.1485505499119*(fIn[17]*fIn[17])+134.1640786499874*(fIn[15]*fIn[15])+420.0000000000001*fIn[1]*fIn[15]+939.1485505499119*(fIn[13]*fIn[13])+187.8297101099823*(fIn[10]*fIn[10])+187.8297101099823*(fIn[5]*fIn[5])))/dxSq[0];
+  dfdx0Sq[10] = (0.2*(84.85281374238573*fIn[13]*fIn[19]+84.85281374238573*fIn[11]*fIn[18]+(84.85281374238573*fIn[15]+84.85281374238573*fIn[12]+94.86832980505142*fIn[1])*fIn[17]+94.8683298050514*fIn[4]*fIn[13]+94.8683298050514*fIn[5]*fIn[11]+94.86832980505142*fIn[7]*fIn[10]))/dxSq[0];
+  dfdx0Sq[11] = (0.7071067811865475*(53.66563145999496*fIn[13]*fIn[17]+53.66563145999496*fIn[7]*fIn[11]))/dxSq[0];
+  dfdx0Sq[12] = (0.1414213562373095*(134.1640786499874*fIn[13]*fIn[18]+120.0*fIn[10]*fIn[17]+134.1640786499874*fIn[7]*fIn[12]+120.0*fIn[4]*fIn[11]))/dxSq[0];
+  dfdx0Sq[13] = (0.7071067811865475*(53.66563145999496*fIn[11]*fIn[17]+53.66563145999496*fIn[7]*fIn[13]))/dxSq[0];
+  dfdx0Sq[14] = (0.004040610178208843*(1680.0*fIn[10]*fIn[19]+(1878.297101099824*fIn[15]+1341.640786499874*fIn[12]+2100.0*fIn[1])*fIn[18]+9391.485505499119*fIn[11]*fIn[17]+2100.0*fIn[5]*fIn[12]+1878.297101099823*fIn[4]*fIn[10]))/dxSq[0];
+  dfdx0Sq[15] = (0.1414213562373095*(134.1640786499874*fIn[11]*fIn[19]+120.0*fIn[10]*fIn[17]+134.1640786499874*fIn[7]*fIn[15]+120.0*fIn[5]*fIn[13]))/dxSq[0];
+  dfdx0Sq[16] = (0.004040610178208843*((1341.640786499874*fIn[15]+1878.297101099824*fIn[12]+2100.0*fIn[1])*fIn[19]+1680.0*fIn[10]*fIn[18]+9391.485505499119*fIn[13]*fIn[17]+2100.0*fIn[4]*fIn[15]+1878.297101099823*fIn[5]*fIn[10]))/dxSq[0];
+  dfdx0Sq[17] = (0.7071067811865475*(53.66563145999496*fIn[7]*fIn[17]+53.66563145999496*fIn[11]*fIn[13]))/dxSq[0];
+  dfdx0Sq[18] = (0.1414213562373095*(107.3312629199899*fIn[17]*fIn[19]+134.1640786499874*fIn[7]*fIn[18]+120.0*fIn[4]*fIn[17]+134.1640786499874*fIn[12]*fIn[13]+120.0*fIn[10]*fIn[11]))/dxSq[0];
+  dfdx0Sq[19] = (0.1414213562373095*(134.1640786499874*fIn[7]*fIn[19]+107.3312629199899*fIn[17]*fIn[18]+120.0*fIn[5]*fIn[17]+134.1640786499874*fIn[11]*fIn[15]+120.0*fIn[10]*fIn[13]))/dxSq[0];
+
+  double dfdx1Sq[20] = {0.};
+  dfdx1Sq[0] = (4.242640687119286*(fIn[19]*fIn[19])+21.21320343559643*(fIn[18]*fIn[18])+4.242640687119286*(fIn[17]*fIn[17])+4.242640687119286*(fIn[16]*fIn[16])+21.21320343559643*(fIn[14]*fIn[14])+21.21320343559643*(fIn[12]*fIn[12])+4.242640687119286*(fIn[11]*fIn[11])+4.242640687119286*(fIn[10]*fIn[10])+21.21320343559643*(fIn[8]*fIn[8])+4.242640687119286*(fIn[6]*fIn[6])+4.242640687119286*(fIn[4]*fIn[4])+4.242640687119286*(fIn[2]*fIn[2]))/dxSq[1];
+  dfdx1Sq[1] = (0.2*(42.42640687119286*fIn[16]*fIn[19]+212.1320343559643*fIn[14]*fIn[18]+37.94733192202057*fIn[10]*fIn[17]+212.1320343559643*fIn[8]*fIn[12]+37.94733192202057*fIn[4]*fIn[11]+42.42640687119286*fIn[6]*fIn[10]+42.42640687119286*fIn[2]*fIn[4]))/dxSq[1];
+  dfdx1Sq[2] = (18.97366596101028*fIn[10]*fIn[18]+18.97366596101028*fIn[6]*fIn[14]+18.97366596101028*fIn[4]*fIn[12]+18.97366596101028*fIn[2]*fIn[8])/dxSq[1];
+  dfdx1Sq[3] = (0.2*(37.94733192202057*fIn[10]*fIn[19]+212.1320343559643*fIn[12]*fIn[18]+42.42640687119286*fIn[11]*fIn[17]+37.94733192202057*fIn[6]*fIn[16]+212.1320343559643*fIn[8]*fIn[14]+42.42640687119286*fIn[4]*fIn[10]+42.42640687119286*fIn[2]*fIn[6]))/dxSq[1];
+  dfdx1Sq[4] = ((16.97056274847715*fIn[17]+18.97366596101028*fIn[6])*fIn[18]+18.97366596101028*fIn[10]*fIn[14]+(16.97056274847715*fIn[11]+18.97366596101028*fIn[2])*fIn[12]+18.97366596101028*fIn[4]*fIn[8])/dxSq[1];
+  dfdx1Sq[5] = (0.2*((33.9411254969543*fIn[17]+37.94733192202057*fIn[6])*fIn[19]+212.1320343559643*fIn[8]*fIn[18]+37.94733192202057*fIn[4]*fIn[17]+37.94733192202057*fIn[10]*fIn[16]+212.1320343559643*fIn[12]*fIn[14]+37.94733192202057*fIn[10]*fIn[11]+42.42640687119286*fIn[2]*fIn[10]+42.42640687119286*fIn[4]*fIn[6]))/dxSq[1];
+  dfdx1Sq[6] = (16.97056274847715*fIn[18]*fIn[19]+18.97366596101028*fIn[4]*fIn[18]+16.97056274847715*fIn[14]*fIn[16]+18.97366596101028*fIn[2]*fIn[14]+18.97366596101028*fIn[10]*fIn[12]+18.97366596101028*fIn[6]*fIn[8])/dxSq[1];
+  dfdx1Sq[7] = (0.02020305089104421*(187.8297101099823*(fIn[19]*fIn[19])+939.1485505499119*(fIn[18]*fIn[18])+134.1640786499874*(fIn[17]*fIn[17])+420.0*fIn[6]*fIn[17]+939.1485505499119*(fIn[12]*fIn[12])+134.1640786499874*(fIn[11]*fIn[11])+420.0000000000001*fIn[2]*fIn[11]+187.8297101099823*(fIn[10]*fIn[10])+187.8297101099823*(fIn[4]*fIn[4])))/dxSq[1];
+  dfdx1Sq[8] = (0.7071067811865475*(26.83281572999748*(fIn[18]*fIn[18])+26.83281572999748*(fIn[14]*fIn[14])+26.83281572999748*(fIn[12]*fIn[12])+26.83281572999748*(fIn[8]*fIn[8])))/dxSq[1];
+  dfdx1Sq[9] = (0.02020305089104421*(134.1640786499874*(fIn[19]*fIn[19])+420.0*fIn[4]*fIn[19]+939.1485505499119*(fIn[18]*fIn[18])+187.8297101099823*(fIn[17]*fIn[17])+134.1640786499874*(fIn[16]*fIn[16])+420.0000000000001*fIn[2]*fIn[16]+939.1485505499119*(fIn[14]*fIn[14])+187.8297101099823*(fIn[10]*fIn[10])+187.8297101099823*(fIn[6]*fIn[6])))/dxSq[1];
+  dfdx1Sq[10] = (0.2*(84.85281374238573*fIn[14]*fIn[19]+(84.85281374238573*fIn[16]+84.85281374238573*fIn[11]+94.86832980505142*fIn[2])*fIn[18]+84.85281374238573*fIn[12]*fIn[17]+94.8683298050514*fIn[4]*fIn[14]+94.8683298050514*fIn[6]*fIn[12]+94.86832980505142*fIn[8]*fIn[10]))/dxSq[1];
+  dfdx1Sq[11] = (0.1414213562373095*(120.0*fIn[10]*fIn[18]+134.1640786499874*fIn[14]*fIn[17]+120.0*fIn[4]*fIn[12]+134.1640786499874*fIn[8]*fIn[11]))/dxSq[1];
+  dfdx1Sq[12] = (0.7071067811865475*(53.66563145999496*fIn[14]*fIn[18]+53.66563145999496*fIn[8]*fIn[12]))/dxSq[1];
+  dfdx1Sq[13] = (0.004040610178208843*(1680.0*fIn[10]*fIn[19]+9391.485505499119*fIn[12]*fIn[18]+(1878.297101099824*fIn[16]+1341.640786499874*fIn[11]+2100.0*fIn[2])*fIn[17]+2100.0*fIn[6]*fIn[11]+1878.297101099823*fIn[4]*fIn[10]))/dxSq[1];
+  dfdx1Sq[14] = (0.7071067811865475*(53.66563145999496*fIn[12]*fIn[18]+53.66563145999496*fIn[8]*fIn[14]))/dxSq[1];
+  dfdx1Sq[15] = (0.004040610178208843*((1341.640786499874*fIn[16]+1878.297101099824*fIn[11]+2100.0*fIn[2])*fIn[19]+9391.485505499119*fIn[14]*fIn[18]+1680.0*fIn[10]*fIn[17]+2100.0*fIn[4]*fIn[16]+1878.297101099823*fIn[6]*fIn[10]))/dxSq[1];
+  dfdx1Sq[16] = (0.1414213562373095*(134.1640786499874*fIn[12]*fIn[19]+120.0*fIn[10]*fIn[18]+134.1640786499874*fIn[8]*fIn[16]+120.0*fIn[6]*fIn[14]))/dxSq[1];
+  dfdx1Sq[17] = (0.1414213562373095*(107.3312629199899*fIn[18]*fIn[19]+120.0*fIn[4]*fIn[18]+134.1640786499874*fIn[8]*fIn[17]+134.1640786499874*fIn[11]*fIn[14]+120.0*fIn[10]*fIn[12]))/dxSq[1];
+  dfdx1Sq[18] = (0.7071067811865475*(53.66563145999496*fIn[8]*fIn[18]+53.66563145999496*fIn[12]*fIn[14]))/dxSq[1];
+  dfdx1Sq[19] = (0.1414213562373095*(134.1640786499874*fIn[8]*fIn[19]+(107.3312629199899*fIn[17]+120.0*fIn[6])*fIn[18]+134.1640786499874*fIn[12]*fIn[16]+120.0*fIn[10]*fIn[14]))/dxSq[1];
+
+  out[0] += ((dfdx1Sq[19]+dfdx0Sq[19])*weight[19]+(dfdx1Sq[18]+dfdx0Sq[18])*weight[18]+(dfdx1Sq[17]+dfdx0Sq[17])*weight[17]+(dfdx1Sq[16]+dfdx0Sq[16])*weight[16]+(dfdx1Sq[15]+dfdx0Sq[15])*weight[15]+(dfdx1Sq[14]+dfdx0Sq[14])*weight[14]+(dfdx1Sq[13]+dfdx0Sq[13])*weight[13]+(dfdx1Sq[12]+dfdx0Sq[12])*weight[12]+(dfdx1Sq[11]+dfdx0Sq[11])*weight[11]+(dfdx1Sq[10]+dfdx0Sq[10])*weight[10]+(dfdx1Sq[9]+dfdx0Sq[9])*weight[9]+(dfdx1Sq[8]+dfdx0Sq[8])*weight[8]+(dfdx1Sq[7]+dfdx0Sq[7])*weight[7]+(dfdx1Sq[6]+dfdx0Sq[6])*weight[6]+(dfdx1Sq[5]+dfdx0Sq[5])*weight[5]+(dfdx1Sq[4]+dfdx0Sq[4])*weight[4]+(dfdx1Sq[3]+dfdx0Sq[3])*weight[3]+(dfdx1Sq[2]+dfdx0Sq[2])*weight[2]+(dfdx1Sq[1]+dfdx0Sq[1])*weight[1]+(dfdx1Sq[0]+dfdx0Sq[0])*weight[0])*vol;
+}

--- a/kernels/array_integrate/gkyl_array_integrate_kernels.h
+++ b/kernels/array_integrate/gkyl_array_integrate_kernels.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <gkyl_util.h>
+#include <math.h>
+
+EXTERN_C_BEG
+
+GKYL_CU_DH void gkyl_array_integrate_op_none_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+GKYL_CU_DH void gkyl_array_integrate_op_abs_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+GKYL_CU_DH void gkyl_array_integrate_op_sq_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_1x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_1x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_2x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_2x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_grad_sq_3x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_2x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_2x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_gradperp_sq_3x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+GKYL_CU_DH void gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p1_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+GKYL_CU_DH void gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p2_ker(double *dxSq, double vol, int num_comp, int num_basis, const double *weight, const double *fIn, double *out);
+
+
+
+
+EXTERN_C_END
+

--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -10,6 +10,7 @@
 #include <gkyl_proj_on_basis.h>
 #include <gkyl_array_integrate.h>
 #include <math.h>
+#include <assert.h>
 
 // allocate array (filled with zeros)
 static struct gkyl_array*
@@ -75,7 +76,7 @@ void test_1x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
   double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
-  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
@@ -155,7 +156,7 @@ void test_1x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
   double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
-  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
@@ -233,7 +234,7 @@ void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
   double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
-  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
@@ -313,7 +314,7 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, integ_op, use_gpu);
 
   double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
-  gkyl_array_integrate_advance(integ_up, distf, 1., &local, fint);
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
 
   gkyl_array_integrate_release(integ_up);
 
@@ -326,6 +327,144 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
   TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 1.5*1.5 : 1.5, fint_ho[1], 1e-12) );
   TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint_ho[2], 1e-12) );
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
+}
+
+void evalFunc_1x_op_gradsq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0];
+  fout[0] = 3.1*x;
+}
+
+void test_1x_op_gradsq(int poly_order, bool use_gpu)
+{
+  double lower[] = {-6.0}, upper[] = {6.0};
+  int cells[] = {16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 1;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_1x_op_gradsq, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ, use_gpu);
+
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  double *arr = gkyl_array_fetch(distf,1);
+  double volFac = grid.dx[0]/2.;
+  double dx0Sq = pow(grid.dx[0],2);
+  if (poly_order == 1)
+    TEST_CHECK( gkyl_compare( cells[0]*12.*pow(arr[1],2)*volFac/dx0Sq, fint_ho[0], 1e-12) );
+  else if (poly_order == 2)
+    TEST_CHECK( gkyl_compare( cells[0]*12.*(5.*pow(arr[2],2)+pow(arr[1],2))*volFac/dx0Sq, fint_ho[0], 1e-12) );
+  else
+    assert(false);
+
+  gkyl_array_release(distf);
+  gkyl_proj_on_basis_release(projf);
+  gkyl_free(fint_ho);
+  if (use_gpu)
+    gkyl_cu_free(fint);
+  else
+    gkyl_free(fint);
+}
+
+void evalFunc_2x_op_gradsq(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+  fout[0] = 3.1*x;
+}
+
+void test_2x_op_gradsq(int poly_order, bool use_gpu)
+{
+  double lower[] = {0., -6.0}, upper[] = {1., 6.0};
+  int cells[] = {6, 16};
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int nc = 1;
+
+  // grids
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+
+  // basis functions
+  struct gkyl_basis basis;
+  gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+
+  int ghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext; // local, local-ext ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // projection updater for dist-function
+  gkyl_proj_on_basis *projf = gkyl_proj_on_basis_new(&grid, &basis, poly_order+1, nc, evalFunc_2x_op_gradsq, NULL);
+
+  // create distribution function array
+  struct gkyl_array *distf = mkarr(nc*basis.num_basis, local_ext.volume, use_gpu);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(nc*basis.num_basis, local_ext.volume, false) : distf;
+
+  // project distribution function on basis
+  gkyl_proj_on_basis_advance(projf, 0.0, &local, distf_ho);
+  if (use_gpu) gkyl_array_copy(distf, distf_ho);
+
+  // integrate distribution function.
+  struct gkyl_array_integrate *integ_up = gkyl_array_integrate_new(&grid, &basis, nc, GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ, use_gpu);
+
+  double *fint = use_gpu? gkyl_cu_malloc(nc*sizeof(double)) : gkyl_malloc(nc*sizeof(double));
+  gkyl_array_integrate_advance(integ_up, distf, 1., NULL, &local, fint);
+
+  gkyl_array_integrate_release(integ_up);
+
+  double *fint_ho = gkyl_malloc(nc*sizeof(double));
+  if (use_gpu)
+    gkyl_cu_memcpy(fint_ho, fint, nc*sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(fint_ho, fint, nc*sizeof(double));
+
+  double *fIn = gkyl_array_fetch(distf_ho,cells[1]+2+1);
+  double volFac = (grid.dx[0]/2.)*(grid.dx[1]/2.);
+  double dx0Sq = pow(grid.dx[0],2), dx1Sq = pow(grid.dx[1],2);
+  if (poly_order == 1)
+    TEST_CHECK( gkyl_compare( cells[0]*cells[1]*12.*((dx1Sq+dx0Sq)*fIn[3]*fIn[3]+dx0Sq*fIn[2]*fIn[2]+dx1Sq*fIn[1]*fIn[1])*volFac/(dx0Sq*dx1Sq), fint_ho[0], 1e-12) );
+  else if (poly_order == 2)
+    TEST_CHECK( gkyl_compare( cells[0]*cells[1]*12.*((dx1Sq+5*dx0Sq)*fIn[7]*fIn[7]+(5*dx1Sq+dx0Sq)*fIn[6]*fIn[6]+5*dx0Sq*fIn[5]*fIn[5]+5*dx1Sq*fIn[4]*fIn[4]+(dx1Sq+dx0Sq)*fIn[3]*fIn[3]+dx0Sq*fIn[2]*fIn[2]+dx1Sq*fIn[1]*fIn[1])*volFac/(dx0Sq*dx1Sq), fint_ho[0], 1e-12) );
+  else
+    assert(false);
 
   gkyl_array_release(distf);
   gkyl_proj_on_basis_release(projf);
@@ -378,6 +517,30 @@ void test_2x_cpu()
   test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, false);
 }
 
+void test_1x_gradsq_cpu()
+{
+  test_1x_op_gradsq(1, false);
+  test_1x_op_gradsq(2, false);
+}
+
+void test_2x_gradsq_cpu()
+{
+  test_2x_op_gradsq(1, false);
+  test_2x_op_gradsq(2, false);
+}
+
+//void test_2x_gradperpsq_cpu()
+//{
+//  test_2x_op_gradperpsq(1, false);
+//  test_2x_op_gradperpsq(2, false);
+//}
+//
+//void test_3x_gradperpsq_cpu()
+//{
+//  test_3x_op_gradperpsq(1, false);
+//  test_3x_op_gradperpsq(2, false);
+//}
+
 #ifdef GKYL_HAVE_CUDA
 void test_1x_gpu()
 {
@@ -420,14 +583,30 @@ void test_2x_gpu()
   test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_ABS, 2, true);
   test_2x_nc3_op(GKYL_ARRAY_INTEGRATE_OP_SQ, 2, true);
 }
+
+void test_1x_gradsq_gpu()
+{
+  test_1x_op_gradsq(1, true);
+  test_1x_op_gradsq(2, true);
+}
+
+void test_2x_gradsq_gpu()
+{
+  test_2x_op_gradsq(1, true);
+  test_2x_op_gradsq(2, true);
+}
 #endif
 
 TEST_LIST = {
   { "test_1x_cpu", test_1x_cpu },
   { "test_2x_cpu", test_2x_cpu },
+  { "test_1x_gradsq_cpu", test_1x_gradsq_cpu },
+  { "test_2x_gradsq_cpu", test_2x_gradsq_cpu },
 #ifdef GKYL_HAVE_CUDA
   { "test_1x_gpu", test_1x_gpu },
   { "test_2x_gpu", test_2x_gpu },
+  { "test_1x_gradsq_gpu", test_1x_gradsq_gpu },
+  { "test_2x_gradsq_gpu", test_2x_gradsq_gpu },
 #endif
   { NULL, NULL },
 };

--- a/unit/ctest_array_integrate.c
+++ b/unit/ctest_array_integrate.c
@@ -247,6 +247,7 @@ void test_2x_nc1_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   TEST_CHECK( gkyl_compare( 1.0, fint_ho[0], 1e-12) );
 
   gkyl_array_release(distf);
+  if (use_gpu) gkyl_array_release(distf_ho);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
   if (use_gpu)
@@ -329,6 +330,7 @@ void test_2x_nc3_op(enum gkyl_array_integrate_op integ_op, int poly_order, bool 
   TEST_CHECK( gkyl_compare( integ_op == GKYL_ARRAY_INTEGRATE_OP_SQ? 2.5*2.5 : 2.5, fint_ho[2], 1e-12) );
 
   gkyl_array_release(distf);
+  if (use_gpu) gkyl_array_release(distf_ho);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
   if (use_gpu)
@@ -387,7 +389,7 @@ void test_1x_op_gradsq(int poly_order, bool use_gpu)
   else
     memcpy(fint_ho, fint, nc*sizeof(double));
 
-  double *arr = gkyl_array_fetch(distf,1);
+  double *arr = gkyl_array_fetch(distf_ho,1);
   double volFac = grid.dx[0]/2.;
   double dx0Sq = pow(grid.dx[0],2);
   if (poly_order == 1)
@@ -398,6 +400,7 @@ void test_1x_op_gradsq(int poly_order, bool use_gpu)
     assert(false);
 
   gkyl_array_release(distf);
+  if (use_gpu) gkyl_array_release(distf_ho);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
   if (use_gpu)
@@ -467,6 +470,7 @@ void test_2x_op_gradsq(int poly_order, bool use_gpu)
     assert(false);
 
   gkyl_array_release(distf);
+  if (use_gpu) gkyl_array_release(distf_ho);
   gkyl_proj_on_basis_release(projf);
   gkyl_free(fint_ho);
   if (use_gpu)

--- a/zero/array_integrate.c
+++ b/zero/array_integrate.c
@@ -38,7 +38,7 @@ gkyl_array_integrate_new(const struct gkyl_rect_grid *grid, const struct gkyl_ba
   } else if (op == GKYL_ARRAY_INTEGRATE_OP_EPS_GRADPERP_SQ) {
     assert(ndim > 1);
     for (unsigned d=0; d<ndim; ++d)
-      up->vol *= (grid->dx[d])/2.;
+      up->vol *= grid->dx[d]/2.;
   } else {
     for (unsigned d=0; d<ndim; ++d)
       up->vol *= op == GKYL_ARRAY_INTEGRATE_OP_SQ? grid->dx[d]/2.0 : grid->dx[d]/sqrt(2.0);

--- a/zero/array_integrate_cu.cu
+++ b/zero/array_integrate_cu.cu
@@ -11,9 +11,19 @@ extern "C" {
 }
 
 __global__ static void
-gkyl_array_integrate_set_ker_cu(struct gkyl_array_integrate *up, enum gkyl_array_integrate_op op)
+gkyl_array_integrate_set_ker_cu(struct gkyl_array_integrate *up, enum gkyl_array_integrate_op op, struct gkyl_basis basis)
 {
-  up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+  int ndim = basis.ndim, poly_order = basis.poly_order;
+
+  if (op == GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ) {
+    up->kernel = gkyl_array_integrate_gradsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_GRADPERP_SQ) {
+    up->kernel = gkyl_array_integrate_gradperpsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_EPS_GRADPERP_SQ) {
+    up->kernel = gkyl_array_integrate_epsgradperpsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else {
+    up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+  }
 }
 
 struct gkyl_array_integrate*
@@ -26,16 +36,29 @@ gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct 
   up->num_basis = basis->num_basis;
   up->num_comp = num_comp;
   up->use_gpu = true;
+  for (int d=0; d<grid->ndim; ++d) up->dxSq[d] = grid->dx[d]*grid->dx[d];
+
+  assert(basis->poly_order > 0); // Need to check normalization for p=0.
 
   int ndim = basis->ndim;
   up->vol = 1.0;
-  if (basis->poly_order > 0) {
+  if (op == GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ) {
+    for (unsigned d=0; d<ndim; ++d)
+      up->vol *= (1./(2.*grid->dx[d]));
+
+    up->vol *= 12.;
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_GRADPERP_SQ) {
+    assert(ndim > 1);
+    for (unsigned d=0; d<2; ++d)
+      up->vol *= (1./(2.*grid->dx[d]));
+    up->vol *= 12.;
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_EPS_GRADPERP_SQ) {
+    assert(ndim > 1);
+    for (unsigned d=0; d<2; ++d)
+      up->vol *= (grid->dx[d])/2.;
+  } else {
     for (unsigned d=0; d<ndim; ++d)
       up->vol *= op == GKYL_ARRAY_INTEGRATE_OP_SQ? grid->dx[d]/2.0 : grid->dx[d]/sqrt(2.0);
-  } else {
-    // For polyOrder = 0 no normalization is applied.
-    for (unsigned d=0; d<ndim; ++d)
-      up->vol *= grid->dx[d];
   }
 
   // Copy struct to device.
@@ -43,7 +66,7 @@ gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct 
   gkyl_cu_memcpy(up_cu, up, sizeof(struct gkyl_array_integrate), GKYL_CU_MEMCPY_H2D);
 
   // Set the kernel.
-  gkyl_array_integrate_set_ker_cu<<<1,1>>>(up_cu, op);
+  gkyl_array_integrate_set_ker_cu<<<1,1>>>(up_cu, op, *basis);
 
   up->on_dev = up_cu;
 
@@ -52,8 +75,8 @@ gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct 
 
 template <unsigned int BLOCKSIZE>
 __global__ void
-array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up,
-  const struct gkyl_array *inp, double weight, const struct gkyl_range range, double *out)
+array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up, const struct gkyl_array *inp,
+  double factor, const struct gkyl_array *weight, const struct gkyl_range range, double *out)
 {
   unsigned long linc = blockIdx.x*blockDim.x + threadIdx.x;
 
@@ -67,13 +90,14 @@ array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up,
   gkyl_sub_range_inv_idx(&range, linc, idx);
   long start = gkyl_range_idx(&range, idx);
   const double *fptr = (const double*) gkyl_array_cfetch(inp, start);
+  const double *wptr = (const double*) gkyl_array_cfetch(weight, start);
 
   double outLocal[10]; // Set to max of 10 (e.g. heat flux tensor).
   for (unsigned int k=0; k<up->num_comp; ++k)
     outLocal[k] = 0.0;
 
   // Integrate in this cell
-  up->kernel(up->vol*weight, up->num_comp, up->num_basis, fptr, outLocal);
+  up->kernel(up->dxSq, up->vol*factor, up->num_comp, up->num_basis, wptr, fptr, outLocal);
 
   for (size_t k = 0; k < up->num_comp; ++k) {
     double f = 0;
@@ -85,14 +109,14 @@ array_integrate_blockRedAtomic_cub(const struct gkyl_array_integrate *up,
   }
 }
 
-void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *arr,
-  double weight, const struct gkyl_range *range, double *out)
+void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *fin,
+  double factor, const struct gkyl_array *weight, const struct gkyl_range *range, double *out)
 {
   gkyl_cu_memset(out, 0, up->num_comp*sizeof(double));
 
   const int nthreads = GKYL_DEFAULT_NUM_THREADS;
   int nblocks = gkyl_int_div_up(range->volume, nthreads);
-  array_integrate_blockRedAtomic_cub<nthreads><<<nblocks, nthreads>>>(up->on_dev, arr->on_dev, weight, *range, out);
+  array_integrate_blockRedAtomic_cub<nthreads><<<nblocks, nthreads>>>(up->on_dev, fin->on_dev, factor, weight->on_dev, *range, out);
   // device synchronize required because out may be host pinned memory
   cudaDeviceSynchronize();
 }

--- a/zero/array_ops_cu.cu
+++ b/zero/array_ops_cu.cu
@@ -657,7 +657,7 @@ gkyl_array_copy_range_to_range_cu(struct gkyl_array *out,
 {
   if (inp_range->volume > 0) {
     dim3 dimGrid, dimBlock;
-    gkyl_get_array_range_kernel_launch_dims(&dimGrid, &dimBlock, *inp_range, out->ncomp);
+    gkyl_get_array_range_kernel_launch_dims(&dimGrid, &dimBlock, *inp_range, inp->ncomp);
 
     gkyl_array_copy_range_cu_kernel<<<dimGrid, dimBlock>>>(out->on_dev,
       inp->on_dev, *out_range, *inp_range);

--- a/zero/gkyl_array_integrate.h
+++ b/zero/gkyl_array_integrate.h
@@ -9,9 +9,12 @@
 typedef struct gkyl_array_integrate gkyl_array_integrate;
 
 enum gkyl_array_integrate_op {
-  GKYL_ARRAY_INTEGRATE_OP_NONE = 0,
-  GKYL_ARRAY_INTEGRATE_OP_ABS,
-  GKYL_ARRAY_INTEGRATE_OP_SQ,
+  GKYL_ARRAY_INTEGRATE_OP_NONE = 0,  // int dx f
+  GKYL_ARRAY_INTEGRATE_OP_ABS,  // int dx |f|
+  GKYL_ARRAY_INTEGRATE_OP_SQ,  // int dx f^2
+  GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ,  // int dx |nabla f|^2
+  GKYL_ARRAY_INTEGRATE_OP_GRADPERP_SQ,  // int dx |nabla_perp f|^2
+  GKYL_ARRAY_INTEGRATE_OP_EPS_GRADPERP_SQ,  // int dx epsilon*|nabla_perp f|^2
 };
 
 /**
@@ -32,13 +35,14 @@ gkyl_array_integrate_new(const struct gkyl_rect_grid* grid, const struct gkyl_ba
  * Compute the array integral.
  *
  * @param up array_integrate updater.
- * @param arr Input gkyl_array.
- * @param weight Factor to multiply by.
+ * @param fin Input gkyl_array.
+ * @param factor Factor to multiply by.
+ * @param weight Weight field we multiply by inside the integral.
  * @param range Range we'll integrate over.
  * @return out Output integral result(s). On device memory if use_gpu=true.
  */
-void gkyl_array_integrate_advance(gkyl_array_integrate *up, const struct gkyl_array *arr,
-  double weight, const struct gkyl_range *range, double *out);
+void gkyl_array_integrate_advance(gkyl_array_integrate *up, const struct gkyl_array *fin,
+  double factor, const struct gkyl_array *weight, const struct gkyl_range *range, double *out);
 
 /**
  * Release memory associated with this updater.

--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -80,4 +80,4 @@ gkyl_array_integrate_cu_dev_new(const struct gkyl_rect_grid *grid, const struct 
   int num_comp, enum gkyl_array_integrate_op op);
 
 void gkyl_array_integrate_advance_cu(gkyl_array_integrate *up, const struct gkyl_array *arr,
-  double weight, const struct gkyl_range *range, double *out);
+  double factor, const struct gkyl_array *weight, const struct gkyl_range *range, double *out);

--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -5,33 +5,18 @@
 #include <gkyl_util.h>
 #include <math.h>
 #include <gkyl_array_integrate.h>
+#include <gkyl_array_integrate_kernels.h>
 #include <assert.h>
 
-GKYL_CU_DH static void gkyl_array_integrate_op_none_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
-{
-  for (unsigned c=0; c<num_comp; ++c)
-    out[c] += arr[c*num_basis]*vol;
-}
-
-GKYL_CU_DH static void gkyl_array_integrate_op_abs_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
-{
-  for (unsigned c=0; c<num_comp; ++c)
-    out[c] += fabs(arr[c*num_basis])*vol;
-}
-
-GKYL_CU_DH static void gkyl_array_integrate_op_sq_ker(double vol, int num_comp, int num_basis, const double *arr, double *out)
-{
-  for (unsigned c=0; c<num_comp; ++c) {
-    for (unsigned b=0; b<num_basis; ++b)
-      out[c] += pow(arr[c*num_basis+b],2)*vol;
-  }
-}
-
 // Function pointer type for array_integrate kernels.
-typedef void (*array_integrate_t)(double vol, int num_comp, int num_basis,
-  const double *arr, double *out);
+typedef void (*array_integrate_t)(double *dxSq, double vol, int num_comp,
+  int num_basis, const double *weight, const double *fIn, double *out);
 
-typedef struct { array_integrate_t kernels[3]; } array_integrate_kern_list;  // For use in kernel tables.
+// For use in kernel tables.
+typedef struct { array_integrate_t kernels[3]; } array_integrate_kern_list;
+typedef struct { array_integrate_t kernels[2]; } array_integrate_gradsq_kern_list;
+typedef struct { array_integrate_t kernels[2]; } array_integrate_gradperpsq_kern_list;
+typedef struct { array_integrate_t kernels[2]; } array_integrate_epsgradperpsq_kern_list;
 
 GKYL_CU_D
 static const array_integrate_kern_list gkyl_array_integrate_ker_list = {
@@ -42,19 +27,51 @@ static const array_integrate_kern_list gkyl_array_integrate_ker_list = {
   }
 };
 
+GKYL_CU_D
+static const array_integrate_gradsq_kern_list gkyl_array_integrate_gradsq_ker_list[] = {
+  {gkyl_array_integrate_op_grad_sq_1x_ser_p1_ker, gkyl_array_integrate_op_grad_sq_1x_ser_p2_ker},
+  {gkyl_array_integrate_op_grad_sq_2x_ser_p1_ker, gkyl_array_integrate_op_grad_sq_2x_ser_p2_ker},
+  {gkyl_array_integrate_op_grad_sq_3x_ser_p1_ker, NULL},
+};
+
+GKYL_CU_D
+static const array_integrate_gradperpsq_kern_list gkyl_array_integrate_gradperpsq_ker_list[] = {
+  {NULL, NULL},
+  {gkyl_array_integrate_op_grad_sq_2x_ser_p1_ker, gkyl_array_integrate_op_grad_sq_2x_ser_p2_ker},
+  {gkyl_array_integrate_op_gradperp_sq_3x_ser_p1_ker, gkyl_array_integrate_op_gradperp_sq_3x_ser_p2_ker},
+};
+
+GKYL_CU_D
+static const array_integrate_epsgradperpsq_kern_list gkyl_array_integrate_epsgradperpsq_ker_list[] = {
+  {NULL, NULL},
+  {gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p1_ker, gkyl_array_integrate_op_eps_gradperp_sq_2x_ser_p2_ker},
+  {gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p1_ker, gkyl_array_integrate_op_eps_gradperp_sq_3x_ser_p2_ker},
+};
+
 // Primary struct in this updater.
 struct gkyl_array_integrate {
   int num_basis, num_comp;
   bool use_gpu;
+  double dxSq[GKYL_MAX_DIM];
   double vol;  // Single-cell volume factor.
   array_integrate_t kernel;  // Single cell integration kernel.
   struct gkyl_array_integrate *on_dev;  // Pointer to itself on device.
 };
 
 GKYL_CU_D static
-void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, struct gkyl_array_integrate *up)
+void gkyl_array_integrate_choose_kernel(enum gkyl_array_integrate_op op, const struct gkyl_basis *basis, struct gkyl_array_integrate *up)
 {
-  up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+  int ndim = basis->ndim, poly_order = basis->poly_order;
+
+  if (op == GKYL_ARRAY_INTEGRATE_OP_GRAD_SQ) {
+    up->kernel = gkyl_array_integrate_gradsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_GRADPERP_SQ) {
+    up->kernel = gkyl_array_integrate_gradperpsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else if (op == GKYL_ARRAY_INTEGRATE_OP_EPS_GRADPERP_SQ) {
+    up->kernel = gkyl_array_integrate_epsgradperpsq_ker_list[ndim-1].kernels[poly_order-1];
+  } else {
+    up->kernel = gkyl_array_integrate_ker_list.kernels[op];
+  }
   assert(up->kernel);
 }
 


### PR DESCRIPTION
(goes with gkylcas PR 28: https://github.com/ammarhakim/gkylcas/pull/28)

In order to incorporate this additional operator we extended array_integrate by adding support for a (gkyl_array) weight. I also moved the kernels to a new kernel folder. Unit tests still pass on CPU and GPU.