### PR TITLE
Lbo bug fix

### DIFF
--- a/apps/gk_species_lbo.c
+++ b/apps/gk_species_lbo.c
@@ -31,7 +31,7 @@ gk_species_lbo_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, stru
   if (s->info.collisions.normNu) {
     lbo->normNu = true;
     lbo->self_nu_fac = s->info.collisions.self_nu_fac;
-    double tpar_min = (s->info.mass/6.0)*s->grid.dx[cdim];
+    double tpar_min = (s->info.mass/6.0)*s->grid.dx[cdim]*s->grid.dx[cdim];
     double tperp_min = (s->info.collisions.bmag_mid/3.0)*s->grid.dx[cdim+1];
     lbo->vtsq_min = (tpar_min + 2*tperp_min)/(3*s->info.mass);
     double nuFrac = s->info.collisions.nuFrac ? s->info.collisions.nuFrac : 1.0;

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -782,7 +782,7 @@ gkyl_gyrokinetic_app_write_coll_mom(gkyl_gyrokinetic_app* app, int sidx, double 
   const struct gkyl_array *fin[app->num_species];
   gk_species_lbo_moms(app, gk_s, &gk_s->lbo, gk_s->f);
   if (gk_s->lbo.num_cross_collisions)
-    gk_species_lbo_moms(app, gk_s, &gk_s->lbo, gk_s->f);
+    gk_species_lbo_cross_moms(app, gk_s, &gk_s->lbo, gk_s->f);
 
   // copy data from device to host before writing it out
   if (app->use_gpu) {


### PR DESCRIPTION
Two fixes for the LBO. First, the cross moments weren't being accounted for when writing out the moments (nu_sum and nu_prim_moms). Second the tpar_min was missing a factor of dvpar.
Plotted here is nu_sum for the "square" species at the final time and the "bump" species at the final and initial times for before any changes, only the change in the write function, and both fixes from the rt_gk_lbo_relax_varnu_1x2v_p1 regression test. The change in tpar_min has no effect on nu as seen by nu_sum being the same for both "only_write_changed" and "vtsq_min_fixed".
The "square" species at t=0 still has nu_sum=0. This looks like it is some subtlety with the write that I haven't figured out as it is nonzero even if only one step is taken.
![bump_at_t=0_nusum](https://github.com/ammarhakim/gkylzero/assets/146042713/c37f5955-0b7a-4506-8b1c-85eea258b2f0)
![bump_at_t=100_nusum](https://github.com/ammarhakim/gkylzero/assets/146042713/3f2bf51e-52d1-479a-bfad-0f3ee9df3370)
![squared_at_t=100_nusum](https://github.com/ammarhakim/gkylzero/assets/146042713/e2f0f482-bc2e-4f75-bbed-c82bd6da0d1a)
