### PR TITLE
Add new methods in velocity_space which provide the min/max dv in the…

### DIFF
--- a/apps/gk_neut_species.c
+++ b/apps/gk_neut_species.c
@@ -151,12 +151,12 @@ gk_neut_species_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app, struc
   }
 
   s->has_neutral_reactions = false;
+  s->model_id = GKYL_MODEL_GEN_GEO;
   if (!s->info.is_static) {
     struct gkyl_dg_vlasov_auxfields aux_inp = {.field = 0, .cot_vec = s->cot_vec, 
       .alpha_surf = s->alpha_surf, .sgn_alpha_surf = s->sgn_alpha_surf, .const_sgn_alpha = s->const_sgn_alpha };
     // Set field type and model id for neutral species in GK system and create solver
     s->field_id = GKYL_FIELD_NULL;
-    s->model_id = GKYL_MODEL_GEN_GEO;
     s->slvr = gkyl_dg_updater_vlasov_new(&s->grid, &app->confBasis, &app->neut_basis, 
       &app->local, &s->local_vel, &s->local, is_zero_flux, s->model_id, s->field_id, &aux_inp, app->use_gpu);
 

--- a/apps/gk_species_bgk.c
+++ b/apps/gk_species_bgk.c
@@ -36,13 +36,12 @@ gk_species_bgk_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, stru
     double bmag_mid = s->info.collisions.bmag_mid ? s->info.collisions.bmag_mid : bmag_mid_ptr[0];
     gkyl_array_release(bmag_mid_host);
 
-    // Compute a minimum representable temperature based on the largest dv in the grid.
-    // This is pessimistic for nonuniform grids, but it's a conservative choice for now.
-    double dv_max[vdim];
-    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MAX, dv_max, s->vel_map->local_vel);
+    // Compute a minimum representable temperature based on the smallest dv in the grid.
+    double dv_min[vdim];
+    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MAX, dv_min, s->vel_map->local_vel);
 
-    double tpar_min = (s->info.mass/6.0)*pow(dv_max[0],2);
-    double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_max[1] : tpar_min;
+    double tpar_min = (s->info.mass/6.0)*pow(dv_min[0],2);
+    double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_min[1] : tpar_min;
     bgk->vtsq_min = (tpar_min + 2.0*tperp_min)/(3.0*s->info.mass);
 
     bgk->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->confBasis, app->poly_order+1,

--- a/apps/gk_species_bgk.c
+++ b/apps/gk_species_bgk.c
@@ -29,19 +29,28 @@ gk_species_bgk_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, stru
     double eps0 = s->info.collisions.eps0 ? s->info.collisions.eps0: GKYL_EPSILON0;
     double hbar = s->info.collisions.hbar ? s->info.collisions.hbar: GKYL_PLANCKS_CONSTANT_H/2/M_PI;
     double eV = s->info.collisions.eV ? s->info.collisions.eV: GKYL_ELEMENTARY_CHARGE;
+
     struct gkyl_array* bmag_mid_host = app->use_gpu? mkarr(false, 1, 1) : gkyl_array_acquire(app->gk_geom->bmag_mid);
     gkyl_array_copy(bmag_mid_host, app->gk_geom->bmag_mid);
     double *bmag_mid_ptr = gkyl_array_fetch(bmag_mid_host, 0);
     double bmag_mid = s->info.collisions.bmag_mid ? s->info.collisions.bmag_mid : bmag_mid_ptr[0];
     gkyl_array_release(bmag_mid_host);
-    double tpar_min = (s->info.mass/6.0)*pow(s->grid.dx[cdim],2);
-    double tperp_min = vdim>1 ? (bmag_mid/3.0)*s->grid.dx[cdim+1] : tpar_min;
+
+    // Compute a minimum representable temperature based on the largest dv in the grid.
+    // This is pessimistic for nonuniform grids, but it's a conservative choice for now.
+    double dv_max[vdim];
+    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MAX, dv_max, s->vel_map->local_vel);
+
+    double tpar_min = (s->info.mass/6.0)*pow(dv_max[0],2);
+    double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_max[1] : tpar_min;
     bgk->vtsq_min = (tpar_min + 2.0*tperp_min)/(3.0*s->info.mass);
+
     bgk->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->confBasis, app->poly_order+1,
       nuFrac, 1.0, 1.0, app->use_gpu);
     bgk->self_nu_fac = nuFrac*gkyl_calc_norm_nu(s->info.collisions.n_ref, s->info.collisions.n_ref, 
       s->info.mass, s->info.mass, s->info.charge, s->info.charge, 
       s->info.collisions.T_ref, s->info.collisions.T_ref, bmag_mid, eps0, hbar, eV);
+
     // Create arrays for scaling collisionality by normalization factor
     // norm_nu is computed from Spitzer calc and is the normalization factor for the local
     // density and thermal velocity, norm_nu_sr = n/(vth_s^2 + vth_r^2)^(3/2)

--- a/apps/gk_species_bgk.c
+++ b/apps/gk_species_bgk.c
@@ -38,7 +38,7 @@ gk_species_bgk_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, stru
 
     // Compute a minimum representable temperature based on the smallest dv in the grid.
     double dv_min[vdim];
-    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MAX, dv_min, s->vel_map->local_vel);
+    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MIN, dv_min, s->vel_map->local_vel);
 
     double tpar_min = (s->info.mass/6.0)*pow(dv_min[0],2);
     double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_min[1] : tpar_min;

--- a/apps/gk_species_lbo.c
+++ b/apps/gk_species_lbo.c
@@ -37,13 +37,12 @@ gk_species_lbo_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, stru
     double bmag_mid = s->info.collisions.bmag_mid ? s->info.collisions.bmag_mid : bmag_mid_ptr[0];
     gkyl_array_release(bmag_mid_host);
 
-    // Compute a minimum representable temperature based on the largest dv in the grid.
-    // This is pessimistic for nonuniform grids, but it's a conservative choice for now.
-    double dv_max[vdim];
-    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MAX, dv_max, s->vel_map->local_vel);
+    // Compute a minimum representable temperature based on the smallest dv in the grid.
+    double dv_min[vdim];
+    gkyl_velocity_map_reduce_dv_range(s->vel_map, GKYL_MIN, dv_min, s->vel_map->local_vel);
 
-    double tpar_min = (s->info.mass/6.0)*pow(dv_max[0],2);
-    double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_max[1] : tpar_min;
+    double tpar_min = (s->info.mass/6.0)*pow(dv_min[0],2);
+    double tperp_min = vdim>1 ? (bmag_mid/3.0)*dv_min[1] : tpar_min;
     lbo->vtsq_min = (tpar_min + 2.0*tperp_min)/(3.0*s->info.mass);
 
     lbo->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->confBasis, app->poly_order+1,

--- a/unit/ctest_velocity_map.c
+++ b/unit/ctest_velocity_map.c
@@ -175,6 +175,48 @@ test_vmap_1x2v_p1(bool use_gpu)
   }
   gkyl_array_release(vmap_ref);
 
+  // Check min/max cell lengths over the whole grid.
+  double dv_min[vdim], dv_max[vdim];
+  gkyl_velocity_map_reduce_dv(gvm, GKYL_MIN, dv_min);
+  gkyl_velocity_map_reduce_dv(gvm, GKYL_MAX, dv_max);
+
+  double dv_comp[vdim];
+  for (int d=0; d<vdim; d++) {
+    dv_comp[d] = (upper_vel[d] - lower_vel[d])/cells_vel[d];
+  }
+  for (int d=0; d<vdim; d++) {
+    double vc_lo[1], vc_up[1];
+    double vp_lo[1], vp_up[1];
+  
+    // Check min dv.
+    vc_lo[0] = 0.0;
+    vc_up[0] = dv_comp[d];
+    if (d==0) {
+      test_vmap_1x2v_p1_mapc2p_vel_vpar(0.0, vc_lo, vp_lo, NULL);
+      test_vmap_1x2v_p1_mapc2p_vel_vpar(0.0, vc_up, vp_up, NULL);
+    }
+    else {
+      test_vmap_1x2v_p1_mapc2p_vel_mu(0.0, vc_lo, vp_lo, NULL);
+      test_vmap_1x2v_p1_mapc2p_vel_mu(0.0, vc_up, vp_up, NULL);
+    }
+    double dv_min_ref = vp_up[0] - vp_lo[0];
+    TEST_CHECK( gkyl_compare(dv_min[d], dv_min_ref, 1e-12) );
+
+    // Check max dv.
+    vc_lo[0] = upper_vel[d]-dv_comp[d];
+    vc_up[0] = upper_vel[d];
+    if (d==0) {
+      test_vmap_1x2v_p1_mapc2p_vel_vpar(0.0, vc_lo, vp_lo, NULL);
+      test_vmap_1x2v_p1_mapc2p_vel_vpar(0.0, vc_up, vp_up, NULL);
+    }
+    else {
+      test_vmap_1x2v_p1_mapc2p_vel_mu(0.0, vc_lo, vp_lo, NULL);
+      test_vmap_1x2v_p1_mapc2p_vel_mu(0.0, vc_up, vp_up, NULL);
+    }
+    double dv_max_ref = vp_up[0] - vp_lo[0];
+    TEST_CHECK( gkyl_compare(dv_max[1], dv_max_ref, 1e-12) );
+  }
+
   gkyl_array_release(vmap_ho);
   gkyl_velocity_map_release(gvm);
 }

--- a/zero/gkyl_velocity_map.h
+++ b/zero/gkyl_velocity_map.h
@@ -80,6 +80,30 @@ void
 gkyl_velocity_map_get_boundary_values(const struct gkyl_velocity_map* gvm, double *vbounds);
 
 /**
+ * Reduce (i.e. get the min or max) the cell length in physical
+ * velocity units over the whole velocity grid.
+ *
+ * @param gvm Velocity map object.
+ * @param op GKYL_MIN or GKYL_MAX.
+ * @param dv_m Min/Max velocity cell length on the grid.
+ */
+void
+gkyl_velocity_map_reduce_dv(const struct gkyl_velocity_map* gvm, enum gkyl_array_op op, double *dv_m);
+
+/**
+ * Reduce (i.e. get the min or max) the cell length in physical
+ * velocity units over a specified velocity range.
+ *
+ * @param gvm Velocity map object.
+ * @param op GKYL_MIN or GKYL_MAX.
+ * @param range_vel Velocity range to get min/max dv from.
+ * @param dv_m Min/Max velocity cell length on the grid.
+ */
+void
+gkyl_velocity_map_reduce_dv_range(const struct gkyl_velocity_map* gvm, enum gkyl_array_op op,
+  double *dv_m, struct gkyl_range range_vel);
+
+/**
  * Evaluate the velocity mapping at a specific computational (velocity) coordinate.
  * NOTE: done on the host.
  *


### PR DESCRIPTION
… velocity grid, important for the case of mapped grids. Correct the calculation of vtsq_min in LBO and BGK apps using these methos. Unfortunately, based on LAPD sims, the only thing that makes sense for now is to compute vtsq_min using the largest dv in the grid, which can be very pessimistic where dv is small, but otherwise the sims were crashing. I think the proper thing to do may be to make nu a phase-space array, but I will wait on doing that.