### PR TITLE
Adding a couple methods with detailed doxygen-style comments for future developers

### DIFF
--- a/zero/gkyl_dg_eqn.h
+++ b/zero/gkyl_dg_eqn.h
@@ -80,6 +80,95 @@ bool gkyl_dg_eqn_is_cu_dev(const struct gkyl_dg_eqn *eqn);
 struct gkyl_dg_eqn* gkyl_dg_eqn_acquire(const struct gkyl_dg_eqn* eqn);
 
 /**
+ * Compute the volume term in a DG discretization.
+ *
+ * @param eqn Equation object (contains the volume kernel function pointer vol_termf_t).
+ * @param xc  Cell center coordinates
+ * @param dx  Grid spacing
+ * @param idx Cell index
+ * @param qIn Input state vector
+ * @param qRhsOut Output RHS for use in an explicit time-stepping scheme
+ * @return cfl frequency *if volume term is computing stable time step* (otherwise returns 0.0)
+ */
+GKYL_CU_DH
+static inline double
+gkyl_dg_eqn_vol_update(const struct gkyl_dg_eqn *eqn, 
+  const double* xc, const double* dx, const int* idx,
+  const double* qIn, double* GKYL_RESTRICT qRhsOut)
+{
+  return eqn->vol_term(eqn, xc, dx, idx, qIn, qRhsOut);
+}
+
+/**
+ * Compute the surface term in a DG discretization in direction dir.
+ *
+ * @param eqn Equation object (contains the surface kernel function pointers surf_termf_t).
+ * @param dir Direction of surface update to be computed
+ * @param xcL Cell center coordinates in left (or lower) cell
+ * @param xcC Cell center coordinates in center cell (the cell being updated)
+ * @param xcR Cell center coordinates in right (or upper) cell
+ * @param dxL Grid spacing in left (or lower) cell
+ * @param dxC Grid spacing in center cell (the cell being updated)
+ * @param dxR Grid spacing in right (or upper) cell
+ * @param idxL Cell index in left (or lower) cell
+ * @param idxC Cell index in center cell (the cell being updated)
+ * @param idxR Cell index in right (or upper) cell
+ * @param qInL Input state vector in left (or lower) cell
+ * @param qInC Input state vector in center cell (the cell being updated)
+ * @param qInR Input state vector in right (or upper) cell
+ * @param qRhsOut Output RHS for use in an explicit time-stepping scheme in center cell (the cell being updated)
+ * @return cfl frequency *if surface term is computing stable time step* (otherwise returns 0.0)
+ */
+GKYL_CU_DH
+static inline double
+gkyl_dg_eqn_surf_update(const struct gkyl_dg_eqn *eqn, 
+  int dir,
+  const double*  xcL, const double*  xcC, const double*  xcR, 
+  const double*  dxL, const double* dxC, const double* dxR,
+  const int*  idxL, const int*  idxC, const int*  idxR,
+  const double* qInL, const double*  qInC, const double*  qInR, double* GKYL_RESTRICT qRhsOut)
+{
+  return eqn->surf_term(eqn, dir, 
+    xcL, xcC, xcR, 
+    dxL, dxC, dxR, 
+    idxL, idxC, idxR, 
+    qInL, qInC, qInR, qRhsOut);
+}
+
+/**
+ * Compute the boundary surface term in a DG discretization in direction dir.
+ *
+ * @param eqn Equation object (contains the surface kernel function pointers surf_termf_t).
+ * @param dir Direction of surface update to be computed
+ * @param xcEdge Cell center coordinates in edge cell (next cell in interior relative to skin cell)
+ * @param xcSkin Cell center coordinates in skin cell (the cell being updated)
+ * @param dxEdge Grid spacing in edge cell (next cell in interior relative to skin cell)
+ * @param dxSkin Grid spacing in skin cell (the cell being updated)
+ * @param idxEdge Cell index in edge cell (next cell in interior relative to skin cell)
+ * @param idxSkin Cell index in skin cell (the cell being updated)
+ * @param edge Parameter for whether we are at lower or upper edge for determining relative location of edge cell
+ * @param qInEdge Input state vector in edge cell (next cell in interior relative to skin cell)
+ * @param qInSkin Input state vector in skin cell (the cell being updated)
+ * @param qRhsOut Output RHS for use in an explicit time-stepping scheme in skin cell (the cell being updated)
+ * @return cfl frequency *if boundary surface term is computing stable time step* (otherwise returns 0.0)
+ */
+GKYL_CU_DH
+static inline double
+gkyl_dg_eqn_boundary_surf_update(const struct gkyl_dg_eqn *eqn,
+  int dir,
+  const double*  xcEdge, const double*  xcSkin,
+  const double*  dxEdge, const double* dxSkin,
+  const int* idxEdge, const int* idxSkin, const int edge,
+  const double* qInEdge, const double* qInSkin, double* GKYL_RESTRICT qRhsOut)
+{
+  return eqn->boundary_surf_term(eqn, dir, 
+    xcEdge, xcSkin, 
+    dxEdge, dxSkin, 
+    idxEdge, idxSkin, edge, 
+    qInEdge, qInSkin, qRhsOut);
+}
+
+/**
  * Delete equation object
  *
  * @param eqn Equation object to delete.


### PR DESCRIPTION
These methods should help to have a clear idea of what the function pointers inside dg_eqn are. Eventually we will follow gkyl_wv_eqn and actually call these methods within hyper_dg but for now this is just to add some additional information to the header file that can help new developers navigate the complexity of the dg_eqn object.