### PR TITLE
expose ghost and skin cell coordinates to wave apply_bc

### DIFF
--- a/amr/amr_block.c
+++ b/amr/amr_block.c
@@ -12,7 +12,7 @@ skin_ghost_ranges_init_block(struct skin_ghost_ranges_block* sgr, const struct g
 }
 
 void
-euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 5; i++) {
     ghost[i] = skin[i];
@@ -20,7 +20,7 @@ euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double
 }
 
 void
-gr_euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+gr_euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 29; i++) {
     ghost[i] = skin[i];

--- a/amr/amr_block_coupled.c
+++ b/amr/amr_block_coupled.c
@@ -1,7 +1,7 @@
 #include <gkyl_amr_block_coupled_priv.h>
 
 void
-five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 5; i++) {
     ghost[i] = skin[i];
@@ -11,7 +11,7 @@ five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* 
 }
 
 void
-ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 10; i++) {
     if (i == 1 || i == 5 || i == 6) {
@@ -24,7 +24,7 @@ ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* G
 }
 
 void
-maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 8; i++) {
     if (i == 1 || i == 2 || i == 3 || i == 6) {
@@ -37,7 +37,7 @@ maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL
 }
 
 void
-five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 5; i++) {
     ghost[i] = skin[i];
@@ -45,7 +45,7 @@ five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, 
 }
 
 void
-ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 10; i++) {
     ghost[i] = skin[i];
@@ -53,7 +53,7 @@ ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, d
 }
 
 void
-maxwell_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx)
+maxwell_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 8; i++) {
     ghost[i] = skin[i];

--- a/amr/gkyl_amr_block_coupled_priv.h
+++ b/amr/gkyl_amr_block_coupled_priv.h
@@ -105,7 +105,7 @@ struct five_moment_copy_job_ctx {
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying wall boundary conditions for the coupled ten-moment equations.
@@ -116,7 +116,7 @@ void five_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, dou
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying wall boundary conditions for the Maxwell equations.
@@ -127,7 +127,7 @@ void ten_moment_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, doub
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying transmissive boundary conditions for the coupled five-moment equations.
@@ -138,7 +138,7 @@ void maxwell_wall_bc(double t, int nc, const double* GKYL_RESTRICT skin, double*
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying transmissive boundary conditions for the coupled ten-moment equations.
@@ -149,7 +149,7 @@ void five_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT s
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying transmissive boundary conditions for the Maxwell equations.
@@ -160,7 +160,7 @@ void ten_moment_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT sk
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void maxwell_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void maxwell_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Initialize block AMR updaters for both physical (outer-block) and non-physical (inter-block) boundary conditions for the coupled five-moment equations.

--- a/amr/gkyl_amr_block_priv.h
+++ b/amr/gkyl_amr_block_priv.h
@@ -108,7 +108,7 @@ void skin_ghost_ranges_init_block(struct skin_ghost_ranges_block* sgr, const str
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying transmissive boundary conditions for the general relativistic Euler equations.
@@ -119,7 +119,7 @@ void euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, d
 * @param ghost Ghost cells in boundary region (to which values are copied).
 * @param ctx Context to pass to the function.
 */
-void gr_euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, void* ctx);
+void gr_euler_transmissive_bc(double t, int nc, const double* GKYL_RESTRICT skin, double* GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Initialize block AMR updaters for both physical (outer-block) and non-physical (inter-block) boundary conditions for the Euler equations.

--- a/apps/gkyl_moment.h
+++ b/apps/gkyl_moment.h
@@ -34,14 +34,14 @@ struct gkyl_moment_species {
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
   // pointer to boundary condition functions along x
-  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along y
-  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along z
-  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
 };
 
 // Parameter for EM field
@@ -69,14 +69,14 @@ struct gkyl_moment_field {
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];
   // pointer to boundary condition functions along x
-  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along y
-  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along z
-  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
-  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
 };
 
 // Choices of schemes to use in the fluid solver

--- a/apps/gkyl_moment_priv.h
+++ b/apps/gkyl_moment_priv.h
@@ -262,8 +262,8 @@ integ_sq(int nc, const double *qin, double *integ_out)
 
 // function for copy BC
 static inline void
-bc_copy(double t, int nc, const double *skin,
-  double *GKYL_RESTRICT ghost, void *ctx)
+bc_copy(double t, int nc, const double *skin, double *GKYL_RESTRICT ghost,
+  const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   for (int c = 0; c < nc; ++c)
     ghost[c] = skin[c];

--- a/apps/mom_field.c
+++ b/apps/mom_field.c
@@ -110,7 +110,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
       else
         bc = mom_fld->bcz;
 
-      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
       if (dir == 0)
         bc_lower_func = mom_fld->bcx_lower_func;
       else if (dir == 1)
@@ -118,7 +118,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
       else
         bc_lower_func = mom_fld->bcz_lower_func;
 
-      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
       if (dir == 0)
         bc_upper_func = mom_fld->bcx_upper_func;
       else if (dir == 1)

--- a/apps/mom_species.c
+++ b/apps/mom_species.c
@@ -127,7 +127,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       else
         bc = mom_sp->bcz;
 
-      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      void (*bc_lower_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
       if (dir == 0)
         bc_lower_func = mom_sp->bcx_lower_func;
       else if (dir == 1)
@@ -135,7 +135,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       else
         bc_lower_func = mom_sp->bcz_lower_func;
 
-      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx);
+      void (*bc_upper_func)(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
       if (dir == 0)
         bc_upper_func = mom_sp->bcx_upper_func;
       else if (dir == 1)

--- a/inf/Moments.lua
+++ b/inf/Moments.lua
@@ -362,14 +362,14 @@ struct gkyl_moment_species {
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
   // pointer to boundary condition functions along x
-  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along y
-  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along z
-  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
 };
 
 // Parameter for EM field
@@ -394,14 +394,14 @@ struct gkyl_moment_field {
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];
   // pointer to boundary condition functions along x
-  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcx_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcx_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along y
-  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcy_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcy_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
   // pointer to boundary condition functions along z
-  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
-  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, void *ctx);
+  void (*bcz_lower_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
+  void (*bcz_upper_func)(double t, int nc, const double *skin, double *ghost, const double *skin_xc, const double *ghost_xc, void *ctx);
 };
 
 // Choices of schemes to use in the fluid solver 
@@ -818,7 +818,7 @@ local function gkyl_eval_applied(func)
 end
 
 local function gkyl_eval_bc(func)
-   return function(t, nc, skin, ghost, ctx)
+   return function(t, nc, skin, ghost, skin_xc, ghost_xc, ctx)
       local ret = { func(t, nc, skin, ctx) } -- package return into table
       for i=1,#ret do
          ghost[i-1] = ret[i]

--- a/unit/ctest_wv_apply_bc.c
+++ b/unit/ctest_wv_apply_bc.c
@@ -27,7 +27,8 @@ rtheta_map(double t, const double *xc, double *xp, void *ctx)
 }
 
 static void
-bc_copy(double t, int nc, const double *skin, double *restrict ghost, void *ctx)
+bc_copy(double t, int nc, const double *skin, double *restrict ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   for (int c=0; c<nc; ++c) ghost[c] = skin[c];
 }

--- a/zero/gkyl_evalf_def.h
+++ b/zero/gkyl_evalf_def.h
@@ -19,9 +19,12 @@ typedef void (*evalf_t)(double t, const double *xn, double *fout, void *ctx);
  * @param ncomp Number of compontents (size of skin and ghost arrays)
  * @param skin Pointer to data in skin-cell
  * @param ghost Pointer to data in ghost-cell
+ * @param skin_xc Pointer to array storing coordinates of skin-cell
+ * @param ghost_xc Pointer to array storing coordinates of skin-cell
  * @param ctx Context for function evaluation. Can be NULL
  */
-typedef void (*wv_bc_func_t)(double t, int ncomp, const double *skin, double *ghost, void *ctx);
+typedef void (*wv_bc_func_t)(double t, int ncomp, const double *skin, double *ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx);
 
 /**
  * Type of function for use in array copy op.

--- a/zero/gkyl_wv_euler_priv.h
+++ b/zero/gkyl_wv_euler_priv.h
@@ -111,7 +111,8 @@ riem_to_cons(const struct gkyl_wv_eqn *eqn,
 // Euler perfectly reflecting wall
 GKYL_CU_D
 static void
-euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // copy density and pressure
   ghost[0] = skin[0];
@@ -126,7 +127,8 @@ euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, v
 // Euler no-slip wall
 GKYL_CU_D
 static void
-euler_no_slip(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+euler_no_slip(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // copy density and pressure
   ghost[0] = skin[0];

--- a/zero/gkyl_wv_gr_euler_priv.h
+++ b/zero/gkyl_wv_gr_euler_priv.h
@@ -84,7 +84,8 @@ riem_to_cons(const struct gkyl_wv_eqn* eqn, const double* qstate, const double* 
 */
 GKYL_CU_D
 static void
-gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost, void* ctx);
+gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Boundary condition function for applying no-slip boundary conditions for the general relativistic Euler equations.
@@ -97,7 +98,8 @@ gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
 */
 GKYL_CU_D
 static void
-gr_euler_no_slip(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost, void* ctx);
+gr_euler_no_slip(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void* ctx);
 
 /**
 * Rotate state vector from global to local coordinate frame.

--- a/zero/wv_apply_bc.c
+++ b/zero/wv_apply_bc.c
@@ -58,6 +58,7 @@ gkyl_wv_apply_bc_advance(const gkyl_wv_apply_bc *bc, double tm,
   int meqn = bc->eqn->num_equations;
 
   double skin_local[meqn], ghost_local[meqn];
+  double skin_xc[GKYL_MAX_CDIM], ghost_xc[GKYL_MAX_CDIM];
 
   // return immediately if update region does not touch boundary
   if ( (edge == GKYL_LOWER_EDGE) && (update_rng->lower[dir] > bc->range.lower[dir]) )
@@ -107,6 +108,9 @@ gkyl_wv_apply_bc_advance(const gkyl_wv_apply_bc *bc, double tm,
     }
 
     const struct gkyl_wave_cell_geom *wg = gkyl_wave_geom_get(bc->geom, eidx);
+
+    gkyl_rect_grid_cell_center(&bc->grid, iter.idx, skin_xc);
+    gkyl_rect_grid_cell_center(&bc->grid, gidx, ghost_xc);
 
     // rotate skin data to local coordinates
     gkyl_wv_eqn_rotate_to_local(bc->eqn, wg->tau1[dir], wg->tau2[dir], wg->norm[dir],

--- a/zero/wv_apply_bc.c
+++ b/zero/wv_apply_bc.c
@@ -117,7 +117,7 @@ gkyl_wv_apply_bc_advance(const gkyl_wv_apply_bc *bc, double tm,
       gkyl_array_fetch(out, sloc), skin_local);
       
     // apply boundary condition in local coordinates
-    bc->bcfunc(tm, ncomp, skin_local, ghost_local, bc->ctx);
+    bc->bcfunc(tm, ncomp, skin_local, ghost_local, skin_xc, ghost_xc, bc->ctx);
 
     // rotate back to global
     gkyl_wv_eqn_rotate_to_global(bc->eqn, wg->tau1[dir], wg->tau2[dir], wg->norm[dir],
@@ -134,6 +134,7 @@ gkyl_wv_apply_bc_to_buff(const gkyl_wv_apply_bc *bc, double tm,
   int meqn = bc->eqn->num_equations;
 
   double skin_local[meqn], ghost_local[meqn];
+  double skin_xc[GKYL_MAX_CDIM], ghost_xc[GKYL_MAX_CDIM];
 
   // return immediately if update region does not touch boundary
   if ( (edge == GKYL_LOWER_EDGE) && (update_rng->lower[dir] > bc->range.lower[dir]) )
@@ -180,12 +181,15 @@ gkyl_wv_apply_bc_to_buff(const gkyl_wv_apply_bc *bc, double tm,
 
     const struct gkyl_wave_cell_geom *wgs = gkyl_wave_geom_get(bc->geom, sidx);
 
+    gkyl_rect_grid_cell_center(&bc->grid, iter.idx, skin_xc);
+    gkyl_rect_grid_cell_center(&bc->grid, gidx, ghost_xc);
+
     // rotate skin data to local coordinates of skin-cell edge
     gkyl_wv_eqn_rotate_to_local(bc->eqn, wgs->tau1[dir], wgs->tau2[dir], wgs->norm[dir],
       gkyl_array_cfetch(inp, sloc), skin_local);
       
     // apply boundary condition in local coordinates
-    bc->bcfunc(tm, ncomp, skin_local, ghost_local, bc->ctx);
+    bc->bcfunc(tm, ncomp, skin_local, ghost_local, skin_xc, ghost_xc, bc->ctx);
 
     // rotate back to global coordinates as defined on ghost cell edge
     const struct gkyl_wave_cell_geom *wgg = gkyl_wave_geom_get(bc->geom, gidx);

--- a/zero/wv_gr_euler.c
+++ b/zero/wv_gr_euler.c
@@ -373,7 +373,8 @@ riem_to_cons(const struct gkyl_wv_eqn* eqn, const double* qstate, const double* 
 }
 
 static void
-gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost, void* ctx)
+gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 0; i < 29; i++) {
     ghost[i] = skin[i];
@@ -383,7 +384,8 @@ gr_euler_wall(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
 }
 
 static void
-gr_euler_no_slip(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost, void* ctx)
+gr_euler_no_slip(double t, int nc, const double* skin, double* GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void* ctx)
 {
   for (int i = 1; i < 4; i++) {
     ghost[i] = -skin[i];

--- a/zero/wv_iso_euler.c
+++ b/zero/wv_iso_euler.c
@@ -36,7 +36,8 @@ riem_to_cons(const struct gkyl_wv_eqn *eqn,
 
 // Isothermal Euler perfectly reflecting wall
 static void
-iso_euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+iso_euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // copy density
   ghost[0] = skin[0];
@@ -49,7 +50,8 @@ iso_euler_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghos
 
 // Isothermal Euler no-slip wall
 static void
-iso_euler_no_slip(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+iso_euler_no_slip(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // copy density and pressure
   ghost[0] = skin[0];

--- a/zero/wv_maxwell.c
+++ b/zero/wv_maxwell.c
@@ -37,7 +37,8 @@ riem_to_cons(const struct gkyl_wv_eqn *eqn,
 }
 
 static void
-maxwell_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+maxwell_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // zero-tangent for E field
   ghost[0] = skin[0];

--- a/zero/wv_ten_moment.c
+++ b/zero/wv_ten_moment.c
@@ -53,7 +53,8 @@ ten_moment_free(const struct gkyl_ref_count *ref)
 
 // Ten moment perfectly reflecting wall
 static void
-ten_moment_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost, void *ctx)
+ten_moment_wall(double t, int nc, const double *skin, double * GKYL_RESTRICT ghost,
+    const double *skin_xc, const double *ghost_xc, void *ctx)
 {
   // copy density and Pxx, Pyy, and Pzz
   ghost[0] = skin[0];


### PR DESCRIPTION
For finite-volume runs, enabling boundary conditions that depend on boundary coordinates or gradients.

Notes:
- The coordinates arguments are positioned before `void *ctx`, which might break an older user-defined bc function (non-existent in gkylzero presently);
  - One may avoid this by appending the coordinate arguments to the tail instead, but that reads less natural since `ctx` will be in the middle of the argument list.