### PR TITLE
Bump the openmpi version built by gkylzero from 4.1.5 to 4.1.6. This …

### DIFF
--- a/install-deps/build-openmpi.sh
+++ b/install-deps/build-openmpi.sh
@@ -3,7 +3,7 @@
 source ./build-opts.sh
 
 # Install prefix
-PREFIX=$GKYLSOFT/openmpi-4.1.5
+PREFIX=$GKYLSOFT/openmpi-4.1.6
 # Location where dependency sources will be downloaded
 DEP_SOURCES=$GKYLSOFT/dep_src/
 
@@ -14,15 +14,15 @@ if [ "$DOWNLOAD_PKGS" = "yes" ]
 then
     echo "Downloading OpenMPI .."
     # delete old checkout and builds
-    rm -rf openmpi-4.1.5.tar* openmpi-4.1.5
-    curl -L https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz > openmpi-4.1.5.tar.gz
+    rm -rf openmpi-4.1.6.tar* openmpi-4.1.6
+    curl -L https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz > openmpi-4.1.6.tar.gz
 fi
 
 if [ "$BUILD_PKGS" = "yes" ]
 then
     echo "Building OpenMPI .."
-    gunzip -c openmpi-4.1.5.tar.gz | tar xf -
-    cd openmpi-4.1.5
+    gunzip -c openmpi-4.1.6.tar.gz | tar xf -
+    cd openmpi-4.1.6
 
     ./configure --prefix=$PREFIX --enable-mpi-fortran=none CC=$CC CXX=$CXX
     make -j6 install 


### PR DESCRIPTION
…avoids the error message

checking if .note.GNU-stack is needed... /Library/Developer/CommandLineTools/usr/bin/objdump: error: 'conftest.o': Invalid/Unsupported object file format no
checking suffix for labels... :
checking prefix for global symbol labels... none
configure: error: Could not determine global symbol label prefix

on newer Macs or MacOS versions.