### PR TITLE
Implement adiabatic elc option (only for 1x). Rename previous GK_FIELD_ADIABATIC to GK_FIELD_BOLTZMANN

### DIFF
--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -231,7 +231,7 @@ struct gkyl_gyrokinetic_field {
   double xLCFS; // radial location of the LCFS.
 
   // parameters for adiabatic electrons simulations
-  double electron_mass, electron_charge, electron_temp;
+  double electron_mass, electron_charge, electron_density, electron_temp;
 
   enum gkyl_fem_parproj_bc_type fem_parbc;
   struct gkyl_poisson_bc poisson_bcs;

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -511,7 +511,7 @@ gkyl_gyrokinetic_app_write_field(gkyl_gyrokinetic_app* app, double tm, int frame
     fout[i] = app->species[i].f1;
   }
   gk_field_accumulate_rho_c(app, app->field, fin);
-  if (app->field->gkfield_id == GKYL_GK_FIELD_ADIABATIC) {
+  if (app->field->gkfield_id == GKYL_GK_FIELD_BOLTZMANN) {
     gk_field_calc_ambi_pot_sheath_vals(app, app->field, fin, fout);
   }
   gk_field_rhs(app, app->field);
@@ -1323,7 +1323,7 @@ forward_euler(gkyl_gyrokinetic_app* app, double tcurr, double dt,
     // done here as the RHS update for all species should be complete before
     // boundary fluxes are computed (ion fluxes needed for sheath values) 
     // and these boundary fluxes are stored temporarily in ghost cells of RHS
-    if (app->field->gkfield_id == GKYL_GK_FIELD_ADIABATIC)
+    if (app->field->gkfield_id == GKYL_GK_FIELD_BOLTZMANN)
       gk_field_calc_ambi_pot_sheath_vals(app, app->field, fin, fout);
   }
 

--- a/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
@@ -286,6 +286,7 @@ main(int argc, char **argv)
     .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
     .electron_mass = ctx.mass_elc,
     .electron_charge = ctx.charge_elc,
+    .electron_density = ctx.n0,
     .electron_temp = ctx.Te,
     .bmag_fac = ctx.B0, 
     .kperpSq = pow(ctx.kperp, 2.),

--- a/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
@@ -1,0 +1,397 @@
+#include <math.h>
+#include <stdio.h>
+#include <time.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_const.h>
+#include <gkyl_fem_parproj.h>
+#include <gkyl_gyrokinetic.h>
+
+#include <gkyl_null_comm.h>
+
+#ifdef GKYL_HAVE_MPI
+#include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#ifdef GKYL_HAVE_NCCL
+#include <gkyl_nccl_comm.h>
+#endif
+#endif
+
+#include <rt_arg_parse.h>
+
+struct gk_app_ctx {
+  double charge_elc; // electron charge
+  double mass_elc; // electron mass
+  double charge_ion; // ion charge
+  double mass_ion; // ion mass
+  double n0; // reference density
+  double Te; // electron temperature
+  double Ti; // ion temperature
+  double B0; // reference magnetic field
+  double nu_ion; // ion collision frequency
+  double Lz; // Box size in z.
+  double wavek; // Wave number of ion acoustic wave.
+  double kperp; // perpendicular wave number used in Poisson solve
+  double vpar_max_ion; // Velocity space extents in vparallel for ions
+  double mu_max_ion; // Velocity space extents in mu for ions
+  int Nz, Nvpar, Nmu; // Number of in z, vpar and mu.
+  double final_time; // end time
+  int num_frames; // number of output frames
+};
+
+// Initial conditions.
+void eval_density_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double z = xn[0];
+
+  struct gk_app_ctx *app = ctx;
+  double n0 = app->n0;
+  double wavek = app->wavek;
+
+  double alpha = 0.01;
+  double perturb = alpha*cos(wavek*z);
+
+  fout[0] = n0*(1.+perturb);
+}
+
+void eval_upar_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  fout[0] = 0.0;
+}
+
+void eval_temp_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_app_ctx *app = ctx;
+  double Ti = app->Ti;
+  fout[0] = Ti;
+}
+
+// Collision frequency.
+void eval_nu_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_app_ctx *app = ctx;
+  fout[0] = app->nu_ion;
+}
+
+void mapc2p(double t, const double *xc, double* GKYL_RESTRICT xp, void *ctx)
+{
+  xp[0] = xc[0]; xp[1] = xc[1]; xp[2] = xc[2];
+}
+
+void bmag_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_app_ctx *app = ctx;
+  fout[0] = app->B0;
+}
+
+struct gk_app_ctx
+create_ctx(void)
+{
+  double mi = 1.0; // ion mass
+  double me = mi/1836.16; // electron mass
+  double qi = 1.0; // ion charge
+  double qe = -1.0; // electron charge
+
+  // Reference density and temperature.
+  double n0 = 1.0;
+  double Te = 1.0;
+  double Ti = 1.0;
+  double B0 = 1.0;
+  double nu_ion = 0.005;
+  double wavek = 0.5;
+
+  // Derived parameters.
+  double vtIon = sqrt(Ti/mi);
+
+  // Simulation box size (m).
+  double Lz = 2.*M_PI/wavek;
+
+  double kperp = 0.;
+
+  double vpar_max_ion = 6.0*vtIon;
+  double mu_max_ion = mi*pow(5.0*vtIon,2)/(2.0*B0);
+
+  int Nz = 64;
+  int Nvpar = 96;
+  int Nmu = 16;
+
+  double final_time = 50.0; 
+  double num_frames = 100;
+
+  struct gk_app_ctx ctx = {
+    .charge_elc = qe,  .mass_elc = me,
+    .charge_ion = qi,  .mass_ion = mi,
+    .n0 = n0,
+    .Te = Te,  .Ti = Ti,
+    .B0 = B0,
+    .nu_ion = nu_ion,
+    .Lz = Lz,
+    .wavek = wavek,
+    .kperp = kperp,
+    .vpar_max_ion = vpar_max_ion,
+    .mu_max_ion = mu_max_ion,
+    .Nz = Nz,  .Nvpar = Nvpar,  .Nmu = Nmu,
+    .final_time = final_time,
+    .num_frames = num_frames,
+  };
+  return ctx;
+}
+
+void
+write_data(struct gkyl_tm_trigger *iot, gkyl_gyrokinetic_app *app, double tcurr)
+{
+  if (gkyl_tm_trigger_check_and_bump(iot, tcurr)) {
+    gkyl_gyrokinetic_app_write(app, tcurr, iot->curr-1);
+    gkyl_gyrokinetic_app_calc_mom(app); gkyl_gyrokinetic_app_write_mom(app, tcurr, iot->curr-1);
+  }
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+
+  if (app_args.trace_mem) {
+    gkyl_cu_dev_mem_debug_set(true);
+    gkyl_mem_debug_set(true);
+  }
+
+  struct gk_app_ctx ctx = create_ctx(); // context for init functions
+
+  int NZ = APP_ARGS_CHOOSE(app_args.xcells[0], ctx.Nz);
+  int NVPAR = APP_ARGS_CHOOSE(app_args.vcells[0], ctx.Nvpar);
+  int NMU = APP_ARGS_CHOOSE(app_args.vcells[1], ctx.Nmu);
+
+  int nrank = 1; // Number of processors in simulation.
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Comm_size(MPI_COMM_WORLD, &nrank);
+#endif  
+
+  // Create global range.
+  int ccells[] = { NZ };
+  int cdim = sizeof(ccells) / sizeof(ccells[0]);
+  struct gkyl_range cglobal_r;
+  gkyl_create_global_range(cdim, ccells, &cglobal_r);
+
+  // Create decomposition.
+  int cuts[cdim];
+#ifdef GKYL_HAVE_MPI  
+  for (int d=0; d<cdim; d++) {
+    if (app_args.use_mpi)
+      cuts[d] = app_args.cuts[d];
+    else
+      cuts[d] = 1;
+  }
+#else
+  for (int d=0; d<cdim; d++)
+    cuts[d] = 1;
+#endif  
+    
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(cdim, cuts, &cglobal_r);
+
+  // Construct communicator for use in app.
+  struct gkyl_comm *comm;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_gpu && app_args.use_mpi) {
+#ifdef GKYL_HAVE_NCCL
+    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+#else
+    printf(" Using -g and -M together requires NCCL.\n");
+    assert(false);
+#endif
+  } else if (app_args.use_mpi) {
+    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+  } else {
+    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu
+      }
+    );
+  }
+#else
+  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu
+    }
+  );
+#endif
+
+  int my_rank, comm_size;
+  gkyl_comm_get_rank(comm, &my_rank);
+  gkyl_comm_get_size(comm, &comm_size);
+
+  int ncuts = 1;
+  for (int d=0; d<cdim; d++)
+    ncuts *= cuts[d];
+
+  if (ncuts != comm_size) {
+    if (my_rank == 0)
+      fprintf(stderr, "*** Number of ranks, %d, does not match total cuts, %d!\n", comm_size, ncuts);
+    goto mpifinalize;
+  }
+
+  for (int d=0; d<cdim-1; d++) {
+    if (cuts[d] > 1) {
+      if (my_rank == 0)
+        fprintf(stderr, "*** Parallelization only allowed in z. Number of ranks, %d, in direction %d cannot be > 1!\n", cuts[d], d);
+      goto mpifinalize;
+    }
+  }
+
+  // ions
+  struct gkyl_gyrokinetic_species ion = {
+    .name = "ion",
+    .charge = ctx.charge_ion, .mass = ctx.mass_ion,
+    .lower = { -ctx.vpar_max_ion, 0.0},
+    .upper = {  ctx.vpar_max_ion, ctx.mu_max_ion}, 
+    .cells = { NVPAR, NMU },
+    .polarization_density = ctx.n0,
+
+    .projection = {
+      .proj_id = GKYL_PROJ_MAXWELLIAN, 
+      .density = eval_density_ion,
+      .upar = eval_upar_ion,
+      .temp = eval_temp_ion,      
+      .ctx_density = &ctx,
+      .ctx_upar = &ctx,
+      .ctx_temp = &ctx,
+    },
+
+    .collisions =  {
+      .collision_id = GKYL_LBO_COLLISIONS,
+      .ctx = &ctx,
+      .self_nu = eval_nu_ion,
+    },
+    
+    .num_diag_moments = 5,
+    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
+  };
+
+  // field
+  struct gkyl_gyrokinetic_field field = {
+    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .electron_mass = ctx.mass_elc,
+    .electron_charge = ctx.charge_elc,
+    .electron_temp = ctx.Te,
+    .bmag_fac = ctx.B0, 
+    .kperpSq = pow(ctx.kperp, 2.),
+    .fem_parbc = GKYL_FEM_PARPROJ_PERIODIC, 
+  };
+
+  // GK app
+  struct gkyl_gk gk = {
+    .name = "gk_ion_sound_adiabatic_elc_1x2v_p1",
+
+    .cdim = 1, .vdim = 2,
+    .lower = { -ctx.Lz/2.0 },
+    .upper = {  ctx.Lz/2.0 },
+    .cells = { NZ },
+    .poly_order = 1,
+    .basis_type = app_args.basis_type,
+
+    .geometry = {
+      .geometry_id = GKYL_MAPC2P,
+      .world = {0.0, 0.0},
+      .mapc2p = mapc2p, // mapping of computational to physical space
+      .bmag_func = bmag_func, // mapping of computational to physical space
+      .c2p_ctx = &ctx,
+      .bmag_ctx = &ctx
+    },
+
+    .num_periodic_dir = 1,
+    .periodic_dirs = { 0 },
+
+    .num_species = 1,
+    .species = { ion },
+    .field = field,
+
+    .use_gpu = app_args.use_gpu,
+
+    .has_low_inp = true,
+    .low_inp = {
+      .local_range = decomp->ranges[my_rank],
+      .comm = comm
+    }
+  };
+
+  // create app object
+  gkyl_gyrokinetic_app *app = gkyl_gyrokinetic_app_new(&gk);
+
+  // start, end and initial time-step
+  double tcurr = 0.0, tend = ctx.final_time;
+  double dt = tend-tcurr;
+  int nframe = ctx.num_frames;
+  // create trigger for IO
+  struct gkyl_tm_trigger io_trig = { .dt = tend/nframe };
+
+  // initialize simulation
+  gkyl_gyrokinetic_app_apply_ic(app, tcurr);
+  write_data(&io_trig, app, tcurr);
+  gkyl_gyrokinetic_app_calc_field_energy(app, tcurr);
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((tcurr < tend) && (step <= num_steps)) {
+    gkyl_gyrokinetic_app_cout(app, stdout, "Taking time-step at t = %g ...", tcurr);
+    struct gkyl_update_status status = gkyl_gyrokinetic_update(app, dt);
+    gkyl_gyrokinetic_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
+    if (step % 10 == 0) {
+      gkyl_gyrokinetic_app_calc_field_energy(app, tcurr);
+    }
+    if (!status.success) {
+      gkyl_gyrokinetic_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    tcurr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    write_data(&io_trig, app, tcurr);
+
+    step += 1;
+  }
+  gkyl_gyrokinetic_app_calc_field_energy(app, tcurr);
+  gkyl_gyrokinetic_app_write_field_energy(app);
+  gkyl_gyrokinetic_app_stat_write(app);
+  
+  // fetch simulation statistics
+  struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_app_stat(app);
+
+  gkyl_gyrokinetic_app_cout(app, stdout, "\n");
+  gkyl_gyrokinetic_app_cout(app, stdout, "Number of update calls %ld\n", stat.nup);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Number of forward-Euler calls %ld\n", stat.nfeuler);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Number of RK stage-2 failures %ld\n", stat.nstage_2_fail);
+  if (stat.nstage_2_fail > 0) {
+    gkyl_gyrokinetic_app_cout(app, stdout, "Max rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[1]);
+    gkyl_gyrokinetic_app_cout(app, stdout, "Min rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[0]);
+  }  
+  gkyl_gyrokinetic_app_cout(app, stdout, "Number of RK stage-3 failures %ld\n", stat.nstage_3_fail);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Species RHS calc took %g secs\n", stat.species_rhs_tm);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Species collisions RHS calc took %g secs\n", stat.species_coll_tm);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Field RHS calc took %g secs\n", stat.field_rhs_tm);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Species collisional moments took %g secs\n", stat.species_coll_mom_tm);
+  gkyl_gyrokinetic_app_cout(app, stdout, "Updates took %g secs\n", stat.total_tm);
+
+  gkyl_gyrokinetic_app_cout(app, stdout, "Number of write calls %ld,\n", stat.nio);
+  gkyl_gyrokinetic_app_cout(app, stdout, "IO time took %g secs \n", stat.io_tm);
+
+  // simulation complete, free app
+  gkyl_gyrokinetic_app_release(app);
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+
+  mpifinalize:
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Finalize();
+#endif
+  
+  return 0;
+}

--- a/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
@@ -151,6 +151,11 @@ main(int argc, char **argv)
 {
   struct gkyl_app_args app_args = parse_app_args(argc, argv);
 
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Init(&argc, &argv);
+#endif
+
   if (app_args.trace_mem) {
     gkyl_cu_dev_mem_debug_set(true);
     gkyl_mem_debug_set(true);

--- a/regression/rt_gk_lbo_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_1x2v_p1.c
@@ -398,7 +398,7 @@ main(int argc, char **argv)
 
   // Field.
   struct gkyl_gyrokinetic_field field = {
-    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .gkfield_id = GKYL_GK_FIELD_BOLTZMANN,
     .electron_mass = ctx.mass,
     .electron_charge = ctx.charge,
     .electron_temp = ctx.vt,

--- a/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
@@ -415,7 +415,7 @@ main(int argc, char **argv)
 
   // Field.
   struct gkyl_gyrokinetic_field field = {
-    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .gkfield_id = GKYL_GK_FIELD_BOLTZMANN,
     .electron_mass = ctx.mass,
     .electron_charge = ctx.charge,
     .electron_temp = ctx.vt,

--- a/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
@@ -433,7 +433,7 @@ main(int argc, char **argv)
 
   // field
   struct gkyl_gyrokinetic_field field = {
-    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .gkfield_id = GKYL_GK_FIELD_BOLTZMANN,
     .electron_mass = ctx.me,
     .electron_charge = ctx.qe,
     .electron_temp = ctx.Te0,
@@ -443,7 +443,7 @@ main(int argc, char **argv)
 
   // GK app
   struct gkyl_gk gk = {
-    .name = "gk_ltx_adiabatic_elc_1x2v_p1",
+    .name = "gk_ltx_boltz_elc_1x2v_p1",
 
     .cdim = 1, .vdim = 2,
     .lower = { ctx.z_min },

--- a/regression/rt_gk_mirror_boltz_elc_1x2v_p1_nonuniform_nosource.c
+++ b/regression/rt_gk_mirror_boltz_elc_1x2v_p1_nonuniform_nosource.c
@@ -67,13 +67,6 @@ struct gk_mirror_ctx
   double Ti_perp_m;
   double Ti_par_m;
   double cs_m;
-  // Source parameters
-  double NSrcIon;
-  double lineLengthSrcIon;
-  double sigSrcIon;
-  double NSrcFloorIon;
-  double TSrc0Ion;
-  double TSrcFloorIon;
   // Grid parameters
   double vpar_max_ion;
   double mu_max_ion;
@@ -285,53 +278,6 @@ z_xi(double xi, double psi, void *ctx)
   return z;
 }
 
-void
-eval_density_ion_source(double t, const double *GKYL_RESTRICT xn, double *GKYL_RESTRICT fout, void *ctx)
-{
-  struct gk_mirror_ctx *app = ctx;
-  double psi = psi_RZ(app->RatZeq0, 0.0, ctx); // Magnetic flux function psi of field line.
-  double z = z_xi(xn[0], psi, ctx);
-  double Z = Z_psiz(psi, z, ctx); // Cylindrical axial coordinate.
-  double NSrc = app->NSrcIon;
-  double zSrc = app->lineLengthSrcIon;
-  double sigSrc = app->sigSrcIon;
-  double NSrcFloor = app->NSrcFloorIon;
-  if (fabs(Z) <= app->Z_m)
-  {
-    fout[0] = fmax(NSrcFloor, (NSrc / sqrt(2.0 * M_PI * pow(sigSrc, 2))) *
-                                  exp(-1 * pow((z - zSrc), 2) / (2.0 * pow(sigSrc, 2))));
-  }
-  else
-  {
-    fout[0] = 1e-16;
-  }
-}
-
-void
-eval_upar_ion_source(double t, const double *GKYL_RESTRICT xn, double *GKYL_RESTRICT fout, void *ctx)
-{
-  fout[0] = 0.0;
-}
-
-void
-eval_temp_ion_source(double t, const double *GKYL_RESTRICT xn, double *GKYL_RESTRICT fout, void *ctx)
-{
-  struct gk_mirror_ctx *app = ctx;
-  double psi = psi_RZ(app->RatZeq0, 0.0, ctx); // Magnetic flux function psi of field line.
-  double z = z_xi(xn[0], psi, ctx);
-  double sigSrc = app->sigSrcIon;
-  double TSrc0 = app->TSrc0Ion;
-  double Tfloor = app->TSrcFloorIon;
-  if (fabs(z) <= 2.0 * sigSrc)
-  {
-    fout[0] = TSrc0;
-  }
-  else
-  {
-    fout[0] = Tfloor;
-  }
-}
-
 // Ion initial conditions
 void
 eval_density_ion(double t, const double *GKYL_RESTRICT xn, double *GKYL_RESTRICT fout, void *ctx)
@@ -396,7 +342,7 @@ eval_temp_perp_ion(double t, const double *GKYL_RESTRICT xn, double *GKYL_RESTRI
   double z = z_xi(xn[0], psi, ctx);
   double z_m = app->z_m;
   double z_max = app->z_max;
-  if (fabs(z) <= z_m)
+    if (fabs(z) <= z_m)
   {
     fout[0] = (app->Ti_perp_m - app->Ti_perp0) * ((tanh((fabs(z) - z_m * 0.8) * 10 * z_m)) / 2 + 0.5) + app->Ti_perp0;
   }
@@ -641,23 +587,15 @@ create_ctx(void)
   double gamma = 0.124904;
   double Z_m = 0.98;
 
-  // Source parameters
-  double NSrcIon = 3.1715e23 / 8.0;
-  double lineLengthSrcIon = 0.0;
-  double sigSrcIon = Z_m / 4.0;
-  double NSrcFloorIon = 0.05 * NSrcIon;
-  double TSrc0Ion = Ti0 * 1.25;
-  double TSrcFloorIon = TSrc0Ion / 8.0;
-
   // Grid parameters
-  double vpar_max_ion = 20 * vti;
+  double vpar_max_ion = 10 * vti;
   double mu_max_ion = mi * pow(3. * vti, 2.) / (2. * B_p);
   int num_cell_vpar = 64; // Number of cells in the paralell velocity direction 96
   int num_cell_mu = 192;  // Number of cells in the mu direction 192
   int num_cell_z = 128;
   int poly_order = 1;
-  double final_time = 50e-6;
-  int num_frames = 50;
+  double final_time = 100e-6;
+  int num_frames = 100;
 
   // Bananna tip info. Hardcoad to avoid dependency on ctx
   double B_bt = 1.058278;
@@ -721,12 +659,6 @@ create_ctx(void)
     .Ti_perp_m = Ti_perp_m,
     .Ti_par_m = Ti_par_m,
     .cs_m = cs_m,
-    .NSrcIon = NSrcIon,
-    .lineLengthSrcIon = lineLengthSrcIon,
-    .sigSrcIon = sigSrcIon,
-    .NSrcFloorIon = NSrcFloorIon,
-    .TSrc0Ion = TSrc0Ion,
-    .TSrcFloorIon = TSrcFloorIon,
     .vpar_max_ion = vpar_max_ion,
     .mu_max_ion = mu_max_ion,
     .num_cell_z = num_cell_z,
@@ -804,26 +736,12 @@ int main(int argc, char **argv)
       .ctx_temppar = &ctx,
       .temppar = eval_temp_par_ion,      
       .ctx_tempperp = &ctx,
-      .tempperp = eval_temp_perp_ion,   
+      .tempperp = eval_temp_perp_ion,    
     },
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
       .ctx = &ctx,
       .self_nu = evalNuIon,
-    },
-    .source = {
-      .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
-      .num_sources = 1,
-      .projection[0] = {
-        .proj_id = GKYL_PROJ_MAXWELLIAN, 
-        .ctx_density = &ctx,
-        .density = eval_density_ion_source,
-        .ctx_upar = &ctx,
-        .upar= eval_upar_ion_source,
-        .ctx_temp = &ctx,
-        .temp = eval_temp_ion_source,      
-      }, 
     },
     .bcx = {
       .lower={.type = GKYL_SPECIES_GK_SHEATH,},
@@ -833,7 +751,7 @@ int main(int argc, char **argv)
     .diag_moments = {"M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp"},
   };
   struct gkyl_gyrokinetic_field field = {
-    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .gkfield_id = GKYL_GK_FIELD_BOLTZMANN,
     .electron_mass = ctx.me,
     .electron_charge = ctx.qe,
     .electron_temp = ctx.Te0,
@@ -841,7 +759,7 @@ int main(int argc, char **argv)
     .fem_parbc = GKYL_FEM_PARPROJ_NONE,
   };
   struct gkyl_gk gk = {  // GK app
-    .name = "gk_mirror_adiabatic_elc_1x2v_p1_nonuniform_20vt",
+    .name = "gk_mirror_boltz_elc_1x2v_p1_nonuniform_nosource",
     .cdim = 1,
     .vdim = 2,
     .lower = {ctx.z_min},

--- a/regression/rt_gk_mirror_boltz_elc_1x2v_p1_uniform.c
+++ b/regression/rt_gk_mirror_boltz_elc_1x2v_p1_uniform.c
@@ -850,7 +850,7 @@ int main(int argc, char **argv)
   };
 
   struct gkyl_gyrokinetic_field field = {
-    .gkfield_id = GKYL_GK_FIELD_ADIABATIC,
+    .gkfield_id = GKYL_GK_FIELD_BOLTZMANN,
     .electron_mass = ctx.me,
     .electron_charge = ctx.qe,
     .electron_temp = ctx.Te0,
@@ -859,7 +859,7 @@ int main(int argc, char **argv)
   };
 
   struct gkyl_gk gk = {  // GK app
-    .name = "gk_mirror_adiabatic_elc_1x2v_p1_uniform_comm",
+    .name = "gk_mirror_boltz_elc_1x2v_p1_uniform",
     .cdim = 1,
     .vdim = 2,
     .lower = {ctx.z_min},

--- a/regression/rt_gk_sheath_1x2v_p1.c
+++ b/regression/rt_gk_sheath_1x2v_p1.c
@@ -343,13 +343,10 @@ main(int argc, char **argv)
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)
-  {
     MPI_Init(&argc, &argv);
-  }
 #endif
 
-  if (app_args.trace_mem) 
-  {
+  if (app_args.trace_mem) {
     gkyl_cu_dev_mem_debug_set(true);
     gkyl_mem_debug_set(true);
   }
@@ -363,9 +360,7 @@ main(int argc, char **argv)
   int nrank = 1; // Number of processors in simulation.
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)
-  {
     MPI_Comm_size(MPI_COMM_WORLD, &nrank);
-  }
 #endif  
 
   // Create global range.
@@ -377,22 +372,15 @@ main(int argc, char **argv)
   // Create decomposition.
   int cuts[cdim];
 #ifdef GKYL_HAVE_MPI  
-  for (int d = 0; d < cdim; d++)
-  {
+  for (int d=0; d<cdim; d++) {
     if (app_args.use_mpi)
-    {
       cuts[d] = app_args.cuts[d];
-    }
     else
-    {
       cuts[d] = 1;
-    }
   }
 #else
-  for (int d = 0; d < cdim; d++)
-  {
+  for (int d=0; d<cdim; d++)
     cuts[d] = 1;
-  }
 #endif  
     
   struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(cdim, cuts, &cglobal_r);
@@ -400,11 +388,9 @@ main(int argc, char **argv)
   // Construct communicator for use in app.
   struct gkyl_comm *comm;
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_gpu && app_args.use_mpi)
-  {
+  if (app_args.use_gpu && app_args.use_mpi) {
 #ifdef GKYL_HAVE_NCCL
-    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp)
-      {
+    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
         .mpi_comm = MPI_COMM_WORLD,
         .decomp = decomp
       }
@@ -413,62 +399,45 @@ main(int argc, char **argv)
     printf(" Using -g and -M together requires NCCL.\n");
     assert(0 == 1);
 #endif
-  }
-  else if (app_args.use_mpi) 
-  {
-    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp)
-      {
+  } else if (app_args.use_mpi) {
+    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
         .mpi_comm = MPI_COMM_WORLD,
         .decomp = decomp
       }
     );
-  }
-  else
-  {
-    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
-      {
+  } else {
+    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
         .decomp = decomp,
         .use_gpu = app_args.use_gpu
       }
     );
   }
 #else
-  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
-    {
+  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
       .decomp = decomp,
       .use_gpu = app_args.use_gpu
     }
   );
 #endif
 
-  int my_rank;
+  int my_rank, comm_size;
   gkyl_comm_get_rank(comm, &my_rank);
-  int comm_size;
   gkyl_comm_get_size(comm, &comm_size);
 
   int ncuts = 1;
-  for (int d = 0; d < cdim; d++)
-  {
+  for (int d=0; d<cdim; d++)
     ncuts *= cuts[d];
-  }
 
-  if (ncuts != comm_size)
-  {
+  if (ncuts != comm_size) {
     if (my_rank == 0)
-    {
       fprintf(stderr, "*** Number of ranks, %d, does not match total cuts, %d!\n", comm_size, ncuts);
-    }
     goto mpifinalize;
   }
 
-  for (int d = 0; d < cdim - 1; d++)
-  {
-    if (cuts[d] > 1)
-    {
+  for (int d=0; d<cdim-1; d++) {
+    if (cuts[d] > 1) {
       if (my_rank == 0)
-      {
         fprintf(stderr, "*** Parallelization only allowed in z. Number of ranks, %d, in direction %d cannot be > 1!\n", cuts[d], d);
-      }
       goto mpifinalize;
     }
   }
@@ -609,7 +578,7 @@ main(int argc, char **argv)
 
     .has_low_inp = true,
     .low_inp = {
-      .local_range = decomp -> ranges[my_rank],
+      .local_range = decomp->ranges[my_rank],
       .comm = comm
     }
   };
@@ -696,9 +665,7 @@ main(int argc, char **argv)
   mpifinalize:
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)
-  {
     MPI_Finalize();
-  }
 #endif
 
   return 0;

--- a/zero/gkyl_eqn_type.h
+++ b/zero/gkyl_eqn_type.h
@@ -22,9 +22,10 @@ enum gkyl_gkmodel_id {
 // Identifiers for specific gyrokinetic field object types
 enum gkyl_gkfield_id {
   GKYL_GK_FIELD_ES = 0, // Electrostatic GK. This is default
-  GKYL_GK_FIELD_ADIABATIC = 1, // Adiabatic electrons GK field, phi = phi_sheath + (T_e/e)*ln(n_i/n_is)
-  GKYL_GK_FIELD_ES_IWL = 2, // Inner-wall limited ES.
-  GKYL_GK_FIELD_EM = 3, // Electromagnetic GK
+  GKYL_GK_FIELD_BOLTZMANN = 1, // GK Boltzmann, isothermal electrons, phi = phi_sheath + (T_e/e)*ln(n_i/n_is)
+  GKYL_GK_FIELD_ADIABATIC = 2, // GK field with an adiabatic species.
+  GKYL_GK_FIELD_ES_IWL = 3, // Inner-wall limited ES.
+  GKYL_GK_FIELD_EM = 4, // Electromagnetic GK
 };
 
 // Identifiers for specific field object types


### PR DESCRIPTION
- Rename the GK_FIELD_ADIABATIC option to GK_FIELD_BOLTZMANN, since in 2 papers we've referred to that as the Boltzmann electron model.
- Implement a new GK_FIELD_ADIABATIC, only in 1x for now, in which the electrons are not evolved and they simply contribute to the charge density in the Poisson equation with n_e = n_e0*(1 + e*phi/T_e).
- Tested GK_FIELD_ADIABATIC (one CPU and GPU) with one of the ion acoustic Landau damping tests in the GkLBO paper and it qualitatively looks very similar, and quantitatively is only 12% off (but I didn't try to do resolution convergence).

This also fixes a bug for 1x simulations with geometry in that the polarization weight was not multiplied by jacobgeo.