### PR TITLE
Make decomp an optional input to mpi_comm

### DIFF
--- a/install-deps/mkdeps.sh
+++ b/install-deps/mkdeps.sh
@@ -120,6 +120,14 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       CXX="$value"
       ;;
+   MPICC)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      MPICC="$value"
+      ;;
+   MPICXX)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      MPICXX="$value"
+      ;;
    FC)
       [ -n "$value" ] || die "Missing value in flag $key."
       FC="$value"

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -231,7 +231,7 @@ test_n4_sync_1x1v()
 {
   int m_sz;
   MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
-  if (m_sz != 2) return;
+  if (m_sz != 4) return;
 
   int rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -286,11 +286,11 @@ test_n4_sync_1x1v()
     TEST_CHECK( iter.idx[1] == f[1] );
   }
 
-  gkyl_rect_decomp_release(decomp);
+  gkyl_array_release(arr);
+  gkyl_comm_release(ext_comm);
   gkyl_rect_decomp_release(ext_decomp);
   gkyl_comm_release(comm);
-  gkyl_comm_release(ext_comm);
-  gkyl_array_release(arr);
+  gkyl_rect_decomp_release(decomp);
 }
 
 void
@@ -510,19 +510,18 @@ test_n4_multicomm_2d()
   MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
   if (m_sz != 4) return;
 
+  struct gkyl_comm *worldcomm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = 0,
+    }
+  );
+
   struct gkyl_range range;
   gkyl_range_init(&range, 2, (int[]) { 1, 1 }, (int[]) { 10, 20 });
 
   int confcuts[] = { 2, 1 };
   struct gkyl_rect_decomp *confdecomp = gkyl_rect_decomp_new_from_cuts(2, confcuts, &range);  
   
-  struct gkyl_comm *worldcomm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
-      .mpi_comm = MPI_COMM_WORLD,
-      .decomp = confdecomp,  // MF 2023/07/28: I think decomp doesn't matter
-                             // for worldcomm.
-    }
-  );
-
   int worldrank;
   gkyl_comm_get_rank(worldcomm, &worldrank);
 
@@ -598,9 +597,9 @@ test_n4_multicomm_2d()
   gkyl_comm_state_release(speciescomm, cstate);
   gkyl_array_release(arrA);
   gkyl_array_release(arrB);
-  gkyl_rect_decomp_release(confdecomp);
   gkyl_comm_release(speciescomm);
   gkyl_comm_release(confcomm);
+  gkyl_rect_decomp_release(confdecomp);
   gkyl_comm_release(worldcomm);
 }
   
@@ -610,7 +609,7 @@ TEST_LIST = {
   {"test_n2_sync_1d", test_n2_sync_1d},
   {"test_n4_sync_2d_no_corner", test_n4_sync_2d_no_corner },
   {"test_n4_sync_2d_use_corner", test_n4_sync_2d_use_corner},
-  {"test_n2_sync_1x1v", test_n4_sync_1x1v },
+  {"test_n4_sync_1x1v", test_n4_sync_1x1v },
   {"test_n1_per_sync_2d", test_n1_per_sync_2d },
   {"test_n2_array_send_irecv_1d", test_n2_array_send_irecv_1d},
   {"test_n2_array_isend_irecv_2d", test_n2_array_isend_irecv_2d},

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -75,9 +75,9 @@ comm_free(const struct gkyl_ref_count *ref)
   struct mpi_comm *mpi = container_of(comm, struct mpi_comm, base);
 
   if (mpi->has_decomp) {
+    int ndim = mpi->decomp->ndim;
     gkyl_rect_decomp_release(mpi->decomp);
 
-    int ndim = mpi->decomp->ndim;
     gkyl_rect_decomp_neigh_release(mpi->neigh);
     for (int d=0; d<ndim; ++d)
       gkyl_rect_decomp_neigh_release(mpi->per_neigh[d]);


### PR DESCRIPTION
Basically put stuff in mpi_comm associated in decomp inside an if statement so we can create an mpi_comm with decomp=0, i.e. without decomposition. In this case mpi_comm is used solely as a communicator (see comment in 521de203a76f5b0a794f676266ea38e9cec89f2d)