### PR TITLE
Corner syncs added to communicator system

### DIFF
--- a/apps/gkyl_moment_priv.h
+++ b/apps/gkyl_moment_priv.h
@@ -284,11 +284,6 @@ void calc_integ_quant(const struct gkyl_wv_eqn *eqn, double vol,
 // Check array "q" for nans
 bool check_for_nans(const struct gkyl_array *q, struct gkyl_range update_rng);
 
-// Apply periodic BCs to array "f" in direction "dir"
-void moment_apply_periodic_bc(const gkyl_moment_app *app,
-  struct gkyl_array *bc_buffer, int dir,
-  struct gkyl_array *f);
-
 // Apply periodic BCs to corner cells of "f" (ONLY WORKS IN 2D)
 void moment_apply_periodic_corner_sync_2d(const gkyl_moment_app *app,
   struct gkyl_array *f);

--- a/apps/mom_field.c
+++ b/apps/mom_field.c
@@ -221,8 +221,6 @@ moment_field_apply_bc(gkyl_moment_app *app, double tcurr,
   struct timespec wst = gkyl_wall_clock();
   
   int num_periodic_dir = app->num_periodic_dir, ndim = app->ndim, is_non_periodic[3] = {1, 1, 1};
-  gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, num_periodic_dir,
-    app->periodic_dirs, f);
   
   for (int d=0; d<num_periodic_dir; ++d)
     is_non_periodic[app->periodic_dirs[d]] = 0;
@@ -241,7 +239,11 @@ moment_field_apply_bc(gkyl_moment_app *app, double tcurr,
           field->bc_buffer, d, field->lower_bc[d], field->upper_bc[d], f);
     }
 
+  // sync interior ghost cells
   gkyl_comm_array_sync(app->comm, &app->local, &app->local_ext, f);
+  // sync periodic ghost cells
+  gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, num_periodic_dir,
+    app->periodic_dirs, f);
 
   app->stat.field_bc_tm += gkyl_time_diff_now_sec(wst);  
 }

--- a/apps/mom_priv.c
+++ b/apps/mom_priv.c
@@ -36,18 +36,6 @@ check_for_nans(const struct gkyl_array *q, struct gkyl_range update_rng)
   return false;
 }
 
-// apply periodic BCs
-void
-moment_apply_periodic_bc(const gkyl_moment_app *app, struct gkyl_array *bc_buffer,
-  int dir, struct gkyl_array *f)
-{
-  gkyl_array_copy_to_buffer(bc_buffer->data, f,   &(app->skin_ghost.lower_skin[dir]));
-  gkyl_array_copy_from_buffer(f, bc_buffer->data, &(app->skin_ghost.upper_ghost[dir]));
-
-  gkyl_array_copy_to_buffer(bc_buffer->data, f,   &(app->skin_ghost.upper_skin[dir]));
-  gkyl_array_copy_from_buffer(f, bc_buffer->data, &(app->skin_ghost.lower_ghost[dir]));
-}
-
 void
 moment_apply_periodic_corner_sync_2d(const gkyl_moment_app *app, struct gkyl_array *f)
 {

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -258,8 +258,6 @@ moment_species_apply_bc(gkyl_moment_app *app, double tcurr,
   for (int d=0; d<num_periodic_dir; ++d)
     is_non_periodic[app->periodic_dirs[d]] = 0;
 
-  if (ndim == 2)
-    moment_apply_periodic_corner_sync_2d(app, f); // TODO: SHOULD BE IN PER_SYNC
   for (int d=0; d<ndim; ++d)
     if (is_non_periodic[d]) {
       // handle non-wedge BCs

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -252,9 +252,6 @@ moment_species_apply_bc(gkyl_moment_app *app, double tcurr,
   
   int num_periodic_dir = app->num_periodic_dir, ndim = app->ndim, is_non_periodic[3] = {1, 1, 1};
 
-  gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, num_periodic_dir,
-    app->periodic_dirs, f);
-  
   for (int d=0; d<num_periodic_dir; ++d)
     is_non_periodic[app->periodic_dirs[d]] = 0;
 
@@ -272,7 +269,11 @@ moment_species_apply_bc(gkyl_moment_app *app, double tcurr,
           sp->bc_buffer, d, sp->lower_bc[d], sp->upper_bc[d], f);
     }
 
+  // sync interior ghost cells
   gkyl_comm_array_sync(app->comm, &app->local, &app->local_ext, f);
+  // sync periodic ghost cells
+  gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, num_periodic_dir,
+    app->periodic_dirs, f);
 
   app->stat.species_bc_tm += gkyl_time_diff_now_sec(wst);
 }

--- a/regression/rt_10m_burch_grad_closure.c
+++ b/regression/rt_10m_burch_grad_closure.c
@@ -468,7 +468,8 @@ main(int argc, char **argv)
     comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
       {
         .decomp = decomp,
-        .use_gpu = app_args.use_gpu
+        .use_gpu = app_args.use_gpu,
+        .sync_corners = true
       }
     );
   }
@@ -476,7 +477,8 @@ main(int argc, char **argv)
   comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
     {
       .decomp = decomp,
-      .use_gpu = app_args.use_gpu
+      .use_gpu = app_args.use_gpu,
+      .sync_corners = true
     }
   );
 #endif

--- a/regression/rt_10m_burch_grad_closure.c
+++ b/regression/rt_10m_burch_grad_closure.c
@@ -458,7 +458,8 @@ main(int argc, char **argv)
     comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp)
       {
         .mpi_comm = MPI_COMM_WORLD,
-        .decomp = decomp
+        .decomp = decomp,
+        .sync_corners = true
       }
     );
   }

--- a/unit/ctest_range.c
+++ b/unit/ctest_range.c
@@ -1100,6 +1100,43 @@ void test_extend(void)
   TEST_CHECK( ext_range.upper[1] == 10 );
 }
 
+static void
+test_perp_extend(void)
+{
+  int lo[] = {1, 1}, up[] = { 4, 8 };
+  
+  struct gkyl_range range;
+  gkyl_range_init(&range, 2, lo, up);
+
+  int elo[] = { 1, 2 }, eup[] = { 3, 4 };
+
+  do {
+    struct gkyl_range ext_range;
+    gkyl_range_perp_extend(&ext_range, 0, &range, elo, eup);
+    
+    TEST_CHECK( ext_range.volume == (4+0)*(8+2+4) );
+    
+    TEST_CHECK( ext_range.lower[0] == 1 );
+    TEST_CHECK( ext_range.upper[0] == 4 );
+    
+    TEST_CHECK( ext_range.lower[1] == 1-2 );
+    TEST_CHECK( ext_range.upper[1] == 8+4 );
+  } while (0);
+
+  do {
+    struct gkyl_range ext_range;
+    gkyl_range_perp_extend(&ext_range, 1, &range, elo, eup);
+    
+    TEST_CHECK( ext_range.volume == (4+1+3)*8 );
+    
+    TEST_CHECK( ext_range.lower[0] == 1-1 );
+    TEST_CHECK( ext_range.upper[0] == 4+3 );
+    
+    TEST_CHECK( ext_range.lower[1] == 1 );
+    TEST_CHECK( ext_range.upper[1] == 8 );
+  } while (0);  
+}
+
 // CUDA specific tests
 #ifdef GKYL_HAVE_CUDA
 
@@ -1158,6 +1195,7 @@ TEST_LIST = {
   { "intersect_2", test_intersect_2 },
   { "sub_intersect", test_sub_intersect },
   { "extend", test_extend },
+  { "perp_extend", test_perp_extend },  
 #ifdef GKYL_HAVE_CUDA
   { "cu_range", test_cu_range },
 #endif  

--- a/unit/ctest_rect_decomp.c
+++ b/unit/ctest_rect_decomp.c
@@ -399,6 +399,38 @@ test_rect_decomp_per_2d_2(void)
 }
 
 void
+test_rect_decomp_per_2d_corner(void)
+{
+  struct gkyl_range range;
+  gkyl_range_init(&range, 2, (int[]) { 1, 2 }, (int[]) { 100, 100 });
+  
+  int cuts[] = { 1, 1 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(2, cuts, &range);
+
+  struct gkyl_range crange;
+  gkyl_range_init_from_shape(&crange, 2, cuts);  
+
+  struct gkyl_range_iter iter;
+
+  gkyl_range_iter_init(&iter, &crange);
+  while ( gkyl_range_iter_next(&iter) ) {
+    
+    for (int d=0; d<range.ndim; ++d) {
+      struct gkyl_rect_decomp_neigh *neigh = gkyl_rect_decomp_calc_periodic_neigh(decomp,
+        d, true, gkyl_range_idx(&crange, iter.idx));
+
+      if (is_on_dir_edge(range.ndim, d, iter.idx, cuts)) {
+        TEST_CHECK( neigh->num_neigh == 1 );
+      }
+      
+      gkyl_rect_decomp_neigh_release(neigh);
+    }
+  }
+
+  gkyl_rect_decomp_release(decomp);
+}
+
+void
 test_rect_decomp_per_3d(void)
 {
   struct gkyl_range range;

--- a/unit/ctest_rect_decomp.c
+++ b/unit/ctest_rect_decomp.c
@@ -404,7 +404,7 @@ test_rect_decomp_per_2d_corner(void)
   struct gkyl_range range;
   gkyl_range_init(&range, 2, (int[]) { 1, 2 }, (int[]) { 100, 100 });
   
-  int cuts[] = { 1, 1 };
+  int cuts[] = { 2, 2 };
   struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(2, cuts, &range);
 
   struct gkyl_range crange;
@@ -420,7 +420,7 @@ test_rect_decomp_per_2d_corner(void)
         d, true, gkyl_range_idx(&crange, iter.idx));
 
       if (is_on_dir_edge(range.ndim, d, iter.idx, cuts)) {
-        TEST_CHECK( neigh->num_neigh == 1 );
+        TEST_CHECK( neigh->num_neigh == 2 ); // each domain has 2 neighbors
       }
       
       gkyl_rect_decomp_neigh_release(neigh);
@@ -529,6 +529,8 @@ TEST_LIST = {
   { "rect_decomp_per_2d", test_rect_decomp_per_2d },
   { "rect_decomp_per_2d_2", test_rect_decomp_per_2d_2 },
   { "rect_decomp_per_3d", test_rect_decomp_per_3d },
+
+  { "rect_decomp_per_2d_corner", test_rect_decomp_per_2d_corner },
 
   { "rect_decomp_2d_2v", test_rect_decomp_2d_2v },
 

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -655,16 +655,7 @@ mpi_n4_per_sync_corner_2d(void)
   gkyl_range_iter_init(&iter, &local_ext);
   while (gkyl_range_iter_next(&iter)) {
     const double *d = gkyl_array_cfetch(arr, gkyl_range_idx(&local_ext, iter.idx));
-
-    if (
-      ((iter.idx[0] == 0) && (iter.idx[1] == 0)) ||
-      ((iter.idx[0] == 0) && (iter.idx[1] == 11)) ||
-      ((iter.idx[0] == 11) && (iter.idx[1] == 0)) ||
-      ((iter.idx[0] == 11) && (iter.idx[1] == 11))
-      ) {
-    }
-    else
-      TEST_CHECK( d[0] == 1.5 );
+    TEST_CHECK( d[0] == 1.5 );
   }
 
   gkyl_rect_decomp_release(decomp);

--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -560,7 +560,7 @@ mpi_n2_per_sync_2d_tests(int *cuts, int num_per_dirs, int *per_dirs)
 
   // Redefine local_ext_x so it's local shifted in the right direction
   // so it covers the ghost cells of interest.
-  int decomp_dir = cuts[0]>1? 0 : 1;
+  int decomp_dir = cuts[0] > 1 ? 0 : 1;
   int delta[] = {0, 0};
   delta[decomp_dir] = 2*rank-1;
   struct gkyl_range local_ext_x_shifted;
@@ -609,6 +609,62 @@ mpi_n2_per_sync_2d_tests(int *cuts, int num_per_dirs, int *per_dirs)
 	}
       }
     }
+  }
+
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_array_release(arr);
+}
+
+static void
+mpi_n4_per_sync_corner_2d(void)
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 4) return;
+  
+  struct gkyl_range range;
+  gkyl_range_init(&range, 2, (int[]) { 1, 1 }, (int[]) { 10, 10 });
+
+  int cuts[] = { 2, 2 };
+  struct gkyl_rect_decomp *decomp =
+    gkyl_rect_decomp_new_from_cuts(range.ndim, cuts, &range);
+
+  struct gkyl_comm *comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .decomp = decomp,
+      .mpi_comm = MPI_COMM_WORLD,
+      .sync_corners = true
+    }
+  );
+
+  int rank;
+  gkyl_comm_get_rank(comm, &rank);
+
+  int nghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&decomp->ranges[rank], nghost, &local_ext, &local);
+
+
+  struct gkyl_array *arr = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
+  gkyl_array_clear_range(arr, 1.5, &local);
+
+  gkyl_comm_array_sync(comm, &local, &local_ext, arr);
+  gkyl_comm_array_per_sync(comm, &local, &local_ext, 2, (int[]) { 0, 1 }, arr);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local_ext);
+  while (gkyl_range_iter_next(&iter)) {
+    const double *d = gkyl_array_cfetch(arr, gkyl_range_idx(&local_ext, iter.idx));
+
+    if (
+      ((iter.idx[0] == 0) && (iter.idx[1] == 0)) ||
+      ((iter.idx[0] == 0) && (iter.idx[1] == 11)) ||
+      ((iter.idx[0] == 11) && (iter.idx[1] == 0)) ||
+      ((iter.idx[0] == 11) && (iter.idx[1] == 11))
+      ) {
+    }
+    else
+      TEST_CHECK( d[0] == 1.5 );
   }
 
   gkyl_rect_decomp_release(decomp);
@@ -1004,17 +1060,24 @@ mpi_bcast_2d()
 TEST_LIST = {
   {"mpi_1", mpi_1},
   {"mpi_allreduce", mpi_allreduce},
+  
   {"mpi_n2_allgather_1d", mpi_n2_allgather_1d},
   {"mpi_n4_allgather_2d", mpi_n4_allgather_2d},
+  
   {"mpi_n2_sync_1d", mpi_n2_sync_1d},
   {"mpi_n4_sync_2d_no_corner", mpi_n4_sync_2d_no_corner },
   {"mpi_n4_sync_2d_use_corner", mpi_n4_sync_2d_use_corner},
   {"mpi_n2_sync_1x1v", mpi_n4_sync_1x1v },
+  
   {"mpi_n1_per_sync_2d", mpi_n1_per_sync_2d },
   {"mpi_n2_per_sync_2d", mpi_n2_per_sync_2d },
+  {"mpi_n4_per_sync_corner_2d", mpi_n4_per_sync_corner_2d },
+  
   {"mpi_n2_array_send_irecv_1d", mpi_n2_array_send_irecv_1d},
   {"mpi_n2_array_isend_irecv_2d", mpi_n2_array_isend_irecv_2d},
+  
   {"mpi_n4_multicomm_2d", mpi_n4_multicomm_2d},
+  
   {"mpi_bcast_1d", mpi_bcast_1d},
   {"mpi_bcast_2d", mpi_bcast_2d},
   {NULL, NULL},

--- a/zero/gkyl_comm.h
+++ b/zero/gkyl_comm.h
@@ -60,7 +60,8 @@ typedef int (*gkyl_array_sync_t)(struct gkyl_comm *comm,
 
 // "Synchronize" @a array across the periodic directions
 typedef int (*gkyl_array_per_sync_t)(struct gkyl_comm *comm,
-  const struct gkyl_range *local, const struct gkyl_range *local_ext,
+  const struct gkyl_range *local,
+  const struct gkyl_range *local_ext,
   int nper_dirs, const int *per_dirs,
   struct gkyl_array *array);
 
@@ -118,11 +119,11 @@ struct gkyl_comm {
   gkyl_array_bcast_t gkyl_array_bcast; // broadcast array to other processes.
   gkyl_array_sync_t gkyl_array_sync; // sync array.
   gkyl_array_per_sync_t gkyl_array_per_sync; // sync array in periodic dirs.
+
   barrier_t barrier; // barrier.
 
   gkyl_array_write_t gkyl_array_write; // array output
   gkyl_array_read_t gkyl_array_read; // array input
-
 
   extend_comm_t extend_comm; // extend communcator
   split_comm_t split_comm; // split communicator.

--- a/zero/gkyl_comm_priv.h
+++ b/zero/gkyl_comm_priv.h
@@ -41,6 +41,35 @@ skin_ghost_ranges_init(struct skin_ghost_ranges *sgr,
 #undef G_MAX
 }
 
+// Create ghost and skin sub-ranges given a parent range: includes
+// corners
+static void
+skin_ghost_ranges_with_corners_init(struct skin_ghost_ranges *sgr,
+  const struct gkyl_range *parent, const int *ghost)
+{
+#define G_MAX(a,b) (a)>(b)?(a):(b)
+  
+  int ndim = parent->ndim;
+  long max_vol = 0;
+    
+  for (int d=0; d<ndim; ++d) {
+    gkyl_skin_ghost_with_corners_ranges(&sgr->lower_skin[d], &sgr->lower_ghost[d],
+      d, GKYL_LOWER_EDGE, parent, ghost);
+
+    max_vol = G_MAX(max_vol, sgr->lower_skin[d].volume);
+    max_vol = G_MAX(max_vol, sgr->lower_ghost[d].volume);
+    
+    gkyl_skin_ghost_with_corners_ranges(&sgr->upper_skin[d], &sgr->upper_ghost[d],
+      d, GKYL_UPPER_EDGE, parent, ghost);
+
+    max_vol = G_MAX(max_vol, sgr->upper_skin[d].volume);
+    max_vol = G_MAX(max_vol, sgr->upper_ghost[d].volume);
+  }
+
+  sgr->max_vol = max_vol;
+#undef G_MAX
+}
+
 // define long -> skin_ghost_ranges ...
 #define i_key long
 #define i_val struct skin_ghost_ranges

--- a/zero/gkyl_range.h
+++ b/zero/gkyl_range.h
@@ -297,9 +297,36 @@ void gkyl_range_upper_skin(struct gkyl_range* srng,
   const struct gkyl_range* range, int dir, int nskin);
 
 /**
- * Create ghost and skin sub-ranges given parent range. The skin and
- * ghost ranges are sub-ranges of the parent range and DO NOT include
- * corners.
+ * Create ghost and skin sub-ranges given parent *extended* range. The
+ * skin and ghost ranges are sub-ranges of the parent range and DO NOT
+ * include corners. For 2D, dir=1 and nghost = { 1, 1} skin and ghost
+ * are the cells marked below ("S"kin, "G"ghost)
+ *
+ * Lower-edge:
+ * +--+--+--+
+ * |  |  |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |  |  |  |
+ * +--+--+--+
+ *
+ * Upper-edge:
+ * +--+--+--+
+ * |  |  |  |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |  |  |
+ * +--+--+--+
  *
  * @param skin On output, skin range
  * @param ghost On outout, ghost range
@@ -309,6 +336,48 @@ void gkyl_range_upper_skin(struct gkyl_range* srng,
  * @param nghost Number of ghost cells in 'dir' are nghost[dir]
  */
 void gkyl_skin_ghost_ranges(struct gkyl_range *skin, struct gkyl_range *ghost,
+  int dir, enum gkyl_edge_loc edge, const struct gkyl_range *parent, const int *nghost);
+
+/**
+ * Create ghost and skin sub-ranges given parent *extended* range. The
+ * skin and ghost ranges are sub-ranges of the parent range. The
+ * ranges include the corners.  For 2D, dir=1 and nghost = { 1, 1}
+ * skin and ghost are the cells marked below ("S"kin, "G"ghost)
+ *
+ * Lower-edge:
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ * |G |S |  |
+ * +--+--+--+
+ *
+ * Upper-edge:
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ * |  |S |G |
+ * +--+--+--+
+ *
+ * @param skin On output, skin range
+ * @param ghost On outout, ghost range
+ * @param dir Direction in which skin/ghost are computed
+ * @param edge Edge on which skin/ghost are computed
+ * @param parent Range for which skin/ghost are computed
+ * @param nghost Number of ghost cells in 'dir' are nghost[dir]
+ */
+void gkyl_skin_ghost_with_corners_ranges(struct gkyl_range *skin, struct gkyl_range *ghost,
   int dir, enum gkyl_edge_loc edge, const struct gkyl_range *parent, const int *nghost);
 
 /**

--- a/zero/gkyl_range.h
+++ b/zero/gkyl_range.h
@@ -252,7 +252,22 @@ void gkyl_range_shorten_from_below(struct gkyl_range *rng,
  * @param elo Lower in dir is reduced by elo[dir]
  * @param eup Upper in dir is increased by eup[dir]
  */
-void gkyl_range_extend(struct gkyl_range *erng,
+void gkyl_range_extend(struct gkyl_range *erng, const struct gkyl_range *rng,
+  const int *elo, const int *eup);
+
+/**
+ * Return a new range that is an extension of the input range. The
+ * lower index in dir is reduced by elo[dir] and upper index increased
+ * by eup[dir]. This method only extends the range in the directions
+ * other than the input @a dir.
+ *
+ * @param erng Extended range
+ * @param dir Direction to skip extension
+ * @param rng Range to extend
+ * @param elo Lower in dir is reduced by elo[dir]
+ * @param eup Upper in dir is increased by eup[dir]
+ */
+void gkyl_range_perp_extend(struct gkyl_range *erng, int dir,
   const struct gkyl_range* rng, const int *elo, const int *eup);
 
 /**

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -360,6 +360,9 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
           struct gkyl_range neigh_shift;
           gkyl_range_shift(&neigh_shift, &mpi->decomp->ranges[nid], delta);
 
+          /* struct gkyl_range neigh_shift_ext; */
+          /* gkyl_range_extend(&neigh_shift_ext, &neigh_shift, elo, eup); */
+
           int isrecv = gkyl_sub_range_intersect(
             &mpi->recv[nridx].range, local_ext, &neigh_shift);
           size_t recv_vol = array->esznc*mpi->recv[nridx].range.volume;
@@ -399,7 +402,7 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
           gkyl_range_extend(&neigh_shift_ext, &neigh_shift, elo, eup);
           int issend = gkyl_sub_range_intersect(
             &mpi->send[nsidx].range, local, &neigh_shift_ext);
-          
+
           size_t send_vol = array->esznc*mpi->send[nsidx].range.volume;
 
           if (issend) {

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -14,7 +14,7 @@
 
 // Maximum number of recv neighbors: not sure hard-coding this is a
 // good idea.
-#define MAX_RECV_NEIGH 32
+#define MAX_RECV_NEIGH 128
 
 #define MPI_BASE_TAG 4242
 #define MPI_BASE_PER_TAG 5252
@@ -354,8 +354,8 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
         int delta[GKYL_MAX_DIM] = { 0 };
         delta[dir] = shift_sign[e]*gkyl_range_shape(&mpi->decomp->parent_range, dir);
 
-        if (mpi->per_neigh[dir]->num_neigh == 1) { // really should  be a loop
-          int nid = mpi->per_neigh[dir]->neigh[0];
+        for (int pn=0; pn<mpi->per_neigh[dir]->num_neigh; ++pn) {
+          int nid = mpi->per_neigh[dir]->neigh[pn];
 
           struct gkyl_range neigh_shift;
           gkyl_range_shift(&neigh_shift, &mpi->decomp->ranges[nid], delta);
@@ -393,8 +393,8 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
         int delta[GKYL_MAX_DIM] = { 0 };
         delta[dir] = shift_sign[e]*gkyl_range_shape(&mpi->decomp->parent_range, dir);
 
-        if (mpi->per_neigh[dir]->num_neigh == 1) { // really should  be a loop
-          int nid = mpi->per_neigh[dir]->neigh[0];
+        for (int pn=0; pn<mpi->per_neigh[dir]->num_neigh; ++pn) {
+          int nid = mpi->per_neigh[dir]->neigh[pn];
 
           struct gkyl_range neigh_shift, neigh_shift_ext;
           gkyl_range_shift(&neigh_shift, &mpi->decomp->ranges[nid], delta);
@@ -675,7 +675,7 @@ gkyl_mpi_comm_new(const struct gkyl_mpi_comm_inp *inp)
     mpi->neigh = gkyl_rect_decomp_calc_neigh(mpi->decomp, inp->sync_corners, rank);
     for (int d=0; d<mpi->decomp->ndim; ++d)
       mpi->per_neigh[d] =
-        gkyl_rect_decomp_calc_periodic_neigh(mpi->decomp, d, false, rank);
+        gkyl_rect_decomp_calc_periodic_neigh(mpi->decomp, d, inp->sync_corners, rank);
   
     gkyl_range_init(&mpi->dir_edge, 2, (int[]) { 0, 0 }, (int[]) { GKYL_MAX_DIM, 2 });
   

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -360,9 +360,6 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
           struct gkyl_range neigh_shift;
           gkyl_range_shift(&neigh_shift, &mpi->decomp->ranges[nid], delta);
 
-          /* struct gkyl_range neigh_shift_ext; */
-          /* gkyl_range_extend(&neigh_shift_ext, &neigh_shift, elo, eup); */
-
           int isrecv = gkyl_sub_range_intersect(
             &mpi->recv[nridx].range, local_ext, &neigh_shift);
           size_t recv_vol = array->esznc*mpi->recv[nridx].range.volume;
@@ -398,8 +395,8 @@ array_per_sync(struct gkyl_comm *comm, const struct gkyl_range *local,
 
           struct gkyl_range neigh_shift, neigh_shift_ext;
           gkyl_range_shift(&neigh_shift, &mpi->decomp->ranges[nid], delta);
-
           gkyl_range_extend(&neigh_shift_ext, &neigh_shift, elo, eup);
+
           int issend = gkyl_sub_range_intersect(
             &mpi->send[nsidx].range, local, &neigh_shift_ext);
 

--- a/zero/range.c
+++ b/zero/range.c
@@ -327,6 +327,20 @@ gkyl_range_extend(struct gkyl_range *erng,
 }
 
 void
+gkyl_range_perp_extend(struct gkyl_range *erng, int dir,
+  const struct gkyl_range* rng, const int *elo, const int *eup)
+{
+  int ndim = rng->ndim;
+  int elo_p[GKYL_MAX_DIM] = {0}, eup_p[GKYL_MAX_DIM] = {0};
+  for (int i=0; i<ndim; ++i) {
+    elo_p[i] = elo[i];
+    eup_p[i] = eup[i];
+  }
+  elo_p[dir] = 0; eup_p[dir] = 0;
+  gkyl_range_extend(erng, rng, elo_p, eup_p);
+}
+
+void
 gkyl_range_lower_skin(struct gkyl_range *rng,
   const struct gkyl_range* range, int dir, int nskin)
 {

--- a/zero/range.c
+++ b/zero/range.c
@@ -425,6 +425,41 @@ gkyl_skin_ghost_ranges(struct gkyl_range *skin, struct gkyl_range *ghost,
   }
 }
 
+void
+gkyl_skin_ghost_with_corners_ranges(struct gkyl_range *skin, struct gkyl_range *ghost,
+  int dir, enum gkyl_edge_loc edge, const struct gkyl_range *parent, const int *nghost)
+{
+  int ndim = parent->ndim;
+  int lo[GKYL_MAX_DIM] = {0}, up[GKYL_MAX_DIM] = {0};
+
+  for (int i=0; i<ndim; ++i) {
+    lo[i] = parent->lower[i];
+    up[i] = parent->upper[i];
+  }
+
+  if (edge == GKYL_LOWER_EDGE) {
+
+    lo[dir] = parent->lower[dir]+nghost[dir];
+    up[dir] = lo[dir]+nghost[dir]-1;
+    gkyl_sub_range_init(skin, parent, lo, up);    
+
+    lo[dir] = parent->lower[dir];
+    up[dir] = lo[dir]+nghost[dir]-1;
+    gkyl_sub_range_init(ghost, parent, lo, up);
+
+  }
+  else {
+
+    up[dir] = parent->upper[dir]-nghost[dir];
+    lo[dir] = up[dir]-nghost[dir]+1;
+    gkyl_sub_range_init(skin, parent, lo, up);
+
+    up[dir] = parent->upper[dir];
+    lo[dir] = up[dir]-nghost[dir]+1;
+    gkyl_sub_range_init(ghost, parent, lo, up);
+  }
+}
+
 int
 gkyl_range_intersect(struct gkyl_range* irng,
   const struct gkyl_range *r1, const struct gkyl_range *r2)

--- a/zero/rect_decomp.c
+++ b/zero/rect_decomp.c
@@ -251,8 +251,8 @@ gkyl_rect_decomp_calc_neigh(const struct gkyl_rect_decomp *decomp,
   return calc_neigh_no_corners(decomp, nidx);
 }
 
-static struct gkyl_rect_decomp_neigh*
-calc_periodic_neigh_no_corners(const struct gkyl_rect_decomp *decomp,
+struct gkyl_rect_decomp_neigh*
+gkyl_rect_decomp_calc_periodic_neigh(const struct gkyl_rect_decomp *decomp,
   int dir, bool inc_corners, int nidx)
 {
   struct rect_decomp_neigh_cont *cont = gkyl_malloc(sizeof(*cont));
@@ -261,7 +261,11 @@ calc_periodic_neigh_no_corners(const struct gkyl_rect_decomp *decomp,
   const struct gkyl_range *curr = &decomp->ranges[nidx];
 
   int elo[GKYL_MAX_DIM] = { 0 }, eup[GKYL_MAX_DIM] = { 0 };
-  elo[dir] = eup[dir] = 1; // only extend in 1 direction
+  if (inc_corners)
+    for (int i=0; i<decomp->ndim; ++i)
+      elo[i] = eup[i] = 1;
+  else
+    elo[dir] = eup[dir] = 1;
   
   if (gkyl_range_is_on_lower_edge(dir, curr, &decomp->parent_range)) {
     int delta[GKYL_MAX_DIM] = { 0 };
@@ -306,23 +310,6 @@ calc_periodic_neigh_no_corners(const struct gkyl_rect_decomp *decomp,
   cont->neigh.neigh = cvec_int_front(&cont->l_neigh);  
   
   return &cont->neigh;
-}
-
-static struct gkyl_rect_decomp_neigh*
-calc_periodic_neigh_with_corners(const struct gkyl_rect_decomp *decomp,
-  int dir, bool inc_corners, int nidx)
-{
-  // THIS METHOD MUST BE WRITTEN
-  return 0;
-}
-
-struct gkyl_rect_decomp_neigh*
-gkyl_rect_decomp_calc_periodic_neigh(const struct gkyl_rect_decomp *decomp,
-  int dir, bool inc_corners, int nidx)
-{
-  if (inc_corners)
-    return calc_periodic_neigh_with_corners(decomp, dir, inc_corners, nidx);
-  return calc_periodic_neigh_no_corners(decomp, dir, inc_corners, nidx);
 }
 
 void

--- a/zero/rect_decomp.c
+++ b/zero/rect_decomp.c
@@ -251,8 +251,8 @@ gkyl_rect_decomp_calc_neigh(const struct gkyl_rect_decomp *decomp,
   return calc_neigh_no_corners(decomp, nidx);
 }
 
-struct gkyl_rect_decomp_neigh*
-gkyl_rect_decomp_calc_periodic_neigh(const struct gkyl_rect_decomp *decomp,
+static struct gkyl_rect_decomp_neigh*
+calc_periodic_neigh_no_corners(const struct gkyl_rect_decomp *decomp,
   int dir, bool inc_corners, int nidx)
 {
   struct rect_decomp_neigh_cont *cont = gkyl_malloc(sizeof(*cont));
@@ -306,6 +306,23 @@ gkyl_rect_decomp_calc_periodic_neigh(const struct gkyl_rect_decomp *decomp,
   cont->neigh.neigh = cvec_int_front(&cont->l_neigh);  
   
   return &cont->neigh;
+}
+
+static struct gkyl_rect_decomp_neigh*
+calc_periodic_neigh_with_corners(const struct gkyl_rect_decomp *decomp,
+  int dir, bool inc_corners, int nidx)
+{
+  // THIS METHOD MUST BE WRITTEN
+  return 0;
+}
+
+struct gkyl_rect_decomp_neigh*
+gkyl_rect_decomp_calc_periodic_neigh(const struct gkyl_rect_decomp *decomp,
+  int dir, bool inc_corners, int nidx)
+{
+  if (inc_corners)
+    return calc_periodic_neigh_with_corners(decomp, dir, inc_corners, nidx);
+  return calc_periodic_neigh_no_corners(decomp, dir, inc_corners, nidx);
 }
 
 void


### PR DESCRIPTION
I have now completed the corner syncs, including for periodic BCs. This is hooked into both the null and mpi comm. But not for nccl. For now this is ok as no GK or VM updater needs corner BCs. But moments do, however, they do not work on GPUs anyway.  Eventually, we will need to implement this in nccl also.