### PR TITLE
Rename gkyl_range_shorten to gkyl_range_shorten_from_above, and imple…

### DIFF
--- a/unit/ctest_range.c
+++ b/unit/ctest_range.c
@@ -239,14 +239,14 @@ void test_sub_sub_range()
   }
 }
 
-void test_shorten()
+void test_shorten_from_above()
 {
   int lower[] = {1, 1, 1}, upper[] = {20, 30, 20};
   struct gkyl_range range, shortr, shortr2;
 
   gkyl_range_init(&range, 3, lower, upper);
-  gkyl_range_shorten(&shortr, &range, 1, 1);
-  gkyl_range_shorten(&shortr2, &range, 1, 3);
+  gkyl_range_shorten_from_above(&shortr, &range, 1, 1);
+  gkyl_range_shorten_from_above(&shortr2, &range, 1, 3);
 
   TEST_CHECK( gkyl_range_is_sub_range(&shortr) == 1 );
 
@@ -268,6 +268,42 @@ void test_shorten()
 
   TEST_CHECK( shortr2.lower[1] == range.lower[1] );
   TEST_CHECK( shortr2.upper[1] == range.lower[1]+3-1 ); // shortened range
+
+  TEST_CHECK( shortr2.lower[2] == range.lower[2] );
+  TEST_CHECK( shortr2.upper[2] == range.upper[2] );
+
+  TEST_CHECK( shortr2.volume == 20*20*3 );
+}
+
+void test_shorten_from_below()
+{
+  int lower[] = {1, 1, 1}, upper[] = {20, 30, 20};
+  struct gkyl_range range, shortr, shortr2;
+
+  gkyl_range_init(&range, 3, lower, upper);
+  gkyl_range_shorten_from_below(&shortr, &range, 1, 1);
+  gkyl_range_shorten_from_below(&shortr2, &range, 1, 3);
+
+  TEST_CHECK( gkyl_range_is_sub_range(&shortr) == 1 );
+
+  // shortr
+  TEST_CHECK( shortr.lower[0] == range.lower[0] );
+  TEST_CHECK( shortr.upper[0] == range.upper[0] );
+
+  TEST_CHECK( shortr.lower[1] == range.upper[1] );
+  TEST_CHECK( shortr.upper[1] == range.upper[1] ); // shortened range
+
+  TEST_CHECK( shortr.lower[2] == range.lower[2] );
+  TEST_CHECK( shortr.upper[2] == range.upper[2] );
+
+  TEST_CHECK( shortr.volume == 20*20 );
+
+  // shortr2
+  TEST_CHECK( shortr2.lower[0] == range.lower[0] );
+  TEST_CHECK( shortr2.upper[0] == range.upper[0] );
+
+  TEST_CHECK( shortr2.lower[1] == range.upper[1]-3+1 );
+  TEST_CHECK( shortr2.upper[1] == range.upper[1] ); // shortened range
 
   TEST_CHECK( shortr2.lower[2] == range.lower[2] );
   TEST_CHECK( shortr2.upper[2] == range.upper[2] );
@@ -1077,7 +1113,8 @@ TEST_LIST = {
   { "range_iter_init_next", test_range_iter_init_next},
   { "sub_sub_range",  test_sub_sub_range },
   { "sub_range_inv_idx",  test_sub_range_inv_idx },
-  { "shorten", test_shorten },
+  { "shorten_from_above", test_shorten_from_above },
+  { "shorten_from_below", test_shorten_from_below },
   { "skin", test_skin },
   { "range_index_1d", test_range_index_1d },
   { "range_index_2d", test_range_index_2d },

--- a/zero/fem_parproj.c
+++ b/zero/fem_parproj.c
@@ -45,7 +45,7 @@ gkyl_fem_parproj_new(const struct gkyl_range *solve_range, const struct gkyl_ran
   up->parnum_cells = up->par_range.volume;
 
   // Range of perpendicular cells.
-  gkyl_range_shorten(&up->perp_range, up->solve_range, up->pardir, 1);
+  gkyl_range_shorten_from_above(&up->perp_range, up->solve_range, up->pardir, 1);
 
   // 1D range of parallel cells.
   int lower1d[] = {up->par_range.lower[up->pardir]}, upper1d[] = {up->par_range.upper[up->pardir]};

--- a/zero/gkyl_range.h
+++ b/zero/gkyl_range.h
@@ -204,15 +204,30 @@ void gkyl_range_deflate(struct gkyl_range* srng,
 
 /**
  * Return range which has 'dir' direction shortened to length
- * 'len'. The shortened range has the same dimensions and the same
+ * 'len', reducing the upper limit of 'range' in that direction.
+ * The shortened range has the same dimensions and the same
  * start index in 'dir'.
  *
- * @param rng Shortned range.
+ * @param rng Shortened range.
  * @param range Range object to shorten
  * @param dir Direction to shorten
  * @param len Length of shortened direction
  */
-void gkyl_range_shorten(struct gkyl_range *rng,
+void gkyl_range_shorten_from_above(struct gkyl_range *rng,
+  const struct gkyl_range* range, int dir, int len);
+
+/**
+ * Return range which has 'dir' direction shortened to length
+ * 'len', increasing the lower limit of 'range' in that direction.
+ * The shortened range has the same dimensions and the same
+ * start index in 'dir'.
+ *
+ * @param rng Shortened range.
+ * @param range Range object to shorten
+ * @param dir Direction to shorten
+ * @param len Length of shortened direction
+ */
+void gkyl_range_shorten_from_below(struct gkyl_range *rng,
   const struct gkyl_range* range, int dir, int len);
 
 /**

--- a/zero/kep_scheme.c
+++ b/zero/kep_scheme.c
@@ -222,7 +222,7 @@ gkyl_kep_scheme_advance(const gkyl_kep_scheme *kep, const struct gkyl_range *upd
     int upidx = update_rng->upper[dir]+1; // one more edge than cells
 
     struct gkyl_range perp_range;
-    gkyl_range_shorten(&perp_range, update_rng, dir, 1);
+    gkyl_range_shorten_from_above(&perp_range, update_rng, dir, 1);
     struct gkyl_range_iter iter;
     gkyl_range_iter_init(&iter, &perp_range);
 

--- a/zero/range.c
+++ b/zero/range.c
@@ -272,7 +272,7 @@ gkyl_range_deflate(struct gkyl_range* srng,
 }
 
 void
-gkyl_range_shorten(struct gkyl_range *rng,
+gkyl_range_shorten_from_above(struct gkyl_range *rng,
   const struct gkyl_range* range, int dir, int len)
 {
   int ndim = range->ndim;
@@ -283,6 +283,21 @@ gkyl_range_shorten(struct gkyl_range *rng,
     up[i] = range->upper[i];
   }
   up[dir] = lo[dir]+len-1;
+  gkyl_sub_range_init(rng, range, lo, up);
+}
+
+void
+gkyl_range_shorten_from_below(struct gkyl_range *rng,
+  const struct gkyl_range* range, int dir, int len)
+{
+  int ndim = range->ndim;
+  int lo[GKYL_MAX_DIM] = {0}, up[GKYL_MAX_DIM] = {0};
+  
+  for (int i=0; i<ndim; ++i) {
+    lo[i] = range->lower[i];
+    up[i] = range->upper[i];
+  }
+  lo[dir] = up[dir]-len+1;
   gkyl_sub_range_init(rng, range, lo, up);
 }
 

--- a/zero/wave_prop.c
+++ b/zero/wave_prop.c
@@ -298,7 +298,7 @@ gkyl_wave_prop_advance(gkyl_wave_prop *wv,
     gkyl_range_init(&slice_range, 1, (int[]) { loidx }, (int[]) { upidx } );
 
     struct gkyl_range perp_range;
-    gkyl_range_shorten(&perp_range, update_range, dir, 1);
+    gkyl_range_shorten_from_above(&perp_range, update_range, dir, 1);
     struct gkyl_range_iter iter;
     gkyl_range_iter_init(&iter, &perp_range);
 


### PR DESCRIPTION
…ment gkyl_range_shorten_from_below. The latter is to be used in some limited tokamak stuff; in principle you can do it with a shorten_from_above and a shift, but it's easier/safer to do it with one command (shorten_from_below). Unit tests pass, and ran a couple of reg tests as well.