### PR TITLE
Added dynvec for correct lte all moms status

### DIFF
--- a/apps/gkyl_vlasov.h
+++ b/apps/gkyl_vlasov.h
@@ -442,6 +442,14 @@ void gkyl_vlasov_app_write_integrated_mom(gkyl_vlasov_app *app);
 void gkyl_vlasov_app_write_integrated_L2_f(gkyl_vlasov_app *app);
 
 /**
+ * Write integrated correct lte status of the species distribution function to file. Correct
+ * lte status is appended to the same file.
+ * 
+ * @param app App object.
+ */
+void gkyl_vlasov_app_write_lte_corr_status(gkyl_vlasov_app *app);
+
+/**
  * Write field energy to file. Field energy data is appended to the
  * same file.
  * 

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -172,6 +172,8 @@ struct vm_bgk_collisions {
   // Correction updater for insuring LTE distribution has desired LTE (n, V_drift, T/m) moments
   bool correct_all_moms; // boolean if we are correcting all the moments
   struct gkyl_vlasov_lte_correct *corr_lte; 
+  gkyl_dynvec corr_stat;
+  bool is_first_corr_status_write_call;
 
   struct gkyl_bgk_collisions *up_bgk; // BGK updater (also computes stable timestep)
 };
@@ -567,6 +569,7 @@ void vm_species_moment_init(struct gkyl_vlasov_app *app, struct vm_species *s,
 /**
  * Calculate moment, given distribution function @a fin.
  *
+ * @param sm vm species moment
  * @param phase_rng Phase-space range
  * @param conf_rng Config-space range
  * @param fin Input distribution function array

--- a/regression/rt_neut_sr_bgk_sod_shock_1x1v_p2.c
+++ b/regression/rt_neut_sr_bgk_sod_shock_1x1v_p2.c
@@ -166,6 +166,7 @@ main(int argc, char **argv)
 
   gkyl_vlasov_app_write(app, tcurr, 1);
   gkyl_vlasov_app_calc_mom(app); gkyl_vlasov_app_write_mom(app, tcurr, 1);
+  gkyl_vlasov_app_write_lte_corr_status(app);
   gkyl_vlasov_app_stat_write(app);
 
   // fetch simulation statistics

--- a/zero/gkyl_vlasov_lte_correct.h
+++ b/zero/gkyl_vlasov_lte_correct.h
@@ -32,6 +32,7 @@ struct gkyl_vlasov_lte_correct_inp {
 struct gkyl_vlasov_lte_correct_status {
   bool iter_converged; // true if iterations converged
   int num_iter; // number of iterations for the correction
+  double error[5]; // error in each moment
 };  
 
 /**


### PR DESCRIPTION
Added dynvec for correct-lte all-moments which gives, number iter, status of convergence, and 5 error components for [n, u, T/m]

Note: The conversion of the status to a dynvec is done by hand at the moment @ammarhakim if you have a different way to do this before merge please comment. https://github.com/ammarhakim/gkylzero/compare/main...lte_corr_dynvec#diff-5e12ac2b111acab49c53e4b55c5ebdcbbd481f2ce7357eec1e1336caf1bec0d1R131