### PR TITLE
In the process of debugging the DG two-fluid solver, I discovered two issues:

### DIFF
--- a/regression/rt_5m_mom_beach.c
+++ b/regression/rt_5m_mom_beach.c
@@ -79,7 +79,7 @@ create_ctx(void)
   int Nx = 400; // Cell count (x-direction).
   double Lx = 1.0; // Domain size (x-direction).
   double Lx100 = Lx / 100.0; // Domain size over 100 (x-direction).
-  double x_last_edge = Lx / Nx; // Location of center of last cell.
+  double x_last_edge = Lx - Lx / Nx; // Location of center of last upper cell (low density side).
   double cfl_frac = 0.95; // CFL coefficient.
 
   double t_end = 5.0e-9; // Final simulation time.

--- a/zero/moment_em_coupling.c
+++ b/zero/moment_em_coupling.c
@@ -179,10 +179,10 @@ em_source_update(const gkyl_moment_em_coupling *mes, double tcurr, double dt,
   if (mes->ramp_app_curr)
     scale_fac_curr = fmin(1.0, tcurr/mes->t_ramp_curr);
   // Add contributions from applied currents to electric field
-  // Note: Conversion from applied current to electric field units occurs here
-  F[0] = FOld[0] - 0.5*dt*app_current[0]/epsilon0*scale_fac_curr;
-  F[1] = FOld[1] - 0.5*dt*app_current[1]/epsilon0*scale_fac_curr;
-  F[2] = FOld[2] - 0.5*dt*app_current[2]/epsilon0*scale_fac_curr;
+  // Note: We solve for epsilon0*E so no additional 1.0/epsilon0 factor in applied current
+  F[0] = FOld[0] - 0.5*dt*app_current[0]*scale_fac_curr;
+  F[1] = FOld[1] - 0.5*dt*app_current[1]*scale_fac_curr;
+  F[2] = FOld[2] - 0.5*dt*app_current[2]*scale_fac_curr;
 
   F_halfK[0] = F[0] + 0.5*K[0];
   F_halfK[1] = F[1] + 0.5*K[1];


### PR DESCRIPTION
The first is that we had too many factors of epsilon0 in the implicit source solve (one of the unknowns is epsilon0*E, so the applied current does not need to be divided by epsilon0). The other was that the moment regression refactor changed x_last_edge to be on the high density side instead of the low density side. We want the waves to propagate from the low density side. Changing back.