### PR TITLE
Reorganize configure to support install in nondefault locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CUDA_ARCH ?= 70
 CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP
 LDFLAGS = 
 PREFIX ?= ${HOME}/gkylsoft
+INSTALL_PREFIX ?= ${PREFIX}
 
 # determine OS we are running on
 UNAME = $(shell uname)
@@ -301,27 +302,27 @@ mpicheck: ${MPI_UNITS} ## Build (if needed) and run all unit tests needing MPI
 
 install: all $(ZERO_SH_INSTALL_LIB) ## Install library and headers
 # Construct install directories
-	$(MKDIR_P) ${PREFIX}/gkylzero/include
-	${MKDIR_P} ${PREFIX}/gkylzero/lib
-	${MKDIR_P} ${PREFIX}/gkylzero/bin
-	${MKDIR_P} ${PREFIX}/gkylzero/share
-	${MKDIR_P} ${PREFIX}/gkylzero/scripts
+	$(MKDIR_P) ${INSTALL_PREFIX}/gkylzero/include
+	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/lib
+	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/bin
+	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/share
+	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/scripts
 # Headers
-	cp ${INSTALL_HEADERS} ${PREFIX}/gkylzero/include
-	./minus/gengkylzeroh.sh > ${PREFIX}/gkylzero/include/gkylzero.h
+	cp ${INSTALL_HEADERS} ${INSTALL_PREFIX}/gkylzero/include
+	./minus/gengkylzeroh.sh > ${INSTALL_PREFIX}/gkylzero/include/gkylzero.h
 # libraries
 #	strip ${ZERO_SH_INSTALL_LIB}  ## MF 2023/10/26: Causes a problem in Macs.
-	cp -f ${ZERO_SH_INSTALL_LIB} ${PREFIX}/gkylzero/lib/libgkylzero.so
+	cp -f ${ZERO_SH_INSTALL_LIB} ${INSTALL_PREFIX}/gkylzero/lib/libgkylzero.so
 # Examples
-	test -e config.mak && cp -f config.mak ${PREFIX}/gkylzero/share/config.mak || echo "No config.mak"
-	cp -f Makefile.sample ${PREFIX}/gkylzero/share/Makefile
-	cp -f regression/rt_arg_parse.h ${PREFIX}/gkylzero/share/rt_arg_parse.h
-	cp -f regression/rt_twostream.c ${PREFIX}/gkylzero/share/rt_twostream.c
+	test -e config.mak && cp -f config.mak ${INSTALL_PREFIX}/gkylzero/share/config.mak || echo "No config.mak"
+	cp -f Makefile.sample ${INSTALL_PREFIX}/gkylzero/share/Makefile
+	cp -f regression/rt_arg_parse.h ${INSTALL_PREFIX}/gkylzero/share/rt_arg_parse.h
+	cp -f regression/rt_twostream.c ${INSTALL_PREFIX}/gkylzero/share/rt_twostream.c
 # Lua wrappers
-	cp -f inf/Vlasov.lua ${PREFIX}/gkylzero/lib/
-	cp -f inf/Moments.lua ${PREFIX}/gkylzero/lib/
+	cp -f inf/Vlasov.lua ${INSTALL_PREFIX}/gkylzero/lib/
+	cp -f inf/Moments.lua ${INSTALL_PREFIX}/gkylzero/lib/
 # Misc scripts
-	cp -f scripts/*.sh ${PREFIX}/gkylzero/scripts
+	cp -f scripts/*.sh ${INSTALL_PREFIX}/gkylzero/scripts
 
 .PHONY: clean
 clean: ## Clean build output

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ CUDA_ARCH ?= 70
 CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP
 LDFLAGS = 
 PREFIX ?= ${HOME}/gkylsoft
-INSTALL_PREFIX ?= ${PREFIX}
 
 # determine OS we are running on
 UNAME = $(shell uname)
@@ -302,27 +301,27 @@ mpicheck: ${MPI_UNITS} ## Build (if needed) and run all unit tests needing MPI
 
 install: all $(ZERO_SH_INSTALL_LIB) ## Install library and headers
 # Construct install directories
-	$(MKDIR_P) ${INSTALL_PREFIX}/gkylzero/include
-	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/lib
-	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/bin
-	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/share
-	${MKDIR_P} ${INSTALL_PREFIX}/gkylzero/scripts
+	$(MKDIR_P) ${PREFIX}/gkylzero/include
+	${MKDIR_P} ${PREFIX}/gkylzero/lib
+	${MKDIR_P} ${PREFIX}/gkylzero/bin
+	${MKDIR_P} ${PREFIX}/gkylzero/share
+	${MKDIR_P} ${PREFIX}/gkylzero/scripts
 # Headers
-	cp ${INSTALL_HEADERS} ${INSTALL_PREFIX}/gkylzero/include
-	./minus/gengkylzeroh.sh > ${INSTALL_PREFIX}/gkylzero/include/gkylzero.h
+	cp ${INSTALL_HEADERS} ${PREFIX}/gkylzero/include
+	./minus/gengkylzeroh.sh > ${PREFIX}/gkylzero/include/gkylzero.h
 # libraries
 #	strip ${ZERO_SH_INSTALL_LIB}  ## MF 2023/10/26: Causes a problem in Macs.
-	cp -f ${ZERO_SH_INSTALL_LIB} ${INSTALL_PREFIX}/gkylzero/lib/libgkylzero.so
+	cp -f ${ZERO_SH_INSTALL_LIB} ${PREFIX}/gkylzero/lib/libgkylzero.so
 # Examples
-	test -e config.mak && cp -f config.mak ${INSTALL_PREFIX}/gkylzero/share/config.mak || echo "No config.mak"
-	cp -f Makefile.sample ${INSTALL_PREFIX}/gkylzero/share/Makefile
-	cp -f regression/rt_arg_parse.h ${INSTALL_PREFIX}/gkylzero/share/rt_arg_parse.h
-	cp -f regression/rt_twostream.c ${INSTALL_PREFIX}/gkylzero/share/rt_twostream.c
+	test -e config.mak && cp -f config.mak ${PREFIX}/gkylzero/share/config.mak || echo "No config.mak"
+	cp -f Makefile.sample ${PREFIX}/gkylzero/share/Makefile
+	cp -f regression/rt_arg_parse.h ${PREFIX}/gkylzero/share/rt_arg_parse.h
+	cp -f regression/rt_twostream.c ${PREFIX}/gkylzero/share/rt_twostream.c
 # Lua wrappers
-	cp -f inf/Vlasov.lua ${INSTALL_PREFIX}/gkylzero/lib/
-	cp -f inf/Moments.lua ${INSTALL_PREFIX}/gkylzero/lib/
+	cp -f inf/Vlasov.lua ${PREFIX}/gkylzero/lib/
+	cp -f inf/Moments.lua ${PREFIX}/gkylzero/lib/
 # Misc scripts
-	cp -f scripts/*.sh ${INSTALL_PREFIX}/gkylzero/scripts
+	cp -f scripts/*.sh ${PREFIX}/gkylzero/scripts
 
 .PHONY: clean
 clean: ## Clean build output

--- a/configure
+++ b/configure
@@ -8,33 +8,15 @@ CC=cc
 ARCH_FLAGS=-march=native
 CUDA_ARCH=70
 
-# Default lapack include and libraries: we prefer linking to static library
-LAPACK_INC=$PREFIX/OpenBLAS/include
-LAPACK_LIB=$PREFIX/OpenBLAS/lib/libopenblas.a
-
-# MPI specific paths and flags
 USE_MPI=
-CONF_MPI_INC_DIR=$PREFIX/openmpi/include
-CONF_MPI_LIB_DIR=$PREFIX/openmpi/lib/
-
-# Lua specific paths and flags (link to static library)
 USE_LUA=
-CONF_LUA_INC_DIR=$PREFIX/luajit/include/luajit-2.1
-CONF_LUA_LIB_DIR=$PREFIX/luajit/lib/
+# Lua link to static library
 CONF_LUA_LIB=luajit-5.1
 
 OSTYPE=`uname -o`
 MACHINE=`uname -n`
 USER=`whoami`
 echo "# OS type is $OSTYPE on $MACHINE user $USER"
-# SuperLU includes and librararies
-SUPERLU_INC=$PREFIX/superlu/include
-if [ "$OSTYPE" = "linux-gnu"* ]
-then
-    SUPERLU_LIB=$PREFIX/superlu/lib64/libsuperlu.a;
-else
-    SUPERLU_LIB=$PREFIX/superlu/lib/libsuperlu.a;
-fi
 
 # Location of CUDA math libraries
 CUDAMATH_LIBS=
@@ -210,6 +192,27 @@ then
     USE_LUA=1
 else
     USE_LUA=
+fi
+
+# Default lapack include and libraries: we prefer linking to static library
+: "${LAPACK_INC:=$PREFIX/OpenBLAS/include}"
+: "${LAPACK_LIB=$PREFIX/OpenBLAS/lib/libopenblas.a}"
+
+# MPI specific paths and flags
+: "${CONF_MPI_INC_DIR=$PREFIX/openmpi/include}"
+: "${CONF_MPI_LIB_DIR=$PREFIX/openmpi/lib/}"
+
+# Lua specific paths and flags
+: "${CONF_LUA_INC_DIR=$PREFIX/luajit/include/luajit-2.1}"
+: "${CONF_LUA_LIB_DIR=$PREFIX/luajit/lib/}"
+
+# SuperLU includes and librararies
+: "${SUPERLU_INC=$PREFIX/superlu/include}"
+if [ "$OSTYPE" = "linux-gnu"* ]
+then
+    : "${SUPERLU_LIB=$PREFIX/superlu/lib64/libsuperlu.a;}"
+else
+    : "${SUPERLU_LIB=$PREFIX/superlu/lib/libsuperlu.a;}"
 fi
 
 # Write out config.mak

--- a/configure
+++ b/configure
@@ -7,7 +7,6 @@ echo "# OS type is $OSTYPE on $MACHINE user $USER"
 
 # Defaults
 PREFIX=${HOME}/gkylsoft
-INSTALL_PREFIX=$PREFIX
 
 # default build options
 CC=cc
@@ -45,10 +44,7 @@ CUDA_ARCH                  CUDA architecture flag to specify compute capability.
 
 -h
 --help                     This help.
---prefix=DIR               Prefix where GkeyllZero dependences are installed
-                           Default is $HOME/gkylsoft/
-
---install-prefix=DIR       Prefix where to install GkeyllZero
+--prefix=DIR               Prefix where GkeyllZero is installed
                            Default is $HOME/gkylsoft/
 
 --use-mpi                  [no] Build MPI-dependent code
@@ -132,10 +128,6 @@ do
    --prefix)
       [ -n "$value" ] || die "Missing value in flag $key."
       PREFIX="$value"
-      ;;
-   --install-prefix)
-      [ -n "$value" ] || die "Missing value in flag $key."
-      INSTALL_PREFIX="$value"
       ;;
    --lapack-inc)
       [ -n "$value" ] || die "Missing value in flag $key."
@@ -229,7 +221,6 @@ cat <<EOF1 > config.mak
 
 # Installation directory
 PREFIX=$PREFIX
-INSTALL_PREFIX=$INSTALL_PREFIX
 # Compilers
 CC=$CC
 ARCH_FLAGS=$ARCH_FLAGS


### PR DESCRIPTION
This is a variation of PR #228 

It moves some things around and defines some paths in a different way in the configure file, so that we can install in non-default locations. It works as follows:
1. If only --prefix is passed, it uses that as the location of the dependencies and the location where gkylzero is installed.
2. Regardless of whether --prefix is passed or not, the paths favor --*-inc and --*-lib when those are given.

I believe we thought non-default install location was working because it was looking for these libraries in $HOME/gkylsoft, and we all had an install there from previous work. But if that doesn't exist it in fact doesn't work. This PR fixes that.