### PR TITLE
Fix missing gk_neut_release, a missing normalization factor in radiation, and other bugs found in the process

### DIFF
--- a/apps/gk_neut_species_moment.c
+++ b/apps/gk_neut_species_moment.c
@@ -8,15 +8,15 @@ gk_neut_species_moment_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_spe
 {
   assert(is_neut_moment_name_valid(nm));
 
-  bool is_integrated = strcmp(nm, "Integrated") == 0;
+  sm->is_integrated = strcmp(nm, "Integrated") == 0;
 
   sm->mcalc = gkyl_dg_updater_moment_new(&s->grid, &app->confBasis, 
     &app->neut_basis, &app->local, &s->local_vel, s->model_id, 0,
-    nm, is_integrated, s->info.mass, app->use_gpu);    
+    nm, sm->is_integrated, s->info.mass, app->use_gpu);    
 
   sm->num_mom = gkyl_dg_updater_moment_num_mom(sm->mcalc);
 
-  if (is_integrated) {
+  if (sm->is_integrated) {
     sm->marr = mkarr(app->use_gpu, sm->num_mom, app->local_ext.volume);
     sm->marr_host = sm->marr;
     if (app->use_gpu)
@@ -53,5 +53,8 @@ gk_neut_species_moment_release(const struct gkyl_gyrokinetic_app *app, const str
   gkyl_dg_updater_moment_release(sm->mcalc);
   gkyl_array_release(sm->marr);
 
-  gkyl_dg_bin_op_mem_release(sm->mem_geo);
+  // free the weak division memory if not computing integrated moments
+  if (!sm->is_integrated) {
+    gkyl_dg_bin_op_mem_release(sm->mem_geo);
+  }
 }

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -604,6 +604,11 @@ gk_species_release(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
 
   gk_species_bflux_release(app, &s->bflux);
 
+  if (s->has_diffusion) {
+    gkyl_array_release(s->diffD);
+    gkyl_dg_updater_diffusion_gyrokinetic_release(s->diff_slvr);
+  }
+
   // Copy BCs are allocated by default. Need to free.
   for (int d=0; d<app->cdim; ++d) {
     if ((s->lower_bc[d].type == GKYL_SPECIES_GK_SHEATH) ||

--- a/apps/gk_species_radiation.c
+++ b/apps/gk_species_radiation.c
@@ -8,7 +8,8 @@ gk_species_radiation_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s
   int pdim = cdim+vdim;
   // Cutoff below which radiation is set to 0. Set to 1eV. Keep the radiation from driving Te negative.
   // Very little radiation below 1eV for most elements.
-  rad->vtsq_min = s->info.charge/s->info.mass;
+  double T_min_eV = 1.0;
+  rad->vtsq_min = T_min_eV*fabs(s->info.charge)/s->info.mass;
   // make appropriate reduced bases and surface bases for radiation variables
   struct gkyl_basis rad_basis, surf_rad_vpar_basis, surf_rad_mu_basis, surf_vpar_basis, surf_mu_basis;
   if (app->poly_order > 1) {

--- a/apps/gk_species_react.c
+++ b/apps/gk_species_react.c
@@ -285,6 +285,7 @@ gk_species_react_release(const struct gkyl_gyrokinetic_app *app, const struct gk
     gkyl_array_release(react->m0_elc[i]);
     gkyl_array_release(react->m0_ion[i]);
     gkyl_array_release(react->m0_donor[i]);
+    gkyl_array_release(react->m0_mod[i]);
     gkyl_array_release(react->prim_vars[i]); 
     gkyl_array_release(react->prim_vars_proj_inp[i]); 
 

--- a/apps/gkyl_gyrokinetic_comms.h
+++ b/apps/gkyl_gyrokinetic_comms.h
@@ -42,4 +42,4 @@ gkyl_gyrokinetic_comms_new(bool use_mpi, bool use_gpu, struct gkyl_rect_decomp *
  * @param comm Communicator object.
  */
 void
-gyrokinetic_comms_release(struct gkyl_rect_decomp *decomp, struct gkyl_comm *comm);
+gkyl_gyrokinetic_comms_release(struct gkyl_rect_decomp *decomp, struct gkyl_comm *comm);

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -2572,6 +2572,11 @@ gkyl_gyrokinetic_app_release(gkyl_gyrokinetic_app* app)
   if (app->num_species > 0)
     gkyl_free(app->species);
 
+  for (int i=0; i<app->num_neut_species; ++i)
+    gk_neut_species_release(app, &app->neut_species[i]);
+  if (app->num_neut_species > 0)
+    gkyl_free(app->neut_species);
+
   gkyl_comm_release(app->comm);
 
   if (app->use_gpu) {

--- a/apps/gyrokinetic_comms.c
+++ b/apps/gyrokinetic_comms.c
@@ -100,7 +100,7 @@ gkyl_gyrokinetic_comms_new(bool use_mpi, bool use_gpu, struct gkyl_rect_decomp *
 }
 
 void
-gyrokinetic_comms_release(struct gkyl_rect_decomp *decomp, struct gkyl_comm *comm)
+gkyl_gyrokinetic_comms_release(struct gkyl_rect_decomp *decomp, struct gkyl_comm *comm)
 {
   gkyl_rect_decomp_release(decomp);
   gkyl_comm_release(comm);

--- a/regression/rt_gk_asdex_3x2v_p1.c
+++ b/regression/rt_gk_asdex_3x2v_p1.c
@@ -651,7 +651,7 @@ main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_3x2v_p1.c
+++ b/regression/rt_gk_bgk_3x2v_p1.c
@@ -697,7 +697,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_cross_relax_1x2v_p1.c
+++ b/regression/rt_gk_bgk_cross_relax_1x2v_p1.c
@@ -568,7 +568,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_periodic_sod_shock_1x2v_p1.c
+++ b/regression/rt_gk_bgk_periodic_sod_shock_1x2v_p1.c
@@ -418,7 +418,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_relax_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_1x2v_p1.c
@@ -475,7 +475,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_relax_bimaxwellian_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_bimaxwellian_1x2v_p1.c
@@ -513,7 +513,7 @@ main(int argc, char **argv)
 
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_bgk_relax_bimaxwellian_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_bimaxwellian_nonuniformv_1x2v_p1.c
@@ -539,7 +539,7 @@ main(int argc, char **argv)
 
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -895,7 +895,7 @@ main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_ion_sound_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_1x2v_p1.c
@@ -436,7 +436,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
@@ -439,7 +439,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_ion_sound_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_nonuniformv_1x2v_p1.c
@@ -511,7 +511,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lapd_cart_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cart_3x2v_p1.c
@@ -692,7 +692,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lapd_cyl_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cyl_3x2v_p1.c
@@ -690,7 +690,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_cross_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_cross_relax_1x2v_p1.c
@@ -560,7 +560,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_1x2v_p1.c
@@ -332,7 +332,7 @@ main(int argc, char **argv)
   struct gkyl_gk app_inp = {
     .name = "gk_lbo_relax_1x2v_p1",
 
-    .cdim = 1, .vdim = 2,
+    .cdim = ctx.cdim, .vdim = ctx.vdim,
     .lower = { 0.0 },
     .upper = { ctx.Lz },
     .cells = { cells_x[0] },

--- a/regression/rt_gk_lbo_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_1x2v_p1.c
@@ -473,7 +473,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_1x2v_p1.c
@@ -628,7 +628,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_3x2v_p1.c
@@ -638,7 +638,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_relax_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_nonuniformv_1x2v_p1.c
@@ -503,7 +503,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
@@ -7,17 +7,6 @@
 #include <gkyl_const.h>
 #include <gkyl_fem_parproj.h>
 #include <gkyl_gyrokinetic.h>
-#include <gkyl_util.h>
-
-#include <gkyl_null_comm.h>
-
-#ifdef GKYL_HAVE_MPI
-#include <mpi.h>
-#include <gkyl_mpi_comm.h>
-#ifdef GKYL_HAVE_NCCL
-#include <gkyl_nccl_comm.h>
-#endif
-#endif
 
 #include <rt_arg_parse.h>
 
@@ -25,6 +14,8 @@ struct lbo_relax_varnu_ctx
 {
   // Mathematical constants (dimensionless).
   double pi;
+
+  int cdim, vdim; // Dimensionality.
 
   // Physical constants (using normalized code units).
   double mass; // Top hat/bump mass.
@@ -51,6 +42,7 @@ struct lbo_relax_varnu_ctx
   int Nz; // Cell count (configuration space: z-direction).
   int Nvpar; // Cell count (velocity space: parallel velocity direction).
   int Nmu; // Cell count (velocity space: magnetic moment direction).
+  int cells[GKYL_MAX_DIM]; // Number of cells in all directions.
   double Lz; // Domain size (configuration space: z-direction).
   double vpar_max; // Domain boundary (velocity space: parallel velocity direction).
   double mu_max; // Domain boundary (velocity space: magnetic moment direction).
@@ -67,6 +59,8 @@ create_ctx(void)
 {
   // Mathematical constants (dimensionless).
   double pi = M_PI;
+
+  int cdim = 1, vdim = 2; // Dimensionality.
 
   // Physical constants (using normalized code units).
   double mass = 1.0; // Top hat/bump mass.
@@ -105,6 +99,8 @@ create_ctx(void)
   
   struct lbo_relax_varnu_ctx ctx = {
     .pi = pi,
+    .cdim = cdim,
+    .vdim = vdim,
     .mass = mass,
     .charge = charge,
     .B0 = B0,
@@ -122,6 +118,7 @@ create_ctx(void)
     .Nz = Nz,
     .Nvpar = Nvpar,
     .Nmu = Nmu,
+    .cells = {Nz, Nvpar, Nmu},
     .Lz = Lz,
     .vpar_max = vpar_max,
     .mu_max = mu_max,
@@ -262,96 +259,23 @@ main(int argc, char **argv)
 
   struct lbo_relax_varnu_ctx ctx = create_ctx(); // Context for initialization functions.
 
-  int NZ = APP_ARGS_CHOOSE(app_args.xcells[0], ctx.Nz);
-  int NVPAR = APP_ARGS_CHOOSE(app_args.vcells[0], ctx.Nvpar);
-  int NMU = APP_ARGS_CHOOSE(app_args.vcells[1], ctx.Nmu);
-
-  // Create global range.
-  int ccells[] = { NZ };
-  int cdim = sizeof(ccells) / sizeof(ccells[0]);
-  struct gkyl_range cglobal_r;
-  gkyl_create_global_range(cdim, ccells, &cglobal_r);
+  int cells_x[ctx.cdim], cells_v[ctx.vdim];
+  for (int d=0; d<ctx.cdim; d++)
+    cells_x[d] = APP_ARGS_CHOOSE(app_args.xcells[d], ctx.cells[d]);
+  for (int d=0; d<ctx.vdim; d++)
+    cells_v[d] = APP_ARGS_CHOOSE(app_args.vcells[d], ctx.cells[ctx.cdim+d]);
 
   // Create decomposition.
-  int cuts[cdim];
-#ifdef GKYL_HAVE_MPI  
-  for (int d = 0; d < cdim; d++) {
-    if (app_args.use_mpi) {
-      cuts[d] = app_args.cuts[d];
-    }
-    else {
-      cuts[d] = 1;
-    }
-  }
-#else
-  for (int d = 0; d < cdim; d++) {
-    cuts[d] = 1;
-  }
-#endif  
-    
-  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(cdim, cuts, &cglobal_r);
+  struct gkyl_rect_decomp *decomp = gkyl_gyrokinetic_comms_decomp_new(ctx.cdim, cells_x, app_args.cuts, app_args.use_mpi, stderr);
 
   // Construct communicator for use in app.
-  struct gkyl_comm *comm;
+  struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, decomp, stderr);
+
+  int my_rank = 0;
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_gpu && app_args.use_mpi) {
-#ifdef GKYL_HAVE_NCCL
-    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-        .decomp = decomp
-      }
-    );
-#else
-    printf(" Using -g and -M together requires NCCL.\n");
-    assert(0 == 1);
+  if (app_args.use_mpi)
+    gkyl_comm_get_rank(comm, &my_rank);
 #endif
-  }
-  else if (app_args.use_mpi) {
-    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-        .decomp = decomp
-      }
-    );
-  }
-  else {
-    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .decomp = decomp,
-        .use_gpu = app_args.use_gpu
-      }
-    );
-  }
-#else
-  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp,
-      .use_gpu = app_args.use_gpu
-    }
-  );
-#endif
-
-  int my_rank, comm_size;
-  gkyl_comm_get_rank(comm, &my_rank);
-  gkyl_comm_get_size(comm, &comm_size);
-
-  int ncuts = 1;
-  for (int d = 0; d < cdim; d++) {
-    ncuts *= cuts[d];
-  }
-
-  if (ncuts != comm_size) {
-    if (my_rank == 0) {
-      fprintf(stderr, "*** Number of ranks, %d, does not match total cuts, %d!\n", comm_size, ncuts);
-    }
-    goto mpifinalize;
-  }
-
-  for (int d = 0; d < cdim - 1; d++) {
-    if (cuts[d] > 1) {
-      if (my_rank == 0) {
-        fprintf(stderr, "*** Parallelization only allowed in z. Number of ranks, %d, in direction %d cannot be > 1!\n", cuts[d], d);
-      }
-      goto mpifinalize;
-    }
-  }
 
   // Top hat species.
   struct gkyl_gyrokinetic_species square = {
@@ -359,7 +283,7 @@ main(int argc, char **argv)
     .charge = ctx.charge, .mass = ctx.mass,
     .lower = { -ctx.vpar_max, 0.0 },
     .upper = { ctx.vpar_max, ctx.mu_max },
-    .cells = { NVPAR, NMU },
+    .cells = { cells_v[0], cells_v[1] },
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -390,7 +314,7 @@ main(int argc, char **argv)
     .charge = ctx.charge, .mass = ctx.mass,
     .lower = { -ctx.vpar_max, 0.0 },
     .upper = { ctx.vpar_max, ctx.mu_max },
-    .cells = { NVPAR, NMU },
+    .cells = { cells_v[0], cells_v[1] },
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -428,10 +352,10 @@ main(int argc, char **argv)
   struct gkyl_gk app_inp = {
     .name = "gk_lbo_relax_varnu_1x2v_p1",
 
-    .cdim = 1, .vdim = 2,
+    .cdim = ctx.cdim, .vdim = ctx.vdim,
     .lower = { 0.0 },
     .upper = { ctx.Lz },
-    .cells = { NZ },
+    .cells = { cells_x[0] },
     .poly_order = 1,
     .basis_type = app_args.basis_type,
 
@@ -569,10 +493,8 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gkyl_rect_decomp_release(decomp);
-  gkyl_comm_release(comm);
+  gyrokinetic_comms_release(decomp, comm);
 
-  mpifinalize:
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {
     MPI_Finalize();

--- a/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
@@ -493,7 +493,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_li_react_3x2v_p1.c
+++ b/regression/rt_gk_li_react_3x2v_p1.c
@@ -883,7 +883,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_ltx_1x2v_p1.c
+++ b/regression/rt_gk_ltx_1x2v_p1.c
@@ -747,7 +747,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
@@ -649,7 +649,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_mdpx_cart_3x2v_p1.c
+++ b/regression/rt_gk_mdpx_cart_3x2v_p1.c
@@ -670,7 +670,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
@@ -966,7 +966,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
@@ -1054,7 +1054,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
@@ -996,7 +996,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_rad_1x2v_p1.c
+++ b/regression/rt_gk_rad_1x2v_p1.c
@@ -12,11 +12,11 @@
 
 struct rad_ctx
 {
-  int cdim, vdim; // Dimensionality.
-  
   // Mathematical constants (dimensionless).
   double pi;
 
+  int cdim, vdim; // Dimensionality.
+  
   // Physical constants (using non-normalized physical units).
   double epsilon0; // Permittivity of free space.
   double mass_elc; // Electron mass.
@@ -50,6 +50,7 @@ struct rad_ctx
   int Nz; // Cell count (configuration space: z-direction).
   int Nvpar; // Cell count (velocity space: parallel velocity direction).
   int Nmu; // Cell count (velocity space: magnetic moment direction).
+  int cells[GKYL_MAX_DIM]; // Number of cells in all directions.
   double Lz; // Domain size (configuration space: z-direction).
   double vpar_max_elc; // Domain boundary (electron velocity space: parallel velocity direction).
   double mu_max_elc; // Domain boundary (electron velocity space: magnetic moment direction).
@@ -69,9 +70,7 @@ create_ctx(void)
   // Mathematical constants (dimensionless).
   double pi = M_PI;
 
-  // Dimensionality.
-  int cdim = 1, vdim = 2;
-  int pdim = cdim+vdim;
+  int cdim = 1, vdim = 2; // Dimensionality.
 
   // Physical constants (using non-normalized physical units).
   double epsilon0 = GKYL_EPSILON0; // Permittivity of free space.
@@ -125,6 +124,8 @@ create_ctx(void)
   
   struct rad_ctx ctx = {
     .pi = pi,
+    .cdim = cdim,
+    .vdim = vdim,
     .epsilon0 = epsilon0,
     .mass_elc = mass_elc,
     .charge_elc = charge_elc,
@@ -149,6 +150,7 @@ create_ctx(void)
     .Nz = Nz,
     .Nvpar = Nvpar,
     .Nmu = Nmu,
+    .cells = {Nz, Nvpar, Nmu},
     .Lz = Lz,
     .vpar_max_elc = vpar_max_elc,
     .mu_max_elc = mu_max_elc,
@@ -292,98 +294,23 @@ main(int argc, char **argv)
 
   struct rad_ctx ctx = create_ctx(); // Context for initialization functions.
 
-  int NZ = APP_ARGS_CHOOSE(app_args.xcells[0], ctx.Nz);
-  int NVPAR = APP_ARGS_CHOOSE(app_args.vcells[0], ctx.Nvpar);
-  int NMU = APP_ARGS_CHOOSE(app_args.vcells[1], ctx.Nmu);
-
-  // Create global range.
-  int ccells[] = { NZ };
-  int cdim = sizeof(ccells) / sizeof(ccells[0]);
-  struct gkyl_range cglobal_r;
-  gkyl_create_global_range(cdim, ccells, &cglobal_r);
+  int cells_x[ctx.cdim], cells_v[ctx.vdim];
+  for (int d=0; d<ctx.cdim; d++)
+    cells_x[d] = APP_ARGS_CHOOSE(app_args.xcells[d], ctx.cells[d]);
+  for (int d=0; d<ctx.vdim; d++)
+    cells_v[d] = APP_ARGS_CHOOSE(app_args.vcells[d], ctx.cells[ctx.cdim+d]);
 
   // Create decomposition.
-  int cuts[cdim];
-#ifdef GKYL_HAVE_MPI  
-  for (int d = 0; d < cdim; d++) {
-    if (app_args.use_mpi) {
-      cuts[d] = app_args.cuts[d];
-    }
-    else {
-      cuts[d] = 1;
-    }
-  }
-#else
-  for (int d = 0; d < cdim; d++) {
-    cuts[d] = 1;
-  }
-#endif  
-    
-  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(cdim, cuts, &cglobal_r);
+  struct gkyl_rect_decomp *decomp = gkyl_gyrokinetic_comms_decomp_new(ctx.cdim, cells_x, app_args.cuts, app_args.use_mpi, stderr);
 
   // Construct communicator for use in app.
-  struct gkyl_comm *comm;
+  struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, decomp, stderr);
+
+  int my_rank = 0;
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_gpu && app_args.use_mpi) {
-#ifdef GKYL_HAVE_NCCL
-    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-        .decomp = decomp
-      }
-    );
-#else
-    printf(" Using -g and -M together requires NCCL.\n");
-    assert(0 == 1);
+  if (app_args.use_mpi)
+    gkyl_comm_get_rank(comm, &my_rank);
 #endif
-  }
-  else if (app_args.use_mpi) {
-    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-        .decomp = decomp
-      }
-    );
-  }
-  else {
-    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
-      {
-        .decomp = decomp,
-        .use_gpu = app_args.use_gpu
-      }
-    );
-  }
-#else
-  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp)
-    {
-      .decomp = decomp,
-      .use_gpu = app_args.use_gpu
-    }
-  );
-#endif
-
-  int my_rank, comm_size;
-  gkyl_comm_get_rank(comm, &my_rank);
-  gkyl_comm_get_size(comm, &comm_size);
-
-  int ncuts = 1;
-  for (int d = 0; d < cdim; d++) {
-    ncuts *= cuts[d];
-  }
-
-  if (ncuts != comm_size) {
-    if (my_rank == 0) {
-      fprintf(stderr, "*** Number of ranks, %d, does not match total cuts, %d!\n", comm_size, ncuts);
-    }
-    goto mpifinalize;
-  }
-
-  for (int d = 0; d < cdim - 1; d++) {
-    if (cuts[d] > 1) {
-      if (my_rank == 0) {
-        fprintf(stderr, "*** Parallelization only allowed in z. Number of ranks, %d, in direction %d cannot be > 1!\n", cuts[d], d);
-      }
-      goto mpifinalize;
-    }
-  }
 
   // Electron species.
   struct gkyl_gyrokinetic_species elc = {
@@ -391,7 +318,7 @@ main(int argc, char **argv)
     .charge = ctx.charge_elc, .mass = ctx.mass_elc,
     .lower = { -ctx.vpar_max_elc, 0.0 },
     .upper = { ctx.vpar_max_elc, ctx.mu_max_elc },
-    .cells = { NVPAR, NMU },
+    .cells = { cells_v[0], cells_v[1] },
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -445,7 +372,7 @@ main(int argc, char **argv)
     .charge = ctx.charge_ion, .mass = ctx.mass_ion,
     .lower = { -ctx.vpar_max_ion, 0.0 },
     .upper = { ctx.vpar_max_ion, ctx.mu_max_ion },
-    .cells = { NVPAR, NMU },
+    .cells = { cells_v[0], cells_v[1] },
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -494,10 +421,10 @@ main(int argc, char **argv)
   struct gkyl_gk app_inp = {
     .name = "gk_rad_1x2v_p1",
 
-    .cdim = 1, .vdim = 2,
+    .cdim = ctx.cdim, .vdim = ctx.vdim,
     .lower = { -0.5 * ctx.Lz },
     .upper = { 0.5 * ctx.Lz },
-    .cells = { NZ },
+    .cells = { cells_x[0] },
     .poly_order = 1,
     .basis_type = app_args.basis_type,
 
@@ -636,10 +563,8 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gkyl_rect_decomp_release(decomp);
-  gkyl_comm_release(comm);
+  gyrokinetic_comms_release(decomp, comm);
 
-  mpifinalize:
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {
     MPI_Finalize();

--- a/regression/rt_gk_rad_1x2v_p1.c
+++ b/regression/rt_gk_rad_1x2v_p1.c
@@ -563,7 +563,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
@@ -584,7 +584,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_1x2v_p1.c
+++ b/regression/rt_gk_sheath_1x2v_p1.c
@@ -651,7 +651,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_2x2v_p1.c
+++ b/regression/rt_gk_sheath_2x2v_p1.c
@@ -731,7 +731,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -736,7 +736,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_bgk_1x2v_p1.c
+++ b/regression/rt_gk_sheath_bgk_1x2v_p1.c
@@ -650,7 +650,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
@@ -698,7 +698,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
@@ -779,7 +779,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
@@ -785,7 +785,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_solovev_out_3x2v_p1.c
+++ b/regression/rt_gk_solovev_out_3x2v_p1.c
@@ -631,7 +631,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -826,7 +826,7 @@ main(int argc, char **argv)
 
   freeresources:
   // Free resources after simulation completion.
-  gkyl_rect_decomp_release(decomp);
+  gkyl_gyrokinetic_app_release(app);
   gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -827,7 +827,7 @@ main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -1048,7 +1048,7 @@ int main(int argc, char **argv)
   freeresources:
   // simulation complete, free app
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
   
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi)

--- a/regression/rt_gk_wham_2x2v_p1.c
+++ b/regression/rt_gk_wham_2x2v_p1.c
@@ -919,7 +919,7 @@ int main(int argc, char **argv)
   freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
-  gyrokinetic_comms_release(decomp, comm);
+  gkyl_gyrokinetic_comms_release(decomp, comm);
 
 #ifdef GKYL_HAVE_MPI
   if (app_args.use_mpi) {

--- a/zero/dg_rad_gyrokinetic_drag.c
+++ b/zero/dg_rad_gyrokinetic_drag.c
@@ -60,6 +60,8 @@ gkyl_dg_rad_gyrokinetic_drag_new(const struct gkyl_basis *conf_basis,
   grad->cdim = cdim;
   grad->pdim = pdim;
 
+  grad->cellav_norm = 1.0/pow(sqrt(2.0),pdim);
+
   grad->eqn.num_equations = 1;
   grad->eqn.surf_term = surf;
   grad->eqn.boundary_surf_term = boundary_surf;

--- a/zero/dg_rad_gyrokinetic_drag.c
+++ b/zero/dg_rad_gyrokinetic_drag.c
@@ -60,7 +60,7 @@ gkyl_dg_rad_gyrokinetic_drag_new(const struct gkyl_basis *conf_basis,
   grad->cdim = cdim;
   grad->pdim = pdim;
 
-  grad->cellav_norm = 1.0/pow(sqrt(2.0),pdim);
+  grad->cellav_norm_conf = 1.0/pow(sqrt(2.0),cdim);
 
   grad->eqn.num_equations = 1;
   grad->eqn.surf_term = surf;

--- a/zero/gkyl_dg_rad_gyrokinetic_drag_priv.h
+++ b/zero/gkyl_dg_rad_gyrokinetic_drag_priv.h
@@ -38,7 +38,7 @@ struct dg_rad_gyrokinetic_drag {
   struct gkyl_dg_eqn eqn; // Base object.
   int cdim; // Config-space dimensions.
   int pdim; // Phase-space dimensions.
-  double cellav_norm; // Norm factor to multiply 0th DG coeff to get cell ave.
+  double cellav_norm_conf; // Norm factor to multiply 0th DG coeff to get cell ave.
   rad_gyrokinetic_surf_t surf[2]; // Surface terms for acceleration.
   rad_gyrokinetic_boundary_surf_t boundary_surf[2]; // Surface terms for acceleration.
   struct gkyl_range phase_range; // Phase-space range.
@@ -61,7 +61,7 @@ kernel_rad_gyrokinetic_vol_1x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm_conf < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -87,7 +87,7 @@ kernel_rad_gyrokinetic_vol_2x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm_conf < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -113,7 +113,7 @@ kernel_rad_gyrokinetic_vol_3x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm_conf < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -221,7 +221,7 @@ surf(const struct gkyl_dg_eqn *eqn,
     long pidxR = gkyl_range_idx(&grad_drag->phase_range, idxR);
     long cidx = gkyl_range_idx(&grad_drag->conf_range, idxR);
     const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-    if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
+    if ( vtsq[0]*grad_drag->cellav_norm_conf < grad_drag->auxfields.vtsq_min) {   
       return 0.0;
     } else {
       return grad_drag->surf[dir-grad_drag->cdim](xcC, dxC,
@@ -254,7 +254,7 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
   if (dir >= grad_drag->cdim) {
     long cidx = gkyl_range_idx(&grad_drag->conf_range, idxSkin);
     const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-    if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
+    if ( vtsq[0]*grad_drag->cellav_norm_conf < grad_drag->auxfields.vtsq_min) {   
       return 0.0;
     } else {
       int vel_idxEdge[2], vel_idxSkin[2];

--- a/zero/gkyl_dg_rad_gyrokinetic_drag_priv.h
+++ b/zero/gkyl_dg_rad_gyrokinetic_drag_priv.h
@@ -38,6 +38,7 @@ struct dg_rad_gyrokinetic_drag {
   struct gkyl_dg_eqn eqn; // Base object.
   int cdim; // Config-space dimensions.
   int pdim; // Phase-space dimensions.
+  double cellav_norm; // Norm factor to multiply 0th DG coeff to get cell ave.
   rad_gyrokinetic_surf_t surf[2]; // Surface terms for acceleration.
   rad_gyrokinetic_boundary_surf_t boundary_surf[2]; // Surface terms for acceleration.
   struct gkyl_range phase_range; // Phase-space range.
@@ -60,7 +61,7 @@ kernel_rad_gyrokinetic_vol_1x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0] < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -86,7 +87,7 @@ kernel_rad_gyrokinetic_vol_2x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0] < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -112,7 +113,7 @@ kernel_rad_gyrokinetic_vol_3x2v_ser_p1(const struct gkyl_dg_eqn *eqn, const doub
 
   long cidx = gkyl_range_idx(&grad_drag->conf_range, idx);
   const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-  if ( vtsq[0] < grad_drag->auxfields.vtsq_min) {   
+  if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
     return 0.0;
   } else {
     int vel_idx[2];
@@ -220,7 +221,7 @@ surf(const struct gkyl_dg_eqn *eqn,
     long pidxR = gkyl_range_idx(&grad_drag->phase_range, idxR);
     long cidx = gkyl_range_idx(&grad_drag->conf_range, idxR);
     const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-    if ( vtsq[0] < grad_drag->auxfields.vtsq_min) {   
+    if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
       return 0.0;
     } else {
       return grad_drag->surf[dir-grad_drag->cdim](xcC, dxC,
@@ -253,7 +254,7 @@ boundary_surf(const struct gkyl_dg_eqn *eqn,
   if (dir >= grad_drag->cdim) {
     long cidx = gkyl_range_idx(&grad_drag->conf_range, idxSkin);
     const double *vtsq = (const double *) gkyl_array_cfetch(grad_drag->auxfields.vtsq, cidx);
-    if ( vtsq[0] < grad_drag->auxfields.vtsq_min) {   
+    if ( vtsq[0]*grad_drag->cellav_norm < grad_drag->auxfields.vtsq_min) {   
       return 0.0;
     } else {
       int vel_idxEdge[2], vel_idxSkin[2];


### PR DESCRIPTION
Mainly fix the facts that:
1. the gyrokinetic app was not releasing gk_neut_species.
2. the if-statement that shuts off radiation was using the 0th DG coefficient of v_t^2, but was missing the normalization factor (1/pow(sqrt(2),pdim)).

But when I valgrind-ed rt_gk_step_out_2x2v_p1, I found some other releasing errors that we hadn't spotted because we had never released gk_neut_species before. So I fixed those here.

Also:
- Add gyrokinetic_comms to a couple of tests I forgot to add them to in PR #377 
- Append gkyl_ to gyrokinetic_comms_release, since it's public.

Tests ran:
- I checked the radiation reg test and it still produces the same result (I guess it wasn't triggering the low T protection).
- I ran rt_gk_step_out through valgrind (which uses neutrals) and it came out clean.
- I ran rt_gk_lbo_relax_1x2v_p1, rt_gk_lbo_relax_varnu_1x2v_p1 and rt_gk_rad_1x2v_p1, which I added gyrokinetic_comms to, through valgrind and they came out clean.