### PR TITLE
dg_10m cublasDgemm production

### DIFF
--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -689,7 +689,6 @@ void test_cu_mat_mm_arrays()
   struct gkyl_array *array_ycu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 4, 2);
 
   // fill each A matrix with its number
-  printf("\n");
   for (size_t j=0; j<mat_A->nc; ++j){
     for (size_t i=0; i<mat_A->nr; ++i){
       double a_val = i*3 + j;
@@ -732,6 +731,8 @@ void test_cu_mat_mm_arrays()
 	cublasCreate_v2(&cuh);
 
   cu_mat_mm_array(cuh, alpha, beta, transa, mat_Acu, transb, array_xcu, array_ycu);
+
+  cublasDestroy(cuh);
 
   // copy to host
   gkyl_mat_copy(mat_A, mat_Acu);

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -723,13 +723,7 @@ void test_cu_mat_mm_arrays()
   gkyl_array_copy(array_xcu, array_x);
   gkyl_array_copy(array_ycu, array_y);
 
-  // Creat the cuda handle
-  cublasHandle_t cuh;
-	cublasCreate_v2(&cuh);
-
-  cu_mat_mm_array(cuh, ctest_prob_mem, array_xcu, array_ycu);
-
-  cublasDestroy(cuh);
+  cu_mat_mm_array(ctest_prob_mem, array_xcu, array_ycu);
 
   // copy to host
   gkyl_mat_copy(mat_A, mat_Acu);

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -723,7 +723,7 @@ void test_cu_mat_mm_arrays()
   gkyl_array_copy(array_xcu, array_x);
   gkyl_array_copy(array_ycu, array_y);
 
-  cu_mat_mm_array(ctest_prob_mem, array_xcu, array_ycu);
+  gkyl_cu_mat_mm_array(ctest_prob_mem, array_xcu, array_ycu);
 
   // copy to host
   gkyl_mat_copy(mat_A, mat_Acu);

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -748,10 +748,8 @@ void test_cu_mat_mm_arrays()
       TEST_CHECK ( expected == actual );
     }
   }
-  gkyl_mat_release(mat_A);
   gkyl_array_release(array_x);
   gkyl_array_release(array_y);
-  gkyl_mat_release(mat_Acu);
   gkyl_array_release(array_xcu);
   gkyl_array_release(array_ycu);
   gkyl_cu_mat_mm_array_mem_release(ctest_prob_mem);

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -522,7 +522,7 @@ void test_nmat_mm()
 void test_mat_mm_arrays()
 {
   struct gkyl_mat_mm_array_mem *ctest_prob_mem; 
-  ctest_prob_mem = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
+  ctest_prob_mem = gkyl_mat_mm_array_mem_new(4, 3, 1.0, 0.0, 
     GKYL_NO_TRANS, GKYL_NO_TRANS, false);
 
   struct gkyl_mat *mat_A = ctest_prob_mem->A;
@@ -799,9 +799,9 @@ void test_cu_nmat_mm()
 void test_cu_mat_mm_arrays()
 {
   struct gkyl_mat_mm_array_mem *ctest_prob_mem_ho, *ctest_prob_mem_cu; 
-  ctest_prob_mem_ho = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
+  ctest_prob_mem_ho = gkyl_mat_mm_array_mem_new(4, 3, 1.0, 0.0, 
     GKYL_NO_TRANS, GKYL_NO_TRANS, false);
-  ctest_prob_mem_cu = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
+  ctest_prob_mem_cu = gkyl_mat_mm_array_mem_new(4, 3, 1.0, 0.0, 
     GKYL_NO_TRANS, GKYL_NO_TRANS, true);
 
   struct gkyl_mat *mat_A = ctest_prob_mem_ho->A;

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -525,7 +525,7 @@ void test_mat_mm_arrays()
   ctest_prob_mem = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
     GKYL_NO_TRANS, GKYL_NO_TRANS, false);
 
-  struct gkyl_mat *mat_A = ctest_prob_mem->A_ho;
+  struct gkyl_mat *mat_A = ctest_prob_mem->A;
   struct gkyl_array *array_x = gkyl_array_new(GKYL_DOUBLE, 3, 2);
   struct gkyl_array *array_y = gkyl_array_new(GKYL_DOUBLE, 4, 2);
 
@@ -733,15 +733,17 @@ void test_cu_nmat_mm()
 
 void test_cu_mat_mm_arrays()
 {
-  struct gkyl_mat_mm_array_mem *ctest_prob_mem; 
-  ctest_prob_mem = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
+  struct gkyl_mat_mm_array_mem *ctest_prob_mem_ho, *ctest_prob_mem_cu; 
+  ctest_prob_mem_ho = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
+    GKYL_NO_TRANS, GKYL_NO_TRANS, false);
+  ctest_prob_mem_cu = gkyl_mat_mm_array_mem_dev_new(4, 3, 1.0, 0.0, 
     GKYL_NO_TRANS, GKYL_NO_TRANS, true);
 
-  struct gkyl_mat *mat_A = ctest_prob_mem->A_ho;
+  struct gkyl_mat *mat_A = ctest_prob_mem_ho->A;
   struct gkyl_array *array_x = gkyl_array_new(GKYL_DOUBLE, 3, 2);
   struct gkyl_array *array_y = gkyl_array_new(GKYL_DOUBLE, 4, 2);
 
-  struct gkyl_mat *mat_Acu = ctest_prob_mem->A_cu;
+  struct gkyl_mat *mat_Acu = ctest_prob_mem_cu->A;
   struct gkyl_array *array_xcu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 3, 2);
   struct gkyl_array *array_ycu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 4, 2);
 
@@ -777,7 +779,7 @@ void test_cu_mat_mm_arrays()
   gkyl_array_copy(array_xcu, array_x);
   gkyl_array_copy(array_ycu, array_y);
 
-  gkyl_mat_mm_array(ctest_prob_mem, array_xcu, array_ycu);
+  gkyl_mat_mm_array(ctest_prob_mem_cu, array_xcu, array_ycu);
 
   // copy to host
   gkyl_mat_copy(mat_A, mat_Acu);
@@ -800,7 +802,8 @@ void test_cu_mat_mm_arrays()
   gkyl_array_release(array_y);
   gkyl_array_release(array_xcu);
   gkyl_array_release(array_ycu);
-  gkyl_mat_mm_array_mem_release(ctest_prob_mem);
+  gkyl_mat_mm_array_mem_release(ctest_prob_mem_ho);
+  gkyl_mat_mm_array_mem_release(ctest_prob_mem_cu);
 
 }
 

--- a/unit/ctest_mat.c
+++ b/unit/ctest_mat.c
@@ -679,12 +679,15 @@ void test_cu_nmat_mm()
 
 void test_cu_mat_mm_arrays()
 {
+  struct gkyl_cu_mat_mm_array_mem *ctest_prob_mem; 
+  ctest_prob_mem = gkyl_cu_mat_mm_array_mem_cu_dev_new(4, 3, 1.0, 0.0, 
+    GKYL_NO_TRANS, GKYL_NO_TRANS);
 
-  struct gkyl_mat *mat_A = gkyl_mat_new(4, 3, 0.0);
+  struct gkyl_mat *mat_A = ctest_prob_mem->A_ho;
   struct gkyl_array *array_x = gkyl_array_new(GKYL_DOUBLE, 3, 2);
   struct gkyl_array *array_y = gkyl_array_new(GKYL_DOUBLE, 4, 2);
 
-  struct gkyl_mat *mat_Acu = gkyl_mat_cu_dev_new(4, 3);
+  struct gkyl_mat *mat_Acu = ctest_prob_mem->A_cu;
   struct gkyl_array *array_xcu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 3, 2);
   struct gkyl_array *array_ycu = gkyl_array_cu_dev_new(GKYL_DOUBLE, 4, 2);
 
@@ -715,12 +718,6 @@ void test_cu_mat_mm_arrays()
     }
   } 
 
-  enum gkyl_mat_trans transa = GKYL_NO_TRANS;
-  enum gkyl_mat_trans transb = GKYL_NO_TRANS;
-  double alpha = 1.0;
-  double beta = 0.0;
-
-
   // copy to device
   gkyl_mat_copy(mat_Acu, mat_A);
   gkyl_array_copy(array_xcu, array_x);
@@ -730,7 +727,7 @@ void test_cu_mat_mm_arrays()
   cublasHandle_t cuh;
 	cublasCreate_v2(&cuh);
 
-  cu_mat_mm_array(cuh, alpha, beta, transa, mat_Acu, transb, array_xcu, array_ycu);
+  cu_mat_mm_array(cuh, ctest_prob_mem, array_xcu, array_ycu);
 
   cublasDestroy(cuh);
 
@@ -757,7 +754,7 @@ void test_cu_mat_mm_arrays()
   gkyl_mat_release(mat_Acu);
   gkyl_array_release(array_xcu);
   gkyl_array_release(array_ycu);
-
+  gkyl_cu_mat_mm_array_mem_release(ctest_prob_mem);
 
 }
 

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -43,7 +43,7 @@ typedef struct gkyl_nmat_mem gkyl_nmat_mem;
 
 // Type for storing preallocating memory needed specificially for 
 // cu_mat_mm_array
-typedef struct gkyl_phase_nodal_to_modal_mem gkyl_phase_nodal_to_modal_mem;
+typedef struct gkyl_cu_mat_mm_array_mem gkyl_cu_mat_mm_array_mem;
 
 /**
  * Construct new matrix with all elements initialized to @a
@@ -361,7 +361,7 @@ void gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem);
  * @param transb Whether or not to transpose B
  * @return Preallocated memory
  */
-gkyl_phase_nodal_to_modal_mem *gkyl_phase_nodal_to_modal_cu_dev_new(int nr, int nc,
+gkyl_cu_mat_mm_array_mem *gkyl_mat_mm_array_mem_cu_dev_new(int nr, int nc,
   double alpha, double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb);
 
 /**
@@ -369,7 +369,7 @@ gkyl_phase_nodal_to_modal_mem *gkyl_phase_nodal_to_modal_cu_dev_new(int nr, int 
  *
  * @param mem Memory to release
  */
-void gkyl_phase_nodal_to_modal_release(gkyl_phase_nodal_to_modal_mem *mem);
+void gkyl_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
 
 /**
  * Solve a batched system of linear equations using LU

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -42,8 +42,8 @@ struct gkyl_nmat {
 typedef struct gkyl_nmat_mem gkyl_nmat_mem;
 
 // Type for storing preallocating memory needed specificially for 
-// cu_mat_mm_array
-typedef struct gkyl_cu_mat_mm_array_mem gkyl_cu_mat_mm_array_mem;
+// mat_mm_array
+typedef struct gkyl_mat_mm_array_mem gkyl_mat_mm_array_mem;
 
 /**
  * Construct new matrix with all elements initialized to @a
@@ -359,23 +359,24 @@ void gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem);
  * @param beta Coefficient infron of C
  * @param transa Whether or not to transpose A
  * @param transb Whether or not to transpose B
+ * @param use_gpu 
  * @return Preallocated memory
  */
-gkyl_cu_mat_mm_array_mem *gkyl_cu_mat_mm_array_mem_cu_dev_new(int nr, int nc,
-  double alpha, double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb);
+gkyl_mat_mm_array_mem *gkyl_mat_mm_array_mem_dev_new(int nr, int nc, double alpha, 
+  double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb, bool use_gpu);
 
 /**
  * Release memory allocated for batched LU solves.
  *
  * @param mem Memory to release
  */
-void gkyl_cu_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
+void gkyl_mat_mm_array_mem_release(gkyl_mat_mm_array_mem *mem);
 
 #ifdef GKYL_HAVE_CUDA
 
 /**
  * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
- * This is done using the cublas_v2 library. The function here, cu_mat_mm_array is designed specifically so
+ * This is done using the cublas_v2 library. The function here, mat_mm_array is designed specifically so
  * A is type gkyl_mat_trans, and B/C are gkyl_arrays. This is purposefully done for calculations with
  * small A but and very large B, C where we don't wish to translate B, C to mat/nmat types. 
  * 
@@ -385,7 +386,7 @@ void gkyl_cu_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
  * @param B gkyl_array matrix for computing A*B = C
  * @param C gkyl_array matrix for computing A*B = C
 */
-void gkyl_cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
+void gkyl_mat_mm_array(struct gkyl_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
   
 #endif
 

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -16,7 +16,6 @@ enum gkyl_mat_trans { GKYL_NO_TRANS, GKYL_TRANS, GKYL_CONJ_TRANS };
 struct gkyl_mat {
   size_t nr, nc; // Number of rows, columns
   double *data; // Pointer to data
-  double **mptr; // pointers to start of each sub-matrix
 
   uint32_t flags;  
   struct gkyl_ref_count ref_count;

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <gkyl_array.h>
 #include <gkyl_ref_count.h>
 #include <gkyl_util.h>
 
@@ -369,6 +370,24 @@ gkyl_cu_mat_mm_array_mem *gkyl_cu_mat_mm_array_mem_cu_dev_new(int nr, int nc,
  * @param mem Memory to release
  */
 void gkyl_cu_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
+
+#ifdef GKYL_HAVE_CUDA
+
+/**
+ * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
+ * This is done using the cublas_v2 library. The function here, cu_mat_mm_array is designed specifically so
+ * A is type gkyl_mat_trans, and B/C are gkyl_arrays. This is purposefully done for calculations with
+ * small A but and very large B, C where we don't wish to translate B, C to mat/nmat types. 
+ * 
+ * Such calculations use this function like the conversion from nodal to modal representation of phase space
+ * quantities.
+ * @param mem structure containing the A matrix, associated transpose properties, alpha, beta
+ * @param B gkyl_array matrix for computing A*B = C
+ * @param C gkyl_array matrix for computing A*B = C
+*/
+void gkyl_cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
+  
+#endif
 
 /**
  * Solve a batched system of linear equations using LU

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -41,6 +41,10 @@ struct gkyl_nmat {
 // operations
 typedef struct gkyl_nmat_mem gkyl_nmat_mem;
 
+// Type for storing preallocating memory needed specificially for 
+// cu_mat_mm_array
+typedef struct gkyl_phase_nodal_to_modal_mem gkyl_phase_nodal_to_modal_mem;
+
 /**
  * Construct new matrix with all elements initialized to @a
  * val. Delete using gkyl_mat_release method.
@@ -344,6 +348,28 @@ gkyl_nmat_mem *gkyl_nmat_linsolve_lu_cu_dev_new(size_t num, size_t nrow);
  * @param mem Memory to release
  */
 void gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem);
+
+/**
+ * Allocate memory needed in modal to nodal conversion matrices needed 
+ * by cublasDgemm
+ *
+ * @param nr Number of rows in the matrix A
+ * @param nc Number of columns in the matrix A
+ * @param alpha Coefficient infront of A*B
+ * @param beta Coefficient infron of C
+ * @param transa Whether or not to transpose A
+ * @param transb Whether or not to transpose B
+ * @return Preallocated memory
+ */
+gkyl_phase_nodal_to_modal_mem *gkyl_phase_nodal_to_modal_cu_dev_new(int nr, int nc,
+  double alpha, double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb);
+
+/**
+ * Release memory allocated for batched LU solves.
+ *
+ * @param mem Memory to release
+ */
+void gkyl_phase_nodal_to_modal_release(gkyl_phase_nodal_to_modal_mem *mem);
 
 /**
  * Solve a batched system of linear equations using LU

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -362,7 +362,7 @@ void gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem);
  * @param use_gpu 
  * @return Preallocated memory
  */
-gkyl_mat_mm_array_mem *gkyl_mat_mm_array_mem_dev_new(int nr, int nc, double alpha, 
+gkyl_mat_mm_array_mem *gkyl_mat_mm_array_mem_new(int nr, int nc, double alpha, 
   double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb, bool use_gpu);
 
 /**

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -361,7 +361,7 @@ void gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem);
  * @param transb Whether or not to transpose B
  * @return Preallocated memory
  */
-gkyl_cu_mat_mm_array_mem *gkyl_mat_mm_array_mem_cu_dev_new(int nr, int nc,
+gkyl_cu_mat_mm_array_mem *gkyl_cu_mat_mm_array_mem_cu_dev_new(int nr, int nc,
   double alpha, double beta, enum gkyl_mat_trans transa, enum gkyl_mat_trans transb);
 
 /**
@@ -369,7 +369,7 @@ gkyl_cu_mat_mm_array_mem *gkyl_mat_mm_array_mem_cu_dev_new(int nr, int nc,
  *
  * @param mem Memory to release
  */
-void gkyl_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
+void gkyl_cu_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem);
 
 /**
  * Solve a batched system of linear equations using LU

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -372,8 +372,6 @@ gkyl_mat_mm_array_mem *gkyl_mat_mm_array_mem_dev_new(int nr, int nc, double alph
  */
 void gkyl_mat_mm_array_mem_release(gkyl_mat_mm_array_mem *mem);
 
-#ifdef GKYL_HAVE_CUDA
-
 /**
  * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
  * This is done using the cublas_v2 library. The function here, mat_mm_array is designed specifically so
@@ -387,8 +385,6 @@ void gkyl_mat_mm_array_mem_release(gkyl_mat_mm_array_mem *mem);
  * @param C gkyl_array matrix for computing A*B = C
 */
 void gkyl_mat_mm_array(struct gkyl_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
-  
-#endif
 
 /**
  * Solve a batched system of linear equations using LU

--- a/zero/gkyl_mat.h
+++ b/zero/gkyl_mat.h
@@ -145,7 +145,7 @@ void gkyl_mat_show(const char *name, FILE *fp, const struct gkyl_mat *mat);
  */
 struct gkyl_mat* gkyl_mat_mm(double alpha, double beta,
   enum gkyl_mat_trans transa, const struct gkyl_mat *A,
-  enum gkyl_mat_trans transb, const struct gkyl_mat *B, struct gkyl_mat *C);
+  enum gkyl_mat_trans transb, const struct gkyl_mat *B, struct gkyl_mat *, bool on_gpu);
 
 /**
  * Computes matrix-vector product:

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -1,23 +1,56 @@
 #pragma once
 
-#include <gkyl_ref_count.h>
-#include <gkyl_util.h>
 #include <gkyl_array.h>
+#include <gkyl_mat.h>
+#include <gkyl_util.h>
+#include <gkyl_ref_count.h>
+
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 
 #ifdef GKYL_HAVE_CUDA
-# include <cuda_runtime.h>
-# include <cublas_v2.h>
-
+//#define CUBLAS_H_
+//#include <cuda_runtime.h>
+#if !defined(CUBLAS_V2_H_)
+#include <cublas_v2.h>
+#endif
 
 /**
+ * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
+ * This is done using the cublas_v2 library. The function here, cu_mat_mm_array is designed specifically so
+ * A is type gkyl_mat_trans, and B/C are gkyl_arrays. This is purposefully done for calculations with
+ * small A but and very large B, C where we don't wish to translate B, C to mat/nmat types. 
+ * 
+ * Such calculations use this function like the conversion from nodal to modal representation of phase space
+ * quantities.
  * @param cuh cublasHandle_t object
- * @param alpha 
+ * @param alpha Coefficient infront of A*B
+ * @param beta Coefficient infron of C
+ * @param transa Whether or not to transpose A
+ * @param A gkyl_mat matrix for computing A*B = C
+ * @param transb Whether or not to transpose B
+ * @param B gkyl_array matrix for computing A*B = C
+ * @param C gkyl_array matrix for computing A*B = C
 */
 void cu_mat_mm_array(cublasHandle_t cuh, double alpha, double beta, enum gkyl_mat_trans transa, struct gkyl_mat *A, 
   enum gkyl_mat_trans transb, struct gkyl_array *B, struct gkyl_array *C);
   
 #endif
+
+struct gkyl_phase_nodal_to_modal_mem {
+
+  // info for alpha*matrix_multiplication(A,B) + Beta*C = C 
+  // using cu_mat_mm_array
+  double alpha;
+  double beta;
+  enum gkyl_mat_trans transa;
+  enum gkyl_mat_trans transb;
+  //struct gkyl_mat *A_ho;
+  //struct gkyl_mat *A_cu;
+
+#ifdef GKYL_HAVE_CUDA
+  cublasHandle_t cuh; // cublas handle
+#endif  
+};

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -16,6 +16,26 @@
 #if !defined(CUBLAS_V2_H_)
 #include <cublas_v2.h>
 #endif
+#endif
+
+
+struct gkyl_cu_mat_mm_array_mem {
+
+  // info for alpha*matrix_multiplication(A,B) + Beta*C = C 
+  // using cu_mat_mm_array
+  double alpha;
+  double beta;
+  enum gkyl_mat_trans transa;
+  enum gkyl_mat_trans transb;
+  struct gkyl_mat *A_ho;
+  struct gkyl_mat *A_cu;
+
+#ifdef GKYL_HAVE_CUDA
+  //cublasHandle_t cuh; // cublas handle
+#endif  
+};
+
+#ifdef GKYL_HAVE_CUDA
 
 /**
  * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
@@ -34,23 +54,6 @@
  * @param B gkyl_array matrix for computing A*B = C
  * @param C gkyl_array matrix for computing A*B = C
 */
-void cu_mat_mm_array(cublasHandle_t cuh, double alpha, double beta, enum gkyl_mat_trans transa, struct gkyl_mat *A, 
-  enum gkyl_mat_trans transb, struct gkyl_array *B, struct gkyl_array *C);
+void cu_mat_mm_array(cublasHandle_t cuh, struct gkyl_cu_mat_mm_array_mem *mem, struct gkyl_array *B, struct gkyl_array *C);
   
 #endif
-
-struct gkyl_cu_mat_mm_array_mem {
-
-  // info for alpha*matrix_multiplication(A,B) + Beta*C = C 
-  // using cu_mat_mm_array
-  double alpha;
-  double beta;
-  enum gkyl_mat_trans transa;
-  enum gkyl_mat_trans transb;
-  //struct gkyl_mat *A_ho;
-  //struct gkyl_mat *A_cu;
-
-#ifdef GKYL_HAVE_CUDA
-  cublasHandle_t cuh; // cublas handle
-#endif  
-};

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -26,8 +26,7 @@ struct gkyl_mat_mm_array_mem {
   double beta;
   enum gkyl_mat_trans transa;
   enum gkyl_mat_trans transb;
-  struct gkyl_mat *A_ho;
-  struct gkyl_mat *A_cu;
+  struct gkyl_mat *A;
 
 #ifdef GKYL_HAVE_CUDA
   cublasHandle_t cuh; // cublas handle

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -46,11 +46,7 @@ struct gkyl_cu_mat_mm_array_mem {
  * Such calculations use this function like the conversion from nodal to modal representation of phase space
  * quantities.
  * @param cuh cublasHandle_t object
- * @param alpha Coefficient infront of A*B
- * @param beta Coefficient infron of C
- * @param transa Whether or not to transpose A
- * @param A gkyl_mat matrix for computing A*B = C
- * @param transb Whether or not to transpose B
+ * @param mem structure containing the A matrix, associated transpose properties, alpha, beta
  * @param B gkyl_array matrix for computing A*B = C
  * @param C gkyl_array matrix for computing A*B = C
 */

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -32,21 +32,3 @@ struct gkyl_cu_mat_mm_array_mem {
   cublasHandle_t cuh; // cublas handle
 #endif  
 };
-
-#ifdef GKYL_HAVE_CUDA
-
-/**
- * Computes: alpha*matrix_multiplication(A,B) + Beta*C = C 
- * This is done using the cublas_v2 library. The function here, cu_mat_mm_array is designed specifically so
- * A is type gkyl_mat_trans, and B/C are gkyl_arrays. This is purposefully done for calculations with
- * small A but and very large B, C where we don't wish to translate B, C to mat/nmat types. 
- * 
- * Such calculations use this function like the conversion from nodal to modal representation of phase space
- * quantities.
- * @param mem structure containing the A matrix, associated transpose properties, alpha, beta
- * @param B gkyl_array matrix for computing A*B = C
- * @param C gkyl_array matrix for computing A*B = C
-*/
-void cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
-  
-#endif

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -28,6 +28,9 @@ struct gkyl_cu_mat_mm_array_mem {
   struct gkyl_mat *A_ho;
   struct gkyl_mat *A_cu;
 
+#ifdef GKYL_HAVE_CUDA
+  cublasHandle_t cuh; // cublas handle
+#endif  
 };
 
 #ifdef GKYL_HAVE_CUDA
@@ -40,11 +43,10 @@ struct gkyl_cu_mat_mm_array_mem {
  * 
  * Such calculations use this function like the conversion from nodal to modal representation of phase space
  * quantities.
- * @param cuh cublasHandle_t object
  * @param mem structure containing the A matrix, associated transpose properties, alpha, beta
  * @param B gkyl_array matrix for computing A*B = C
  * @param C gkyl_array matrix for computing A*B = C
 */
-void cu_mat_mm_array(cublasHandle_t cuh, struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
+void cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
   
 #endif

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -11,8 +11,6 @@
 #include <stdio.h>
 
 #ifdef GKYL_HAVE_CUDA
-//#define CUBLAS_H_
-//#include <cuda_runtime.h>
 #if !defined(CUBLAS_V2_H_)
 #include <cublas_v2.h>
 #endif
@@ -30,9 +28,6 @@ struct gkyl_cu_mat_mm_array_mem {
   struct gkyl_mat *A_ho;
   struct gkyl_mat *A_cu;
 
-#ifdef GKYL_HAVE_CUDA
-  //cublasHandle_t cuh; // cublas handle
-#endif  
 };
 
 #ifdef GKYL_HAVE_CUDA
@@ -50,6 +45,6 @@ struct gkyl_cu_mat_mm_array_mem {
  * @param B gkyl_array matrix for computing A*B = C
  * @param C gkyl_array matrix for computing A*B = C
 */
-void cu_mat_mm_array(cublasHandle_t cuh, struct gkyl_cu_mat_mm_array_mem *mem, struct gkyl_array *B, struct gkyl_array *C);
+void cu_mat_mm_array(cublasHandle_t cuh, struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C);
   
 #endif

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -17,10 +17,11 @@
 #endif
 
 
-struct gkyl_cu_mat_mm_array_mem {
+struct gkyl_mat_mm_array_mem {
 
   // info for alpha*matrix_multiplication(A,B) + Beta*C = C 
-  // using cu_mat_mm_array
+  // using mat_mm_array
+  bool on_gpu; // flag to indicate if we are on GPU
   double alpha;
   double beta;
   enum gkyl_mat_trans transa;

--- a/zero/gkyl_mat_priv.h
+++ b/zero/gkyl_mat_priv.h
@@ -39,7 +39,7 @@ void cu_mat_mm_array(cublasHandle_t cuh, double alpha, double beta, enum gkyl_ma
   
 #endif
 
-struct gkyl_phase_nodal_to_modal_mem {
+struct gkyl_cu_mat_mm_array_mem {
 
   // info for alpha*matrix_multiplication(A,B) + Beta*C = C 
   // using cu_mat_mm_array

--- a/zero/gkyl_vlasov_lte_proj_on_basis.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis.h
@@ -62,6 +62,12 @@ void gkyl_vlasov_lte_proj_on_basis_advance(gkyl_vlasov_lte_proj_on_basis *up,
   const struct gkyl_array *moms_lte, struct gkyl_array *f_lte);
 
 /**
+ * Host-side wrapper for initial canonical-pb vars
+ */
+void gkyl_vlasov_lte_proj_on_basis_geom_quad_vars_cu(gkyl_vlasov_lte_proj_on_basis *up,
+  const struct gkyl_range *conf_range);
+
+/**
  * Host-side wrapper for projection of LTE distribution function on device
  */
 void gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -89,10 +89,5 @@ struct gkyl_vlasov_lte_proj_on_basis {
                                                                 // stores the info to convert phase
                                                                 // space nodal to modal gkyl arrays  
   struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem;  // modal to nodal mm for h_ij_inv_quad
-  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad
-
-
-#ifdef GKYL_HAVE_CUDA
-  cublasHandle_t cuh; // cublas handle
-#endif                
+  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad               
 };

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -88,6 +88,9 @@ struct gkyl_vlasov_lte_proj_on_basis {
   struct gkyl_cu_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
                                                                 // stores the info to convert phase
                                                                 // space nodal to modal gkyl arrays  
+  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem;  // modal to nodal mm for h_ij_inv_quad
+  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad
+
 
 #ifdef GKYL_HAVE_CUDA
   cublasHandle_t cuh; // cublas handle

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -85,7 +85,7 @@ struct gkyl_vlasov_lte_proj_on_basis {
   struct gkyl_array *num_ratio; // Number density ratio: num_ratio = n_target/n0
   struct gkyl_dg_bin_op_mem *mem; // bin_op memory to compute ratio and rescale distribution function
 
-  //struct gkyl_phase_nodal_to_modal_mem *phase_nodal_to_modal_mem; // structure of data which converts  
+  //struct gkyl_cu_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
                                                                 // stores the info to convert phase
                                                                 // space nodal to modal gkyl arrays  
 

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -85,16 +85,9 @@ struct gkyl_vlasov_lte_proj_on_basis {
   struct gkyl_array *num_ratio; // Number density ratio: num_ratio = n_target/n0
   struct gkyl_dg_bin_op_mem *mem; // bin_op memory to compute ratio and rescale distribution function
 
-  //struct gkyl_cu_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
+  struct gkyl_cu_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
                                                                 // stores the info to convert phase
                                                                 // space nodal to modal gkyl arrays  
-
-  double alpha;
-  double beta;
-  enum gkyl_mat_trans transa;
-  enum gkyl_mat_trans transb;
-  struct gkyl_mat *mat_A; // host side memory for the matrix A in nodal to modal
-  struct gkyl_mat *mat_Acu; // device side memory for the matrix A in nodal to modal 
 
 #ifdef GKYL_HAVE_CUDA
   cublasHandle_t cuh; // cublas handle

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -7,6 +7,8 @@
 #include <gkyl_basis.h>
 #include <gkyl_dg_bin_ops.h>
 #include <gkyl_vlasov_lte_moments.h>
+#include <gkyl_mat.h>
+#include <gkyl_mat_priv.h>
 #include <gkyl_range.h>
 #include <gkyl_rect_grid.h> 
 #include <gkyl_util.h>
@@ -82,4 +84,19 @@ struct gkyl_vlasov_lte_proj_on_basis {
   struct gkyl_vlasov_lte_moments *moments_up; // LTE moment calculation routine for computing density
   struct gkyl_array *num_ratio; // Number density ratio: num_ratio = n_target/n0
   struct gkyl_dg_bin_op_mem *mem; // bin_op memory to compute ratio and rescale distribution function
+
+  //struct gkyl_phase_nodal_to_modal_mem *phase_nodal_to_modal_mem; // structure of data which converts  
+                                                                // stores the info to convert phase
+                                                                // space nodal to modal gkyl arrays  
+
+  double alpha;
+  double beta;
+  enum gkyl_mat_trans transa;
+  enum gkyl_mat_trans transb;
+  struct gkyl_mat *mat_A; // host side memory for the matrix A in nodal to modal
+  struct gkyl_mat *mat_Acu; // device side memory for the matrix A in nodal to modal 
+
+#ifdef GKYL_HAVE_CUDA
+  cublasHandle_t cuh; // cublas handle
+#endif                
 };

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -85,9 +85,9 @@ struct gkyl_vlasov_lte_proj_on_basis {
   struct gkyl_array *num_ratio; // Number density ratio: num_ratio = n_target/n0
   struct gkyl_dg_bin_op_mem *mem; // bin_op memory to compute ratio and rescale distribution function
 
-  struct gkyl_cu_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
+  struct gkyl_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
                                                                 // stores the info to convert phase
                                                                 // space nodal to modal gkyl arrays  
-  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem;  // modal to nodal mm for h_ij_inv_quad
-  struct gkyl_cu_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad               
+  struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem;  // modal to nodal mm for h_ij_inv_quad
+  struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad               
 };

--- a/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
+++ b/zero/gkyl_vlasov_lte_proj_on_basis_priv.h
@@ -87,7 +87,5 @@ struct gkyl_vlasov_lte_proj_on_basis {
 
   struct gkyl_mat_mm_array_mem *phase_nodal_to_modal_mem; // structure of data which converts  
                                                                 // stores the info to convert phase
-                                                                // space nodal to modal gkyl arrays  
-  struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem;  // modal to nodal mm for h_ij_inv_quad
-  struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem;  // modal to nodal mm for det_h_quad               
+                                                                // space nodal to modal gkyl arrays            
 };

--- a/zero/mat.c
+++ b/zero/mat.c
@@ -7,6 +7,11 @@
 
 #include <stdbool.h>
 
+#ifdef GKYL_HAVE_CUDA
+# include <cuda_runtime.h>
+# include <cublas_v2.h>
+#endif
+
 // BLAS and LAPACKE includes
 #ifdef GKYL_USING_FRAMEWORK_ACCELERATE
 # include <Accelerate/Accelerate.h>
@@ -578,7 +583,7 @@ cu_nmat_linsolve_lu(gkyl_nmat_mem *mem, struct gkyl_nmat *A, struct gkyl_nmat *x
 
 #ifdef GKYL_HAVE_CUDA
 void
-cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C)
+gkyl_cu_mat_mm_array(struct gkyl_cu_mat_mm_array_mem *mem, const struct gkyl_array *B, struct gkyl_array *C)
 {
 
   double alpha = mem->alpha;

--- a/zero/mat.c
+++ b/zero/mat.c
@@ -389,11 +389,11 @@ gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem)
   gkyl_free(mem);
 }
 
-gkyl_phase_nodal_to_modal_mem *
-gkyl_phase_nodal_to_modal_cu_dev_new(int nr, int nc, double alpha, double beta, 
+gkyl_cu_mat_mm_array_mem *
+gkyl_mat_mm_array_mem_cu_dev_new(int nr, int nc, double alpha, double beta, 
   enum gkyl_mat_trans transa, enum gkyl_mat_trans transb)
 {
-  gkyl_phase_nodal_to_modal_mem *mem = gkyl_malloc(sizeof(*mem));
+  gkyl_cu_mat_mm_array_mem *mem = gkyl_malloc(sizeof(*mem));
 
   mem->alpha = alpha;
   mem->beta = beta;
@@ -411,7 +411,7 @@ gkyl_phase_nodal_to_modal_cu_dev_new(int nr, int nc, double alpha, double beta,
 }
 
 void
-gkyl_phase_nodal_to_modal_release(gkyl_phase_nodal_to_modal_mem *mem)
+gkyl_mat_mm_array_mem_release(gkyl_cu_mat_mm_array_mem *mem)
 {
   //gkyl_mat_release(mem->A_cu);
   //gkyl_mat_release(mem->A_ho);

--- a/zero/mat.c
+++ b/zero/mat.c
@@ -444,7 +444,7 @@ gkyl_nmat_linsolve_lu_release(gkyl_nmat_mem *mem)
 }
 
 gkyl_mat_mm_array_mem *
-gkyl_mat_mm_array_mem_dev_new(int nr, int nc, double alpha, double beta, 
+gkyl_mat_mm_array_mem_new(int nr, int nc, double alpha, double beta, 
   enum gkyl_mat_trans transa, enum gkyl_mat_trans transb, bool use_gpu)
 {
   gkyl_mat_mm_array_mem *mem = gkyl_malloc(sizeof(*mem));

--- a/zero/mat.c
+++ b/zero/mat.c
@@ -238,6 +238,7 @@ gkyl_mat_new(size_t nr, size_t nc, double val)
   mat->data = gkyl_malloc(sizeof(double[nr*nc]));  
   mat->on_dev = mat; // on CPU this is a self-reference
   mat->ref_count = gkyl_ref_count_init(mat_free);
+  for (size_t i=0; i<nr*nc; ++i) mat->data[i] = val;
   return mat;
 }
 

--- a/zero/mat.c
+++ b/zero/mat.c
@@ -802,7 +802,7 @@ gkyl_nmat_cu_dev_new(size_t num, size_t nr, size_t nc)
 #else
 
 struct gkyl_mat*
-gkyl_mat_cu_dev_new(size_t num, size_t nr, size_t nc)
+gkyl_mat_cu_dev_new(size_t nr, size_t nc)
 {
   assert(false);
   return 0;

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -261,16 +261,11 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
 
     gkyl_mat_copy(up->conf_modal_to_nodal_det_h_quad_mem->A_cu, up->conf_modal_to_nodal_det_h_quad_mem->A_ho);
 
-
-    // Create a cuda handle for all cublas operations
-    up->cuh = 0;
-    cublasCreate_v2(&up->cuh);
-
     
     // Call cublas to do the modal to nodal conversion on conf-space quanitites
     if(up->is_canonical_pb){
-      cu_mat_mm_array(up->cuh, up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
-      cu_mat_mm_array(up->cuh, up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
+      cu_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
+      cu_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
     }
 
     // initialize data needed for conf-space quadrature 
@@ -570,7 +565,6 @@ gkyl_vlasov_lte_proj_on_basis_release(gkyl_vlasov_lte_proj_on_basis* up)
     gkyl_cu_mat_mm_array_mem_release(up->conf_modal_to_nodal_h_ij_inv_quad_mem);
     gkyl_cu_mat_mm_array_mem_release(up->conf_modal_to_nodal_det_h_quad_mem);
     gkyl_cu_mat_mm_array_mem_release(up->phase_nodal_to_modal_mem);
-    cublasDestroy(up->cuh);
   }
 #endif
   gkyl_array_release(up->ordinates);

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -204,7 +204,7 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     up->det_h_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
 
     // Allocate the memory for computing the specific phase nodal to modal calculation
-    // up->phase_nodal_to_modal_mem = gkyl_phase_nodal_to_modal_cu_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
+    // up->phase_nodal_to_modal_mem = gkyl_mat_mm_array_mem_cu_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
     //    GKYL_NO_TRANS, GKYL_NO_TRANS);
     up->alpha = 1.0;
     up->beta = 0.0;
@@ -523,7 +523,7 @@ gkyl_vlasov_lte_proj_on_basis_release(gkyl_vlasov_lte_proj_on_basis* up)
     gkyl_array_release(up->h_ij_inv_quad);
     gkyl_array_release(up->det_h_quad);
 
-    // gkyl_phase_nodal_to_modal_release(up->phase_nodal_to_modal_mem);
+    // gkyl_mat_mm_array_mem_release(up->phase_nodal_to_modal_mem);
     gkyl_mat_release(up->mat_A);
     gkyl_mat_release(up->mat_Acu);
     cublasDestroy(up->cuh);

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -127,6 +127,62 @@ init_quad_values(int cdim, const struct gkyl_basis *basis, int num_quad, struct 
   return tot_quad;
 }
 
+
+static void
+gkyl_vlasov_lte_proj_on_basis_geom_quad_vars(gkyl_vlasov_lte_proj_on_basis *up, 
+  const struct gkyl_range *conf_range)
+{
+
+// Setup the intial geometric vars, on GPU 
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    gkyl_vlasov_lte_proj_on_basis_geom_quad_vars_cu(up, conf_range);
+#endif
+
+  // Otherwise run the CPU Version to setup h_ij_inv, det_h
+  int cdim = up->cdim, pdim = up->pdim;
+  int vdim = pdim-cdim;
+  int tot_quad = up->tot_quad;
+  int num_phase_basis = up->num_phase_basis;  
+
+  int tot_conf_quad = up->tot_conf_quad;
+  int num_conf_basis = up->num_conf_basis;
+
+  struct gkyl_range_iter conf_iter;
+
+  // outer loop over configuration space cells; for each
+  // config-space cell inner loop walks over velocity space
+  gkyl_range_iter_init(&conf_iter, conf_range);
+  while (gkyl_range_iter_next(&conf_iter)) {
+    long midx = gkyl_range_idx(conf_range, conf_iter.idx);
+    const double *h_ij_inv_d;
+    const double *det_h_d;
+    h_ij_inv_d = gkyl_array_cfetch(up->h_ij_inv, midx);
+    det_h_d = gkyl_array_cfetch(up->det_h, midx);
+    double *h_ij_inv_quad = (double*) gkyl_array_fetch(up->h_ij_inv_quad, midx);
+    double *det_h_quad = (double*) gkyl_array_fetch(up->det_h_quad, midx);
+
+    // Sum over basis for given LTE moments (n, V_drift, T/m) in the stationary frame
+    for (int n=0; n<tot_conf_quad; ++n) {
+      const double *b_ord = gkyl_array_cfetch(up->conf_basis_at_ords, n);
+
+      det_h_quad[n] = 0.0;
+      for (int k=0; k<num_conf_basis; ++k) {
+        for (int j=0; j<vdim*(vdim+1)/2; ++j) {
+          h_ij_inv_quad[tot_conf_quad*j + n] = 0;
+        }
+      }
+      for (int k=0; k<num_conf_basis; ++k) {
+        det_h_quad[n] += det_h_d[k]*b_ord[k];
+        for (int j=0; j<vdim*(vdim+1)/2; ++j) {
+          h_ij_inv_quad[tot_conf_quad*j + n] += h_ij_inv_d[num_conf_basis*j+k]*b_ord[k];
+        }
+      }
+    }
+  }
+}
+
+
 struct gkyl_vlasov_lte_proj_on_basis* 
 gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_inp *inp)
 {
@@ -187,6 +243,24 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
   up->conf_qrange = get_qrange(up->cdim, up->cdim, num_quad, num_quad_v, is_vdim_p2);
   up->phase_qrange = get_qrange(up->cdim, up->pdim, num_quad, num_quad_v, is_vdim_p2);
 
+  long conf_local_ncells = inp->conf_range->volume;
+  long conf_local_ext_ncells = inp->conf_range_ext->volume;
+
+  // Number density ratio: num_ratio = n_target/n0 and bin_op memory to compute ratio
+  // Used for fixing the density with simple rescaling
+  if (up->use_gpu) {
+    up->num_ratio = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->conf_basis.num_basis, conf_local_ext_ncells);
+    up->mem = gkyl_dg_bin_op_mem_cu_dev_new(conf_local_ncells, up->conf_basis.num_basis);
+    up->h_ij_inv_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad*(vdim*(vdim+1)/2), inp->conf_range_ext->volume);
+    up->det_h_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
+  }
+  else {
+    up->num_ratio = gkyl_array_new(GKYL_DOUBLE, up->conf_basis.num_basis, conf_local_ext_ncells);
+    up->mem = gkyl_dg_bin_op_mem_new(conf_local_ncells, up->conf_basis.num_basis);
+    up->h_ij_inv_quad = gkyl_array_new(GKYL_DOUBLE, up->tot_conf_quad*(vdim*(vdim+1)/2), inp->conf_range_ext->volume);
+    up->det_h_quad = gkyl_array_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
+  }
+
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu) {
     // Allocate device copies of arrays needed for quadrature.
@@ -200,12 +274,10 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     up->V_drift_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad*vdim, inp->conf_range_ext->volume);
     up->T_over_m_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
     up->V_drift_quad_cell_avg = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad*vdim, inp->conf_range_ext->volume);
-    up->h_ij_inv_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad*(vdim*(vdim+1)/2), inp->conf_range_ext->volume);
-    up->det_h_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
     
     // Allocate the memory for computing the specific phase nodal to modal calculation
     struct gkyl_mat_mm_array_mem *phase_nodal_to_modal_mem_ho;
-    phase_nodal_to_modal_mem_ho = gkyl_mat_mm_array_mem_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
+    phase_nodal_to_modal_mem_ho = gkyl_mat_mm_array_mem_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
       GKYL_NO_TRANS, GKYL_NO_TRANS, false);
 
     // Compute the matrix A for the phase nodal to modal memory
@@ -218,66 +290,10 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     }
     
     // copy to device
-    up->phase_nodal_to_modal_mem = gkyl_mat_mm_array_mem_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
+    up->phase_nodal_to_modal_mem = gkyl_mat_mm_array_mem_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
       GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
     gkyl_mat_copy(up->phase_nodal_to_modal_mem->A, phase_nodal_to_modal_mem_ho->A);
     gkyl_mat_mm_array_mem_release(phase_nodal_to_modal_mem_ho);
-
-    // Allocate the memory for computing the specific conf modal to nodal calculation
-    struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_h_ij_inv_quad_mem_ho;
-    conf_modal_to_nodal_h_ij_inv_quad_mem_ho = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad*(vdim*(vdim+1)/2), up->num_conf_basis*(vdim*(vdim+1)/2), 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS, false);
-
-    // Compute the matrix A for the conf modal to nodal memory, and copy to the mat to GPU
-    const double *confb_o = (const double*) up->conf_basis_at_ords->data;
-    for (int n=0; n<up->num_conf_basis*(vdim*(vdim+1)/2); ++n){
-      for (int k=0; k<up->tot_conf_quad*(vdim*(vdim+1)/2); ++k){
-
-        // Since all elements of h_ij (symmetric unqiue elements) are in the components, we have 
-        // to construct a matrix which only maps the relevant modal comps. to the relevent nodes
-        // This ultimately takes a block-diagnol form for the mapping, A.
-        int n_rem = n%up->num_conf_basis;
-        int n_seg = (n-n_rem)/up->num_conf_basis;
-        int k_rem = k%up->tot_conf_quad;
-        int k_seg = (k-k_rem)/up->tot_conf_quad;
-        if (k_seg == n_seg){
-          gkyl_mat_set(conf_modal_to_nodal_h_ij_inv_quad_mem_ho->A, k, n, confb_o[n_rem]);
-        }
-        else {
-          gkyl_mat_set(conf_modal_to_nodal_h_ij_inv_quad_mem_ho->A, k, n, 0.0);
-        }
-        //double actual = gkyl_mat_get(conf_modal_to_nodal_h_ij_inv_quad_mem_ho->A, k, n);
-        //printf("A(m=%d,n=%d): %1.2e,\n", k, n, actual);
-      }
-    }
-    // copy to device
-    up->conf_modal_to_nodal_h_ij_inv_quad_mem = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad*(vdim*(vdim+1)/2), 
-      up->num_conf_basis*(vdim*(vdim+1)/2), 1.0, 0.0, GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
-    gkyl_mat_copy(up->conf_modal_to_nodal_h_ij_inv_quad_mem->A, conf_modal_to_nodal_h_ij_inv_quad_mem_ho->A);
-    gkyl_mat_mm_array_mem_release(conf_modal_to_nodal_h_ij_inv_quad_mem_ho);
-
-    // Allocate the memory for computing the specific conf modal to nodal calculation
-    struct gkyl_mat_mm_array_mem *conf_modal_to_nodal_det_h_quad_mem_ho;
-    conf_modal_to_nodal_det_h_quad_mem_ho = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad, up->num_conf_basis, 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS, false);
-
-    // Compute the matrix A for the conf modal to nodal memory, and copy to the mat to GPU
-    for (int n=0; n<up->num_conf_basis; ++n){
-      for (int k=0; k<up->tot_conf_quad; ++k){
-        gkyl_mat_set(conf_modal_to_nodal_det_h_quad_mem_ho->A, k, n, confb_o[n]);
-      }
-    }
-
-    up->conf_modal_to_nodal_det_h_quad_mem = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad, up->num_conf_basis, 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
-    gkyl_mat_copy(up->conf_modal_to_nodal_det_h_quad_mem->A, conf_modal_to_nodal_det_h_quad_mem_ho->A);
-    gkyl_mat_mm_array_mem_release(conf_modal_to_nodal_det_h_quad_mem_ho);
-    
-    // Call cublas to do the modal to nodal conversion on conf-space quanitites
-    if(up->is_canonical_pb){
-      gkyl_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
-      gkyl_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
-    }
 
     // initialize data needed for conf-space quadrature 
     up->tot_conf_quad = init_quad_values(up->cdim, &up->conf_basis, num_quad,
@@ -316,19 +332,9 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
   };
   up->moments_up = gkyl_vlasov_lte_moments_inew( &inp_mom );
 
-  long conf_local_ncells = inp->conf_range->volume;
-  long conf_local_ext_ncells = inp->conf_range_ext->volume;
-
-  // Number density ratio: num_ratio = n_target/n0 and bin_op memory to compute ratio
-  // Used for fixing the density with simple rescaling
-  if (up->use_gpu) {
-    up->num_ratio = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->conf_basis.num_basis, conf_local_ext_ncells);
-    up->mem = gkyl_dg_bin_op_mem_cu_dev_new(conf_local_ncells, up->conf_basis.num_basis);
-  }
-  else {
-    up->num_ratio = gkyl_array_new(GKYL_DOUBLE, up->conf_basis.num_basis, conf_local_ext_ncells);
-    up->mem = gkyl_dg_bin_op_mem_new(conf_local_ncells, up->conf_basis.num_basis);
-  }
+  // Build the inital geometric vars for canonical-pb
+  if(up->is_canonical_pb)
+    gkyl_vlasov_lte_proj_on_basis_geom_quad_vars(up, inp->conf_range);
 
   return up;
 }
@@ -381,8 +387,6 @@ gkyl_vlasov_lte_proj_on_basis_advance(gkyl_vlasov_lte_proj_on_basis *up,
 
   double xc[GKYL_MAX_DIM], xmu[GKYL_MAX_DIM];
   double n_quad[tot_conf_quad], V_drift_quad[tot_conf_quad][vdim], T_over_m_quad[tot_conf_quad];
-  double h_ij_inv_quad[tot_conf_quad][vdim*(vdim + 1)/2];
-  double det_h_quad[tot_conf_quad];
   double V_drift_quad_cell_avg[tot_conf_quad][vdim];
   double expamp_quad[tot_conf_quad];
 
@@ -396,11 +400,11 @@ gkyl_vlasov_lte_proj_on_basis_advance(gkyl_vlasov_lte_proj_on_basis *up,
     const double *n_d = moms_lte_d;
     const double *V_drift_d = &moms_lte_d[num_conf_basis];
     const double *T_over_m_d = &moms_lte_d[num_conf_basis*(vdim+1)];
-    const double *h_ij_inv_d;
-    const double *det_h_d;
+    double *h_ij_inv_quad;
+    double *det_h_quad;
     if (up->is_canonical_pb) {
-      h_ij_inv_d = gkyl_array_cfetch(up->h_ij_inv, midx);
-      det_h_d = gkyl_array_cfetch(up->det_h, midx);
+      h_ij_inv_quad = gkyl_array_fetch(up->h_ij_inv_quad, midx);
+      det_h_quad = gkyl_array_fetch(up->det_h_quad, midx);
     }
 
     // Sum over basis for given LTE moments (n, V_drift, T/m) in the stationary frame
@@ -423,21 +427,6 @@ gkyl_vlasov_lte_proj_on_basis_advance(gkyl_vlasov_lte_proj_on_basis *up,
           V_drift_quad[n][d] += V_drift_d[num_conf_basis*d+k]*b_ord[k];
         }
         T_over_m_quad[n] += T_over_m_d[k]*b_ord[k];
-      }
-
-      if (up->is_canonical_pb) {
-        det_h_quad[n] = 0.0;
-        for (int k=0; k<num_conf_basis; ++k) {
-          for (int j=0; j<vdim*(vdim+1)/2; ++j) {
-            h_ij_inv_quad[n][j] = 0;
-          }
-        }
-        for (int k=0; k<num_conf_basis; ++k) {
-          det_h_quad[n] += det_h_d[k]*b_ord[k];
-          for (int j=0; j<vdim*(vdim+1)/2; ++j) {
-            h_ij_inv_quad[n][j] += h_ij_inv_d[num_conf_basis*j+k]*b_ord[k];
-          }
-        }
       }
 
       // Amplitude of the exponential.
@@ -515,12 +504,9 @@ gkyl_vlasov_lte_proj_on_basis_advance(gkyl_vlasov_lte_proj_on_basis *up,
                 // Grab the spatial metric component, the ctx includes geometry that isn't 
                 // part of the canonical set of variables, like R on the surf of a sphere
                 // q_can includes the canonical variables list
-                double h_ij_inv_loc = h_ij_inv_quad[cqidx][sym_tensor_index]; 
+                double h_ij_inv_loc = h_ij_inv_quad[tot_conf_quad*sym_tensor_index + cqidx]; 
                 // For off-diagnol components, we need to count these twice, due to symmetry
-                int sym_fact = 2;
-                if (d0 == d1){
-                  sym_fact = 1;
-                }
+                int sym_fact = (d0 == d1) ? 1 : 2;
                 efact += sym_fact*h_ij_inv_loc*(xmu[cdim+d0]-V_drift_quad[cqidx][d0])*(xmu[cdim+d1]-V_drift_quad[cqidx][d1]);
               }
             }
@@ -570,11 +556,7 @@ gkyl_vlasov_lte_proj_on_basis_release(gkyl_vlasov_lte_proj_on_basis* up)
     gkyl_array_release(up->V_drift_quad);
     gkyl_array_release(up->T_over_m_quad);
     gkyl_array_release(up->V_drift_quad_cell_avg);
-    gkyl_array_release(up->h_ij_inv_quad);
-    gkyl_array_release(up->det_h_quad);
 
-    gkyl_mat_mm_array_mem_release(up->conf_modal_to_nodal_h_ij_inv_quad_mem);
-    gkyl_mat_mm_array_mem_release(up->conf_modal_to_nodal_det_h_quad_mem);
     gkyl_mat_mm_array_mem_release(up->phase_nodal_to_modal_mem);
   }
 #endif
@@ -594,6 +576,8 @@ gkyl_vlasov_lte_proj_on_basis_release(gkyl_vlasov_lte_proj_on_basis* up)
   gkyl_vlasov_lte_moments_release(up->moments_up);
   gkyl_array_release(up->num_ratio);
   gkyl_dg_bin_op_mem_release(up->mem);
+  gkyl_array_release(up->h_ij_inv_quad);
+  gkyl_array_release(up->det_h_quad);
 
   gkyl_free(up);
 }

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -264,8 +264,8 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     
     // Call cublas to do the modal to nodal conversion on conf-space quanitites
     if(up->is_canonical_pb){
-      cu_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
-      cu_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
+      gkyl_cu_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
+      gkyl_cu_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
     }
 
     // initialize data needed for conf-space quadrature 

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -204,8 +204,8 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     up->det_h_quad = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->tot_conf_quad, inp->conf_range_ext->volume);
     
     // Allocate the memory for computing the specific phase nodal to modal calculation
-    up->phase_nodal_to_modal_mem = gkyl_cu_mat_mm_array_mem_cu_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS);
+    up->phase_nodal_to_modal_mem = gkyl_mat_mm_array_mem_dev_new(up->num_phase_basis, up->tot_quad, 1.0, 0.0, 
+      GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
 
     // Compute the matrix A for the phase nodal to modal memory
     const double *phase_w = (const double*) up->weights->data;
@@ -220,8 +220,8 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     gkyl_mat_copy(up->phase_nodal_to_modal_mem->A_cu, up->phase_nodal_to_modal_mem->A_ho);
 
     // Allocate the memory for computing the specific conf modal to nodal calculation
-    up->conf_modal_to_nodal_h_ij_inv_quad_mem = gkyl_cu_mat_mm_array_mem_cu_dev_new(up->tot_conf_quad*(vdim*(vdim+1)/2), up->num_conf_basis*(vdim*(vdim+1)/2), 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS);
+    up->conf_modal_to_nodal_h_ij_inv_quad_mem = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad*(vdim*(vdim+1)/2), up->num_conf_basis*(vdim*(vdim+1)/2), 1.0, 0.0, 
+      GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
 
     // Compute the matrix A for the conf modal to nodal memory, and copy to the mat to GPU
     const double *confb_o = (const double*) up->conf_basis_at_ords->data;
@@ -249,8 +249,8 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     gkyl_mat_copy(up->conf_modal_to_nodal_h_ij_inv_quad_mem->A_cu, up->conf_modal_to_nodal_h_ij_inv_quad_mem->A_ho);
 
     // Allocate the memory for computing the specific conf modal to nodal calculation
-    up->conf_modal_to_nodal_det_h_quad_mem = gkyl_cu_mat_mm_array_mem_cu_dev_new(up->tot_conf_quad, up->num_conf_basis, 1.0, 0.0, 
-      GKYL_NO_TRANS, GKYL_NO_TRANS);
+    up->conf_modal_to_nodal_det_h_quad_mem = gkyl_mat_mm_array_mem_dev_new(up->tot_conf_quad, up->num_conf_basis, 1.0, 0.0, 
+      GKYL_NO_TRANS, GKYL_NO_TRANS, up->use_gpu);
 
     // Compute the matrix A for the conf modal to nodal memory, and copy to the mat to GPU
     for (int n=0; n<up->num_conf_basis; ++n){
@@ -264,8 +264,8 @@ gkyl_vlasov_lte_proj_on_basis_inew(const struct gkyl_vlasov_lte_proj_on_basis_in
     
     // Call cublas to do the modal to nodal conversion on conf-space quanitites
     if(up->is_canonical_pb){
-      gkyl_cu_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
-      gkyl_cu_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
+      gkyl_mat_mm_array(up->conf_modal_to_nodal_h_ij_inv_quad_mem, up->h_ij_inv, up->h_ij_inv_quad);
+      gkyl_mat_mm_array(up->conf_modal_to_nodal_det_h_quad_mem, up->det_h, up->det_h_quad);
     }
 
     // initialize data needed for conf-space quadrature 
@@ -562,9 +562,9 @@ gkyl_vlasov_lte_proj_on_basis_release(gkyl_vlasov_lte_proj_on_basis* up)
     gkyl_array_release(up->h_ij_inv_quad);
     gkyl_array_release(up->det_h_quad);
 
-    gkyl_cu_mat_mm_array_mem_release(up->conf_modal_to_nodal_h_ij_inv_quad_mem);
-    gkyl_cu_mat_mm_array_mem_release(up->conf_modal_to_nodal_det_h_quad_mem);
-    gkyl_cu_mat_mm_array_mem_release(up->phase_nodal_to_modal_mem);
+    gkyl_mat_mm_array_mem_release(up->conf_modal_to_nodal_h_ij_inv_quad_mem);
+    gkyl_mat_mm_array_mem_release(up->conf_modal_to_nodal_det_h_quad_mem);
+    gkyl_mat_mm_array_mem_release(up->phase_nodal_to_modal_mem);
   }
 #endif
   gkyl_array_release(up->ordinates);

--- a/zero/vlasov_lte_proj_on_basis.c
+++ b/zero/vlasov_lte_proj_on_basis.c
@@ -136,7 +136,7 @@ gkyl_vlasov_lte_proj_on_basis_geom_quad_vars(gkyl_vlasov_lte_proj_on_basis *up,
 // Setup the intial geometric vars, on GPU 
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu)
-    gkyl_vlasov_lte_proj_on_basis_geom_quad_vars_cu(up, conf_range);
+    return gkyl_vlasov_lte_proj_on_basis_geom_quad_vars_cu(up, conf_range);
 #endif
 
   // Otherwise run the CPU Version to setup h_ij_inv, det_h

--- a/zero/vlasov_lte_proj_on_basis_cu.cu
+++ b/zero/vlasov_lte_proj_on_basis_cu.cu
@@ -43,7 +43,7 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu_ker(const struct gkyl_rect_grid phase_g
   int pdim = phase_range.ndim, cdim = conf_range.ndim;
   int vdim = pdim-cdim;
 
-  int pidx[GKYL_MAX_DIM], cidx[GKYL_MAX_CDIM];
+  int cidx[GKYL_MAX_CDIM];
 
   // 2D thread grid
   // linc2 = c where c is the component index (from 0 to tot_conf_quad)
@@ -218,7 +218,6 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,
   dim3 dimGrid, dimBlock;
   int tot_phase_quad = up->basis_at_ords->size;
   int tot_conf_quad = up->conf_basis_at_ords->size;
-  int num_phase_basis = f_lte->ncomp;
   int num_conf_basis = up->num_conf_basis;
   //gkyl_parallelize_components_kernel_launch_dims(&dimGrid, &dimBlock, *phase_range, tot_phase_quad);
   gkyl_parallelize_components_kernel_launch_dims(&dimGrid, &dimBlock, *conf_range, tot_conf_quad);

--- a/zero/vlasov_lte_proj_on_basis_cu.cu
+++ b/zero/vlasov_lte_proj_on_basis_cu.cu
@@ -236,7 +236,7 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,
      moms_lte->on_dev, up->f_lte_at_nodes->on_dev, num_conf_basis, tot_conf_quad);
 
   // Call cublas to do the matrix multiplication nodal to modal conversion
-  gkyl_cu_mat_mm_array(up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
+  gkyl_mat_mm_array(up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
 
   // Correct the density of the projected LTE distribution function through rescaling.
   // This correction is needed especially for the relativistic LTE, whose pre-factor

--- a/zero/vlasov_lte_proj_on_basis_cu.cu
+++ b/zero/vlasov_lte_proj_on_basis_cu.cu
@@ -252,10 +252,7 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,
      moms_lte->on_dev, up->f_lte_at_nodes->on_dev, num_conf_basis, tot_conf_quad);
 
   // Call cublas to do the nodal to modal conversion
-  cu_mat_mm_array(up->cuh, up->alpha, 
-    up->beta, up->transa, 
-    up->mat_Acu, up->transb, 
-    up->f_lte_at_nodes, f_lte);
+  cu_mat_mm_array(up->cuh, up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
 
   // Correct the density of the projected LTE distribution function through rescaling.
   // This correction is needed especially for the relativistic LTE, whose pre-factor

--- a/zero/vlasov_lte_proj_on_basis_cu.cu
+++ b/zero/vlasov_lte_proj_on_basis_cu.cu
@@ -236,7 +236,7 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,
      moms_lte->on_dev, up->f_lte_at_nodes->on_dev, num_conf_basis, tot_conf_quad);
 
   // Call cublas to do the matrix multiplication nodal to modal conversion
-  cu_mat_mm_array(up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
+  gkyl_cu_mat_mm_array(up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
 
   // Correct the density of the projected LTE distribution function through rescaling.
   // This correction is needed especially for the relativistic LTE, whose pre-factor

--- a/zero/vlasov_lte_proj_on_basis_cu.cu
+++ b/zero/vlasov_lte_proj_on_basis_cu.cu
@@ -236,7 +236,7 @@ gkyl_vlasov_lte_proj_on_basis_advance_cu(gkyl_vlasov_lte_proj_on_basis *up,
      moms_lte->on_dev, up->f_lte_at_nodes->on_dev, num_conf_basis, tot_conf_quad);
 
   // Call cublas to do the matrix multiplication nodal to modal conversion
-  cu_mat_mm_array(up->cuh, up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
+  cu_mat_mm_array(up->phase_nodal_to_modal_mem, up->f_lte_at_nodes, f_lte);
 
   // Correct the density of the projected LTE distribution function through rescaling.
   // This correction is needed especially for the relativistic LTE, whose pre-factor


### PR DESCRIPTION
This is the production version of the cublasDgemm prototyping branch, see [DR](https://github.com/ammarhakim/gkylzero/issues/400). Primarily for computing with cblas/cublas the matrix multiplication: alpha*A(gkyl_mat) * B(gkyl_array/gkyl_mat) + Beta*C(gkyl_array/gkyl_mat) = C(gkyl_array/gkyl_mat). This has been used successfully to reduce the computation time of the nodal to modal conversion in vlasov-lte-proj-on-basis-cu, which we found to be more efficient than loop unrolling on GPU for this specific bottlenecked operation. 

Extensions to gkyl_mat functions:
- _gkyl_mat_mm_array_mem_, new structure to save the matrix A and associated, alpha, beta, transposition information for the matrix multiply.
- **gkyl_mat_mm_array_mem_dev_new**, Builds a new object for computing CPU/GPU side matrix multiplication.
- **gkyl_mat_mm_array_mem_release**, Associated release of the memory.
- **gkyl_mat_mm_array**, Function which does the matrix multiply either or CPU or GPU (depending on build/flags).

New unit tests: (in ctest_mat.c)
- **test_mat_mm_arrays**, Tests CPU side blas matrix multiplication: alpha*A(gkyl_mat) * B(gkyl_array) + Beta*C(gkyl_array) = C(gkyl_array).
- **test_cu_mat_mm**, Tests CPU side blas matrix multiplication: alpha*A(gkyl_mat) * B(gkyl_mat) + Beta*C(gkyl_mat) = C(gkyl_mat).
- **test_cu_mat_mm_arrays**, Tests GPU side blas matrix multiplication using cublas: alpha*A(gkyl_mat) * B(gkyl_array) + Beta*C(gkyl_array) = C(gkyl_array)