### PR TITLE
Implement cleaner way of passing the velocity map, and in the future …

### DIFF
--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -359,12 +359,19 @@ struct gk_react {
   };  
 };
 
+// Context for c2p function passed to proj_on_basis.
+struct gk_proj_on_basis_c2p_func_ctx {
+  int cdim, vdim;
+  struct gkyl_velocity_map *vel_map;
+};
+
 struct gk_proj {
   enum gkyl_projection_id proj_id; // type of projection
   // organization of the different projection objects and the required data and solvers
   union {
     // function projection
     struct {
+      struct gk_proj_on_basis_c2p_func_ctx proj_on_basis_c2p_ctx; // c2p function context.
       struct gkyl_proj_on_basis *proj_func; // projection operator for specified function
       struct gkyl_array *proj_host; // array for projection on host-side if running on GPUs
     };

--- a/zero/gkyl_proj_on_basis.h
+++ b/zero/gkyl_proj_on_basis.h
@@ -6,10 +6,12 @@
 #include <gkyl_evalf_def.h>
 #include <gkyl_range.h>
 #include <gkyl_rect_grid.h>
-#include <gkyl_velocity_map.h>
 
 // Object type
 typedef struct gkyl_proj_on_basis gkyl_proj_on_basis;
+
+// Types for various kernels.
+typedef void (*proj_on_basis_c2p_t)(const double *xcomp, double *xphys, void *ctx);
 
 // input packaged as a struct
 struct gkyl_proj_on_basis_inp {
@@ -23,7 +25,9 @@ struct gkyl_proj_on_basis_inp {
   evalf_t eval; // function to project
   void *ctx; // function context
 
-  const struct gkyl_velocity_map *vel_map; // Optional velocity space mapping object.
+  proj_on_basis_c2p_t c2p_func; // Function that transforms a set of ndim
+                                // computational coordinates to physical ones.
+  void *c2p_func_ctx; // Context for c2p_func.
 };
 
 /**

--- a/zero/velocity_map.c
+++ b/zero/velocity_map.c
@@ -12,7 +12,8 @@ struct mapc2p_vel_identity_ctx {
 };
 
 // Comp. coords = phys. coords mapping (default).
-void mapc2p_vel_identity(double t, const double *zc, double* GKYL_RESTRICT vp, void *ctx)
+static inline void
+mapc2p_vel_identity(double t, const double *zc, double* GKYL_RESTRICT vp, void *ctx)
 {
   struct mapc2p_vel_identity_ctx *identity_ctx = ctx;
   int vdim = identity_ctx->vdim;


### PR DESCRIPTION
…conf-space maps, to proj_on_basis. Reproduces the previous result in gk_lbo_relax_nonuniformv