### PR TITLE
Zero out gkyl_array upon creation (for type int/float/double)

### DIFF
--- a/unit/ctest_array.c
+++ b/unit/ctest_array.c
@@ -29,8 +29,10 @@ void test_array_base()
   TEST_CHECK( gkyl_array_is_cu_dev(arr) == false );
 
   double *arrData  = arr->data;
-  for (unsigned i=0; i<arr->size; ++i)
+  for (unsigned i=0; i<arr->size; ++i){
+    TEST_CHECK( arrData[i] == 0. );
     arrData[i] = (i+0.5)*0.1;
+  }
 
   // clone array
   struct gkyl_array *brr = gkyl_array_clone(arr);
@@ -1295,9 +1297,13 @@ void test_cu_array_base()
   // create host array and initialize it
   struct gkyl_array *arr = gkyl_array_new(GKYL_DOUBLE, 1, 200);
 
-  double *arrData  = arr->data;
-  for (unsigned i=0; i<arr->size; ++i)
+  gkyl_array_copy(arr, arr_cu);
+
+  double *arrData = arr->data;
+  for (unsigned i=0; i<arr->size; ++i) {
+    TEST_CHECK( arrData[i] == 0. );
     arrData[i] = (i+0.5)*0.1;  
+  }
 
   // copy to device
   gkyl_array_copy(arr_cu, arr);

--- a/zero/alloc.c
+++ b/zero/alloc.c
@@ -201,19 +201,21 @@ gkyl_cu_malloc_(const char *file, int line, const char *func, size_t size)
     gkyl_exit("cudaMalloc failed!");
   
   GKYL_CU_MEMMSG("%p 0.cudaMalloc: %s %s:%d\n", ptr, file, func, line);
+
   return ptr;
 }
 
-// for pinned host memory
 void*
 gkyl_cu_malloc_host_(const char *file, int line, const char *func, size_t size)
 {
+  // Allocate pinned host memory.
   void *ptr;
   cudaError_t err = cudaMallocHost(&ptr, size);
   if (err != cudaSuccess)
     gkyl_exit("cudaMallocHost failed!");
 
   GKYL_CU_MEMMSG("%p 0.cudaMallocHost: %s %s:%d\n", ptr, file, func, line);
+
   return ptr;
 }
 
@@ -256,7 +258,9 @@ gkyl_cu_memcpy_async(void *dst, void *src, size_t count, enum gkyl_cu_memcpy_kin
 void
 gkyl_cu_memset(void *data, int val, size_t count)
 {
-  cudaMemset(data, val, count);
+  cudaError_t err = cudaMemset(data, val, count);
+  if (err != cudaSuccess)
+    gkyl_exit("gkyl_cu_memset failed!");
 }
 
 #else

--- a/zero/array.c
+++ b/zero/array.c
@@ -12,6 +12,13 @@
 // alignment boundary is 32 bytes to be compatible with AVX
 static const size_t ARRAY_ALIGN_BND = 32;
 
+#define set_arr_dat_zero_ho(arr, data) \
+  for (size_t i=0; i<arr->size*arr->ncomp; ++i) data[i] = 0
+
+#define set_arr_dat_zero_dev(arr, data_ho) \
+  for (size_t i=0; i<arr->size*arr->ncomp; ++i) data_ho[i] = 0; \
+  gkyl_cu_memcpy(arr->data, data_ho, arr->size*arr->esznc, GKYL_CU_MEMCPY_H2D);
+
 static void*
 g_array_alloc(size_t num, size_t sz)
 {
@@ -82,6 +89,18 @@ gkyl_array_new(enum gkyl_elem_type type, size_t ncomp, size_t size)
   arr->nblocks = 1;
 
   arr->on_dev = arr; // on_dev reference
+
+  // Zero out array elements (not for user-defined type).
+  if (type == GKYL_INT) {
+    int *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  } else if (type == GKYL_FLOAT) {
+    float *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  } else if (type == GKYL_DOUBLE) {
+    double *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  }
 
   return arr;
 }
@@ -227,6 +246,21 @@ gkyl_array_cu_dev_new(enum gkyl_elem_type type, size_t ncomp, size_t size)
   // (which is the host-side pointer to the device data)
   gkyl_cu_memcpy(&((arr->on_dev)->data), &arr->data, sizeof(void*), GKYL_CU_MEMCPY_H2D);
 
+  // Zero out array elements (not for user-defined type).
+  if (type == GKYL_INT) {
+    int *data_ho = gkyl_malloc(arr->size*arr->esznc);
+    set_arr_dat_zero_dev(arr, data_ho);
+    gkyl_free(data_ho);
+  } else if (type == GKYL_FLOAT) {
+    float *data_ho = gkyl_malloc(arr->size*arr->esznc);
+    set_arr_dat_zero_dev(arr, data_ho);
+    gkyl_free(data_ho);
+  } else if (type == GKYL_DOUBLE) {
+    double *data_ho = gkyl_malloc(arr->size*arr->esznc);
+    set_arr_dat_zero_dev(arr, data_ho);
+    gkyl_free(data_ho);
+  }
+
   return arr;
 }
 
@@ -257,6 +291,18 @@ gkyl_array_cu_host_new(enum gkyl_elem_type type, size_t ncomp, size_t size)
 
   arr->on_dev = arr; // on_dev reference
   
+  // Zero out array elements (not for user-defined type).
+  if (type == GKYL_INT) {
+    int *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  } else if (type == GKYL_FLOAT) {
+    float *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  } else if (type == GKYL_DOUBLE) {
+    double *dat_p = arr->data;
+    set_arr_dat_zero_ho(arr, dat_p);
+  }
+
   return arr;
 }
 


### PR DESCRIPTION
ctest_array passes on CPU and GPU