### PR TITLE
f-lte io and BGK Collision Restructuring

### DIFF
--- a/apps/gkyl_vlasov.h
+++ b/apps/gkyl_vlasov.h
@@ -151,6 +151,10 @@ struct gkyl_vlasov_species {
   // pointer to the determinant of the spatial metric
   void (*det_h)(double t, const double *xn, double *aout, void *ctx);
 
+  bool output_f_lte; // Boolean for writing out f_lte (used for calculating transport coeff.)
+  int max_iter; //Maximum number of iterations for f_lte correction
+  double iter_eps; //Maximum eps for f_lte correction
+
   // boundary conditions
   enum gkyl_species_bc_type bcx[2], bcy[2], bcz[2];
 };
@@ -287,6 +291,8 @@ struct gkyl_vlasov_stat {
   double species_lbo_coll_diff_tm[GKYL_MAX_SPECIES]; // time to compute LBO diffusion terms
   double species_coll_tm; // total time for collision updater (excluded moments)
 
+  double species_lte_tm; // time needed to compute the lte equilibrium
+
   long niter_self_bgk_corr[GKYL_MAX_SPECIES]; // number of iterations used to correct self collisions in BGK
 
   double species_bc_tm; // time to compute species BCs
@@ -422,6 +428,16 @@ void gkyl_vlasov_app_write_field(gkyl_vlasov_app* app, double tm, int frame);
  * @param frame Frame number
  */
 void gkyl_vlasov_app_write_species(gkyl_vlasov_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write species data to file - for the local equilbrium.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_vlasov_app_write_species_lte(gkyl_vlasov_app* app, int sidx, double tm, int frame);
 
 /**
  * Write species p/gamma to file.

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -162,7 +162,7 @@ struct vm_lte {
   // also corrects the density of projected distribution function
   struct gkyl_vlasov_lte_proj_on_basis *proj_lte; 
 
-  long self_niter; // total number of iterations correcting self collisions
+  long niter; // total number of iterations correcting self collisions
 
   // Correction updater for insuring LTE distribution has desired LTE (n, V_drift, T/m) moments
   bool correct_all_moms; // boolean if we are correcting all the moments

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -201,6 +201,8 @@ struct vm_bgk_collisions {
 
   struct gkyl_bgk_collisions *up_bgk; // BGK updater (also computes stable timestep)
 
+  struct vm_lte lte; // lte data and updater
+
   bool implicit_step; // whether or not to take an implcit bgk step
   double dt_implicit; // timestep used by the implicit collisions
 };
@@ -769,7 +771,7 @@ void vm_species_lte_moms(gkyl_vlasov_app *app,
   const struct gkyl_array *fin);
 
 /**
- * Compute RHS for f-lte creation
+ * Compute f-lte
  *
  * @param app Vlasov app object
  * @param species Pointer to species
@@ -824,7 +826,7 @@ void vm_species_bgk_moms(gkyl_vlasov_app *app,
  * @param rhs On output, the RHS from bgk
  */
 void vm_species_bgk_rhs(gkyl_vlasov_app *app,
-  const struct vm_species *species,
+  struct vm_species *species,
   struct vm_bgk_collisions *bgk,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
@@ -835,6 +837,14 @@ void vm_species_bgk_rhs(gkyl_vlasov_app *app,
  * @param bgk Species BGK object to release
  */
 void vm_species_bgk_release(const struct gkyl_vlasov_app *app, const struct vm_bgk_collisions *bgk);
+
+/**
+ * Release species lte object.
+ *
+ * @param app Vlasov app object
+ * @param lte Species lte object to release
+ */
+void vm_species_lte_release(const struct gkyl_vlasov_app *app, const struct vm_lte *lte);
 
 /** vm_species_boundary_fluxes API */
 

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -153,6 +153,24 @@ struct vm_lbo_collisions {
   gkyl_dg_updater_collisions *coll_slvr; // collision solver
 };
 
+struct vm_lte {  
+  struct gkyl_array *f_lte;
+
+  struct vm_species_moment moms; // moments needed in the equilibrium
+
+  // LTE distribution function projection object
+  // also corrects the density of projected distribution function
+  struct gkyl_vlasov_lte_proj_on_basis *proj_lte; 
+
+  long self_niter; // total number of iterations correcting self collisions
+
+  // Correction updater for insuring LTE distribution has desired LTE (n, V_drift, T/m) moments
+  bool correct_all_moms; // boolean if we are correcting all the moments
+  struct gkyl_vlasov_lte_correct *corr_lte; 
+  gkyl_dynvec corr_stat;
+  bool is_first_corr_status_write_call;
+};
+
 struct vm_bgk_collisions {  
   struct gkyl_array *nu_sum; // BGK collision frequency 
   struct gkyl_array *nu_sum_host; // BGK collision frequency host-side for I/O
@@ -340,6 +358,8 @@ struct vm_species {
 
   enum gkyl_source_id source_id; // type of source
   struct vm_source src; // applied source
+
+  struct vm_lte lte; // object needed for the lte equilibrium
 
   enum gkyl_collision_id collision_id; // type of collisions
   // collisions
@@ -724,6 +744,42 @@ void vm_species_lbo_rhs(gkyl_vlasov_app *app,
   const struct vm_species *species,
   struct vm_lbo_collisions *lbo,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
+
+/**
+ * Initialize species lte object.
+ *
+ * @param app Vlasov app object
+ * @param s Species object 
+ * @param lte Species lte object
+ */
+void vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s,
+  struct vm_lte *lte);
+
+/**
+ * Compute necessary moments for f-lte creation
+ *
+ * @param app Vlasov app object
+ * @param species Pointer to species
+ * @param lte Pointer to lte object
+ * @param fin Input distribution function
+ */
+void vm_species_lte_moms(gkyl_vlasov_app *app,
+  const struct vm_species *species,
+  struct vm_lte *lte,
+  const struct gkyl_array *fin);
+
+/**
+ * Compute RHS for f-lte creation
+ *
+ * @param app Vlasov app object
+ * @param species Pointer to species
+ * @param lte Pointer to lte
+ * @param fin Input distribution function
+ */
+void vm_species_lte(gkyl_vlasov_app *app,
+  const struct vm_species *species,
+  struct vm_lte *lte,
+  const struct gkyl_array *fin);
 
 /**
  * Release species LBO object.

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -181,23 +181,8 @@ struct vm_bgk_collisions {
   struct gkyl_array *nu_init; // Array for initial collisionality when using Spitzer updater
   struct gkyl_spitzer_coll_freq* spitzer_calc; // Updater for Spitzer collisionality if computing Spitzer value
 
-  struct gkyl_array *f_lte;
-  struct gkyl_array *nu_f_lte;
-
-  enum gkyl_model_id model_id;
-  struct vm_species_moment moms; // moments needed in BGK (n, V_drift, T/m) for LTE distribution
-
-  // LTE distribution function projection object
-  // also corrects the density of projected distribution function
-  struct gkyl_vlasov_lte_proj_on_basis *proj_lte; 
-
-  long self_niter; // total number of iterations correcting self collisions
-
-  // Correction updater for insuring LTE distribution has desired LTE (n, V_drift, T/m) moments
-  bool correct_all_moms; // boolean if we are correcting all the moments
-  struct gkyl_vlasov_lte_correct *corr_lte; 
-  gkyl_dynvec corr_stat;
-  bool is_first_corr_status_write_call;
+  struct gkyl_array *nu_f_lte; // collision frequency times 
+  enum gkyl_model_id model_id; // species model id
 
   struct gkyl_bgk_collisions *up_bgk; // BGK updater (also computes stable timestep)
 
@@ -753,9 +738,10 @@ void vm_species_lbo_rhs(gkyl_vlasov_app *app,
  * @param app Vlasov app object
  * @param s Species object 
  * @param lte Species lte object
+ * @param correct_all_moms boolean to correct all moms
  */
 void vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s,
-  struct vm_lte *lte);
+  struct vm_lte *lte, bool correct_all_moms);
 
 /**
  * Compute necessary moments for f-lte creation

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -744,20 +744,20 @@ void vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s,
   struct vm_lte *lte, bool correct_all_moms);
 
 /**
- * Compute necessary moments for f-lte creation
+ * Compute LTE distribution from input moments
  *
  * @param app Vlasov app object
  * @param species Pointer to species
  * @param lte Pointer to lte object
- * @param fin Input distribution function
+ * @param moms_lte Input LTE moments
  */
-void vm_species_lte_moms(gkyl_vlasov_app *app,
+void vm_species_lte_from_moms(gkyl_vlasov_app *app,
   const struct vm_species *species,
   struct vm_lte *lte,
-  const struct gkyl_array *fin);
+  const struct gkyl_array *moms_lte);
 
 /**
- * Compute f-lte
+ * Compute equivalent LTE distribution from input distribution function. 
  *
  * @param app Vlasov app object
  * @param species Pointer to species

--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -465,7 +465,6 @@ gkyl_vlasov_app_write(gkyl_vlasov_app* app, double tm, int frame)
     gkyl_vlasov_app_write_field(app, tm, frame);
   for (int i=0; i<app->num_species; ++i) {
     gkyl_vlasov_app_write_species(app, i, tm, frame);
-    printf("app->species[i].output_f_lte: %d\n",app->species[i].info.output_f_lte);
     if(app->species[i].info.output_f_lte)
       gkyl_vlasov_app_write_species_lte(app, i, tm, frame);
     if (app->species[i].model_id == GKYL_MODEL_SR && frame == 0)
@@ -714,17 +713,17 @@ gkyl_vlasov_app_write_lte_corr_status(gkyl_vlasov_app* app)
       gkyl_comm_get_rank(app->comm, &rank);
 
       if (rank == 0) {
-        if (s->bgk.is_first_corr_status_write_call) {
+        if (s->bgk.lte.is_first_corr_status_write_call) {
           // write to a new file (this ensure previous output is removed)
-          gkyl_dynvec_write(s->bgk.corr_stat, fileNm);
-          s->bgk.is_first_corr_status_write_call = false;
+          gkyl_dynvec_write(s->bgk.lte.corr_stat, fileNm);
+          s->bgk.lte.is_first_corr_status_write_call = false;
         }
         else {
           // append to existing file
-          gkyl_dynvec_awrite(s->bgk.corr_stat, fileNm);
+          gkyl_dynvec_awrite(s->bgk.lte.corr_stat, fileNm);
         }
       }
-      gkyl_dynvec_clear(s->bgk.corr_stat);
+      gkyl_dynvec_clear(s->bgk.lte.corr_stat);
     }
   } 
 }

--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -523,19 +523,8 @@ gkyl_vlasov_app_write_species_lte(gkyl_vlasov_app* app, int sidx, double tm, int
   char fileNm[sz+1]; // ensures no buffer overflow
   snprintf(fileNm, sizeof fileNm, fmt, app->name, app->species[sidx].info.name, frame);
 
-  // Call the update for f_lte (only neeeded for explicit collisions)
-  int ns = app->num_species;  
-  const struct gkyl_array *fin[ns];
-  struct gkyl_array *fout[ns];
-  for (int i=0; i<ns; ++i) {
-    fin[i] = app->species[i].f;
-  }
-
-  // compute necessary moments and boundary corrections for collisions
-  for (int i=0; i<app->num_species; ++i) {
-    if (app->species[i].info.output_f_lte) {
-      vm_species_lte(app, &app->species[i], &app->species[i].lte, fin[i]);
-    }
+  if (app->species[sidx].info.output_f_lte) {
+    vm_species_lte(app, &app->species[sidx], &app->species[sidx].lte, app->species[sidx].f);
   }
   
   if (app->use_gpu) {

--- a/apps/vlasov_forward_euler.c
+++ b/apps/vlasov_forward_euler.c
@@ -39,8 +39,10 @@ vlasov_forward_euler(gkyl_vlasov_app* app, double tcurr, double dt,
     if (app->species[i].collision_id == GKYL_LBO_COLLISIONS) {
       vm_species_lbo_moms(app, &app->species[i], &app->species[i].lbo, fin[i]);
     }
-    // No need to compute moments for bgk collisions, since they are computed internally
-    // by the f_lte routine
+    else if (app->species[i].collision_id == GKYL_BGK_COLLISIONS && !app->has_implicit_coll_scheme) {
+      vm_species_bgk_moms(app, &app->species[i], 
+        &app->species[i].bgk, fin[i]);
+    }
   }
 
   // compute necessary moments for cross-species collisions

--- a/apps/vlasov_forward_euler.c
+++ b/apps/vlasov_forward_euler.c
@@ -39,10 +39,8 @@ vlasov_forward_euler(gkyl_vlasov_app* app, double tcurr, double dt,
     if (app->species[i].collision_id == GKYL_LBO_COLLISIONS) {
       vm_species_lbo_moms(app, &app->species[i], &app->species[i].lbo, fin[i]);
     }
-    else if (app->species[i].collision_id == GKYL_BGK_COLLISIONS && !app->has_implicit_coll_scheme) {
-      vm_species_bgk_moms(app, &app->species[i], 
-        &app->species[i].bgk, fin[i]);
-    }
+    // No need to compute moments for bgk collisions, since they are computed internally
+    // by the f_lte routine
   }
 
   // compute necessary moments for cross-species collisions

--- a/apps/vlasov_update_implicit_coll.c
+++ b/apps/vlasov_update_implicit_coll.c
@@ -14,6 +14,14 @@ vlasov_update_implicit_coll(gkyl_vlasov_app* app, double dt0)
     fout[i] = app->species[i].f1;
   }
 
+  // compute necessary moments and boundary corrections for collisions
+  for (int i=0; i<app->num_species; ++i) {
+    if (app->species[i].collision_id == GKYL_BGK_COLLISIONS) {
+      vm_species_bgk_moms(app, &app->species[i], 
+        &app->species[i].bgk, fin[i]);
+    }
+  }
+  
   // implicit BGK contributions
   for (int i=0; i<app->num_species; ++i) {
     app->species[i].bgk.implicit_step = true;

--- a/apps/vlasov_update_implicit_coll.c
+++ b/apps/vlasov_update_implicit_coll.c
@@ -14,14 +14,6 @@ vlasov_update_implicit_coll(gkyl_vlasov_app* app, double dt0)
     fout[i] = app->species[i].f1;
   }
 
-  // compute necessary moments and boundary corrections for collisions
-  for (int i=0; i<app->num_species; ++i) {
-    if (app->species[i].collision_id == GKYL_BGK_COLLISIONS) {
-      vm_species_bgk_moms(app, &app->species[i], 
-        &app->species[i].bgk, fin[i]);
-    }
-  }
-
   // implicit BGK contributions
   for (int i=0; i<app->num_species; ++i) {
     app->species[i].bgk.implicit_step = true;

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -656,7 +656,9 @@ vm_species_release(const gkyl_vlasov_app* app, const struct vm_species *s)
   if (s->source_id) {
     vm_species_source_release(app, &s->src);
   }
-
+  if (s->collision_id == GKYL_BGK_COLLISIONS || s->info.output_f_lte){
+    vm_species_lte_release(app, &s->lte);
+  }
   if (s->collision_id == GKYL_LBO_COLLISIONS) {
     vm_species_lbo_release(app, &s->lbo);
   }

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -277,8 +277,9 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
   s->lte = (struct vm_lte) { };
   s->lbo = (struct vm_lbo_collisions) { };
   s->bgk = (struct vm_bgk_collisions) { };
-  if (s->collision_id == GKYL_BGK_COLLISIONS || s->info.output_f_lte){
-    vm_species_lte_init(app, s, &s->lte);
+  if (s->info.output_f_lte){
+    // Always have correct moments on for the f_lte output
+    vm_species_lte_init(app, s, &s->lte, true);
   }
   if (s->collision_id == GKYL_LBO_COLLISIONS) {
     vm_species_lbo_init(app, s, &s->lbo);
@@ -560,7 +561,7 @@ vm_species_bgk_niter(gkyl_vlasov_app *app)
 {
   for (int i=0; i<app->num_species; ++i) {
     if (app->species[i].collision_id == GKYL_BGK_COLLISIONS) {
-      app->stat.niter_self_bgk_corr[i] = app->species[i].bgk.self_niter;
+      app->stat.niter_self_bgk_corr[i] = app->species[i].bgk.lte.self_niter;
     }
   }
 }
@@ -656,7 +657,7 @@ vm_species_release(const gkyl_vlasov_app* app, const struct vm_species *s)
   if (s->source_id) {
     vm_species_source_release(app, &s->src);
   }
-  if (s->collision_id == GKYL_BGK_COLLISIONS || s->info.output_f_lte){
+  if (s->info.output_f_lte){
     vm_species_lte_release(app, &s->lte);
   }
   if (s->collision_id == GKYL_LBO_COLLISIONS) {

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -274,8 +274,12 @@ vm_species_init(struct gkyl_vm *vm, struct gkyl_vlasov_app *app, struct vm_speci
   
   // determine collision type to use in vlasov update
   s->collision_id = s->info.collisions.collision_id;
+  s->lte = (struct vm_lte) { };
   s->lbo = (struct vm_lbo_collisions) { };
   s->bgk = (struct vm_bgk_collisions) { };
+  if (s->collision_id == GKYL_BGK_COLLISIONS || s->info.output_f_lte){
+    vm_species_lte_init(app, s, &s->lte);
+  }
   if (s->collision_id == GKYL_LBO_COLLISIONS) {
     vm_species_lbo_init(app, s, &s->lbo);
   }

--- a/apps/vm_species.c
+++ b/apps/vm_species.c
@@ -561,7 +561,7 @@ vm_species_bgk_niter(gkyl_vlasov_app *app)
 {
   for (int i=0; i<app->num_species; ++i) {
     if (app->species[i].collision_id == GKYL_BGK_COLLISIONS) {
-      app->stat.niter_self_bgk_corr[i] = app->species[i].bgk.lte.self_niter;
+      app->stat.niter_self_bgk_corr[i] = app->species[i].bgk.lte.niter;
     }
   }
 }

--- a/apps/vm_species_bgk.c
+++ b/apps/vm_species_bgk.c
@@ -76,8 +76,8 @@ vm_species_bgk_rhs(gkyl_vlasov_app *app, struct vm_species *species,
   struct timespec wst = gkyl_wall_clock();
   gkyl_array_clear(bgk->nu_f_lte, 0.0);
 
-  // Project the LTE distribution function
-  vm_species_lte(app, species, &bgk->lte, fin);
+  // Project the LTE distribution function from the computed LTE moments
+  vm_species_lte_from_moms(app, species, &bgk->lte, bgk->lte.moms.marr);
 
   gkyl_dg_mul_conf_phase_op_range(&app->confBasis, &app->basis, bgk->lte.f_lte, 
     bgk->self_nu, bgk->lte.f_lte, &app->local, &species->local);

--- a/apps/vm_species_bgk.c
+++ b/apps/vm_species_bgk.c
@@ -44,64 +44,13 @@ vm_species_bgk_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm
   }
 
   bgk->model_id = s->model_id;
-  // allocate moments needed for BGK collisions update
-  vm_species_moment_init(app, s, &bgk->moms, "LTEMoments");
 
-  struct gkyl_vlasov_lte_proj_on_basis_inp inp_proj = {
-    .phase_grid = &s->grid,
-    .conf_basis = &app->confBasis,
-    .phase_basis = &app->basis,
-    .phase_basis_on_dev = app->basis_on_dev.basis, // pointer to (potentially) device-side basis
-    .conf_basis_on_dev = app->basis_on_dev.confBasis, // pointer to (potentially) device-side conf basis
-    .conf_range =  &app->local,
-    .conf_range_ext = &app->local_ext,
-    .vel_range = &s->local_vel,
-    .p_over_gamma = s->p_over_gamma,
-    .gamma = s->gamma,
-    .gamma_inv = s->gamma_inv,
-    .h_ij_inv = s->h_ij_inv,
-    .det_h = s->det_h,
-    .model_id = s->model_id,
-    .mass = s->info.mass,
-    .use_gpu = app->use_gpu,
-  };
-  bgk->proj_lte = gkyl_vlasov_lte_proj_on_basis_inew( &inp_proj );
-
-  bgk->correct_all_moms = false;
   int max_iter = s->info.collisions.max_iter > 0 ? s->info.collisions.max_iter : 100;
   double iter_eps = s->info.collisions.iter_eps > 0 ? s->info.collisions.iter_eps  : 1e-12;
+
+  // Allocate everything needed to make f_lte
+  vm_species_lte_init(app, s, &bgk->lte, s->info.collisions.correct_all_moms);
   
-  if (s->info.collisions.correct_all_moms) {
-    bgk->correct_all_moms = true;
-
-    struct gkyl_vlasov_lte_correct_inp inp_corr = {
-      .phase_grid = &s->grid,
-      .conf_basis = &app->confBasis,
-      .phase_basis = &app->basis,
-      .phase_basis_on_dev = app->basis_on_dev.basis, // pointer to (potentially) device-side basis
-      .conf_basis_on_dev = app->basis_on_dev.confBasis, // pointer to (potentially) device-side conf basis
-      .conf_range =  &app->local,
-      .conf_range_ext = &app->local_ext,
-      .vel_range = &s->local_vel,
-      .p_over_gamma = s->p_over_gamma,
-      .gamma = s->gamma,
-      .gamma_inv = s->gamma_inv,
-      .h_ij_inv = s->h_ij_inv,
-      .det_h = s->det_h,
-      .model_id = s->model_id,
-      .mass = s->info.mass,
-      .use_gpu = app->use_gpu,
-      .max_iter = max_iter,
-      .eps = iter_eps,
-    };
-    bgk->self_niter = 0;
-    bgk->corr_lte = gkyl_vlasov_lte_correct_inew( &inp_corr );
-
-    bgk->corr_stat = gkyl_dynvec_new(GKYL_DOUBLE,7);
-    bgk->is_first_corr_status_write_call = true;
-  }
-
-  bgk->f_lte = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
   bgk->nu_f_lte = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
   // BGK updater (also computes stable timestep)
   bgk->up_bgk = gkyl_bgk_collisions_new(&app->confBasis, &app->basis, app->use_gpu);
@@ -114,7 +63,7 @@ vm_species_bgk_moms(gkyl_vlasov_app *app, const struct vm_species *species,
 {
   struct timespec wst = gkyl_wall_clock();
 
-  vm_species_moment_calc(&bgk->moms, species->local, app->local, fin);
+  vm_species_moment_calc(&bgk->lte.moms, species->local, app->local, fin);
   
   app->stat.species_coll_mom_tm += gkyl_time_diff_now_sec(wst);    
 }
@@ -128,11 +77,11 @@ vm_species_bgk_rhs(gkyl_vlasov_app *app, struct vm_species *species,
   gkyl_array_clear(bgk->nu_f_lte, 0.0);
 
   // Project the LTE distribution function
-  vm_species_lte(app, species, &species->lte, fin);
+  vm_species_lte(app, species, &bgk->lte, fin);
 
-  gkyl_dg_mul_conf_phase_op_range(&app->confBasis, &app->basis, species->lte.f_lte, 
-    bgk->self_nu, species->lte.f_lte, &app->local, &species->local);
-  gkyl_array_accumulate(bgk->nu_f_lte, 1.0, species->lte.f_lte);
+  gkyl_dg_mul_conf_phase_op_range(&app->confBasis, &app->basis, bgk->lte.f_lte, 
+    bgk->self_nu, bgk->lte.f_lte, &app->local, &species->local);
+  gkyl_array_accumulate(bgk->nu_f_lte, 1.0, bgk->lte.f_lte);
 
   gkyl_bgk_collisions_advance(bgk->up_bgk, &app->local, &species->local, 
     bgk->nu_sum, bgk->nu_f_lte, fin, bgk->implicit_step, bgk->dt_implicit, rhs, species->cflrate);
@@ -146,7 +95,6 @@ vm_species_bgk_release(const struct gkyl_vlasov_app *app, const struct vm_bgk_co
   gkyl_array_release(bgk->self_nu);
   gkyl_array_release(bgk->nu_sum);
 
-  gkyl_array_release(bgk->f_lte);
   gkyl_array_release(bgk->nu_f_lte);
 
   if (app->use_gpu) {
@@ -159,13 +107,7 @@ vm_species_bgk_release(const struct gkyl_vlasov_app *app, const struct vm_bgk_co
     gkyl_spitzer_coll_freq_release(bgk->spitzer_calc);
   }
 
-  vm_species_moment_release(app, &bgk->moms);
-
-  gkyl_vlasov_lte_proj_on_basis_release(bgk->proj_lte);
-  if (bgk->correct_all_moms) {
-    gkyl_vlasov_lte_correct_release(bgk->corr_lte);
-    gkyl_dynvec_release(bgk->corr_stat);
-  }
+  vm_species_lte_release(app, &bgk->lte);
 
   gkyl_bgk_collisions_release(bgk->up_bgk);
 }

--- a/apps/vm_species_lte.c
+++ b/apps/vm_species_lte.c
@@ -56,7 +56,7 @@ vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm
       .max_iter = max_iter,
       .eps = iter_eps,
     };
-    lte->self_niter = 0;
+    lte->niter = 0;
     lte->corr_lte = gkyl_vlasov_lte_correct_inew( &inp_corr );
 
     lte->corr_stat = gkyl_dynvec_new(GKYL_DOUBLE,7);
@@ -110,7 +110,7 @@ vm_species_lte(gkyl_vlasov_app *app, const struct vm_species *species,
     corr_vec[6] = status_corr.error[4];
     gkyl_dynvec_append(lte->corr_stat,app->tcurr,corr_vec);
 
-    lte->self_niter += status_corr.num_iter;
+    lte->niter += status_corr.num_iter;
   } 
 
   app->stat.species_lte_tm += gkyl_time_diff_now_sec(wst);

--- a/apps/vm_species_lte.c
+++ b/apps/vm_species_lte.c
@@ -85,7 +85,7 @@ vm_species_lte(gkyl_vlasov_app *app, const struct vm_species *species,
 {
 
   // Always update the moments
-   vm_species_lte_moms(app, species, lte, fin);
+  vm_species_lte_moms(app, species, lte, fin);
 
   struct timespec wst = gkyl_wall_clock();
   gkyl_array_clear(lte->f_lte, 0.0);

--- a/apps/vm_species_lte.c
+++ b/apps/vm_species_lte.c
@@ -1,0 +1,131 @@
+#include <assert.h>
+#include <gkyl_vlasov_priv.h>
+
+void 
+vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm_lte *lte)
+{
+  int cdim = app->cdim, vdim = app->vdim;
+
+  // allocate moments needed for lte update
+  vm_species_moment_init(app, s, &lte->moms, "LTEMoments");
+
+  struct gkyl_vlasov_lte_proj_on_basis_inp inp_proj = {
+    .phase_grid = &s->grid,
+    .conf_basis = &app->confBasis,
+    .phase_basis = &app->basis,
+    .phase_basis_on_dev = app->basis_on_dev.basis, // pointer to (potentially) device-side basis
+    .conf_basis_on_dev = app->basis_on_dev.confBasis, // pointer to (potentially) device-side conf basis
+    .conf_range =  &app->local,
+    .conf_range_ext = &app->local_ext,
+    .vel_range = &s->local_vel,
+    .p_over_gamma = s->p_over_gamma,
+    .gamma = s->gamma,
+    .gamma_inv = s->gamma_inv,
+    .h_ij_inv = s->h_ij_inv,
+    .det_h = s->det_h,
+    .model_id = s->model_id,
+    .mass = s->info.mass,
+    .use_gpu = app->use_gpu,
+  };
+  lte->proj_lte = gkyl_vlasov_lte_proj_on_basis_inew( &inp_proj );
+
+  lte->correct_all_moms = false;
+  int max_iter = s->info.max_iter > 0 ? s->info.max_iter : 100;
+  double iter_eps = s->info.iter_eps > 0 ? s->info.iter_eps  : 1e-12;
+  
+  if (s->lte.correct_all_moms) {
+    lte->correct_all_moms = true;
+
+    struct gkyl_vlasov_lte_correct_inp inp_corr = {
+      .phase_grid = &s->grid,
+      .conf_basis = &app->confBasis,
+      .phase_basis = &app->basis,
+      .phase_basis_on_dev = app->basis_on_dev.basis, // pointer to (potentially) device-side basis
+      .conf_basis_on_dev = app->basis_on_dev.confBasis, // pointer to (potentially) device-side conf basis
+      .conf_range =  &app->local,
+      .conf_range_ext = &app->local_ext,
+      .vel_range = &s->local_vel,
+      .p_over_gamma = s->p_over_gamma,
+      .gamma = s->gamma,
+      .gamma_inv = s->gamma_inv,
+      .h_ij_inv = s->h_ij_inv,
+      .det_h = s->det_h,
+      .model_id = s->model_id,
+      .mass = s->info.mass,
+      .use_gpu = app->use_gpu,
+      .max_iter = max_iter,
+      .eps = iter_eps,
+    };
+    lte->self_niter = 0;
+    lte->corr_lte = gkyl_vlasov_lte_correct_inew( &inp_corr );
+
+    lte->corr_stat = gkyl_dynvec_new(GKYL_DOUBLE,7);
+    lte->is_first_corr_status_write_call = true;
+  }
+
+  lte->f_lte = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
+}
+
+// computes moments
+void
+vm_species_lte_moms(gkyl_vlasov_app *app, const struct vm_species *species,
+  struct vm_lte *lte, const struct gkyl_array *fin)
+{
+  struct timespec wst = gkyl_wall_clock();
+
+  vm_species_moment_calc(&lte->moms, species->local, app->local, fin);
+  
+  app->stat.species_lte_tm += gkyl_time_diff_now_sec(wst);    
+}
+
+// updates f_lte to the current fin
+void
+vm_species_lte(gkyl_vlasov_app *app, const struct vm_species *species,
+  struct vm_lte *lte, const struct gkyl_array *fin)
+{
+
+  // Always update the moments
+   vm_species_lte_moms(app, species, lte, fin);
+
+  struct timespec wst = gkyl_wall_clock();
+  gkyl_array_clear(lte->f_lte, 0.0);
+
+  // Project the LTE distribution function to obtain f_lte.
+  // e.g., Maxwellian for non-relativistic and Maxwell-Juttner for relativistic.
+  // Projection routine also corrects the density of the projected distribution function.
+  gkyl_vlasov_lte_proj_on_basis_advance(lte->proj_lte, &species->local, &app->local, 
+    lte->moms.marr, lte->f_lte);
+
+  // Correct all the moments of the projected LTE distribution function.
+  if (lte->correct_all_moms) {
+    struct gkyl_vlasov_lte_correct_status status_corr = gkyl_vlasov_lte_correct_all_moments(lte->corr_lte, lte->f_lte, lte->moms.marr,
+      &species->local, &app->local);
+    double corr_vec[7];
+    corr_vec[0] = status_corr.num_iter;
+    corr_vec[1] = status_corr.iter_converged;
+    corr_vec[2] = status_corr.error[0];
+    corr_vec[3] = status_corr.error[1];
+    corr_vec[4] = status_corr.error[2];
+    corr_vec[5] = status_corr.error[3];
+    corr_vec[6] = status_corr.error[4];
+    gkyl_dynvec_append(lte->corr_stat,app->tcurr,corr_vec);
+
+    lte->self_niter += status_corr.num_iter;
+  } 
+
+  app->stat.species_lte_tm += gkyl_time_diff_now_sec(wst);
+}
+
+void 
+vm_species_lte_release(const struct gkyl_vlasov_app *app, const struct vm_lte *lte)
+{
+  gkyl_array_release(lte->f_lte);
+
+  vm_species_moment_release(app, &lte->moms);
+
+  gkyl_vlasov_lte_proj_on_basis_release(lte->proj_lte);
+  if (lte->correct_all_moms) {
+    gkyl_vlasov_lte_correct_release(lte->corr_lte);
+    gkyl_dynvec_release(lte->corr_stat);
+  }
+}

--- a/apps/vm_species_lte.c
+++ b/apps/vm_species_lte.c
@@ -2,7 +2,7 @@
 #include <gkyl_vlasov_priv.h>
 
 void 
-vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm_lte *lte)
+vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm_lte *lte, bool correct_all_moms)
 {
   int cdim = app->cdim, vdim = app->vdim;
 
@@ -33,7 +33,7 @@ vm_species_lte_init(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm
   int max_iter = s->info.max_iter > 0 ? s->info.max_iter : 100;
   double iter_eps = s->info.iter_eps > 0 ? s->info.iter_eps  : 1e-12;
   
-  if (s->lte.correct_all_moms) {
+  if (correct_all_moms) {
     lte->correct_all_moms = true;
 
     struct gkyl_vlasov_lte_correct_inp inp_corr = {

--- a/regression/rt_can_pb_neut_bgk_sodshock_1x1v_p2.c
+++ b/regression/rt_can_pb_neut_bgk_sodshock_1x1v_p2.c
@@ -1,0 +1,479 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_vlasov.h>
+#include <gkyl_util.h>
+#include <gkyl_wv_euler.h>
+
+#include <gkyl_null_comm.h>
+
+#ifdef GKYL_HAVE_MPI
+#include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#ifdef GKYL_HAVE_NCCL
+#include <gkyl_nccl_comm.h>
+#endif
+#endif
+
+#include <rt_arg_parse.h>
+
+struct sodshock_ctx
+{
+  // Physical constants (using normalized code units).
+  double mass; // Neutral mass.
+  double charge; // Neutral charge.
+
+  double nl; // Left number density.
+  double Tl; // Left temperature.
+
+  double nr; // Right number density.
+  double Tr; // Right temperature.
+
+  double vt; // Thermal velocity.
+  double Vx_drift; // Drift velocity (x-direction).
+  double nu; // Collision frequency.
+
+  // Simulation parameters.
+  int Nx; // Cell count (configuration space: x-direction).
+  int Nvx; // Cell count (velocity space: vx-direction).
+  double Lx; // Domain size (configuration space: x-direction).
+  double vx_max; // Domain boundary (velocity space: vx-direction).
+  int poly_order; // Polynomial order.
+  double cfl_frac; // CFL coefficient.
+
+  double t_end; // Final simulation time.
+  int num_frames; // Number of output frames.
+  double dt_failure_tol; // Minimum allowable fraction of initial time-step.
+  int num_failures_max; // Maximum allowable number of consecutive small time-steps.
+};
+
+struct sodshock_ctx
+create_ctx(void)
+{
+  // Physical constants (using normalized code units).
+  double mass = 1.0; // Neutral mass.
+  double charge = 0.0; // Neutral charge.
+
+  double nl = 1.0; // Left number density.
+  double Tl = 1.0; // Left temperature.
+
+  double nr = 0.125; // Right number density.
+  double Tr = sqrt(0.1 / 0.125); // Right temperature.
+
+  double vt = 1.0; // Thermal velocity.
+  double Vx_drift = 0.0; // Drift velocity (x-direction).
+  double nu = 100.0; // Collision frequency.
+
+  // Simulation parameters.
+  int Nx = 128; // Cell count (configuration space: x-direction).
+  int Nvx = 32; // Cell count (velocity space: vx-direction).
+  double Lx = 1.0; // Domain size (configuration space: x-direction).
+  double vx_max = 8.0 * vt; // Domain boundary (velocity space: vx-direction).
+  int poly_order = 2; // Polynomial order.
+  double cfl_frac = 1.0; // CFL coefficient.
+
+  double t_end = 0.1; // Final simulation time.
+  int num_frames = 1; // Number of output frames.
+  double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
+  int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
+
+  struct sodshock_ctx ctx = {
+    .mass = mass,
+    .charge = charge,
+    .nl = nl,
+    .Tl = Tl,
+    .nr = nr,
+    .Tr = Tr,
+    .vt = vt,
+    .Vx_drift = Vx_drift,
+    .nu = nu,
+    .Nx = Nx,
+    .Nvx = Nvx,
+    .Lx = Lx,
+    .vx_max = vx_max,
+    .poly_order = poly_order,
+    .cfl_frac = cfl_frac,
+    .t_end = t_end,
+    .num_frames = num_frames,
+    .dt_failure_tol = dt_failure_tol,
+    .num_failures_max = num_failures_max,
+  };
+
+  return ctx;
+}
+
+void
+h_ij_inv(double t, const double* xn, double* fout, void* ctx)
+{
+  fout[0] = 1;
+}
+
+void
+det_h(double t, const double* xn, double* fout, void* ctx)
+{
+  fout[0] = 1;
+}
+
+
+void
+hamil(double t, const double* xn, double* fout, void* ctx)
+{
+  double x = xn[0], v = xn[1];
+  fout[0] = 0.5*v*v;
+}
+
+void
+evalDensityInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
+{
+  struct sodshock_ctx *app = ctx;
+  double x = xn[0];
+
+  double nl = app->nl;
+  double nr = app->nr;
+
+  double n = 0.0;
+
+  if (x < 0.5) {
+    n = nl;
+  }
+  else {
+    n = nr;
+  }
+
+  // Set distribution function.
+  fout[0] = n;
+}
+
+void
+evalTempInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
+{
+  struct sodshock_ctx *app = ctx;
+  double x = xn[0];
+
+  double Tl = app->Tl;
+  double Tr = app->Tr;
+
+  double T = 0.0;
+
+  if (x < 0.5) {
+    T = Tl;
+  }
+  else {
+    T = Tr;
+  }
+
+  // Set temperature.
+  fout[0] = T;
+}
+
+void
+evalVDriftInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
+{
+  struct sodshock_ctx *app = ctx;
+
+  double Vx_drift = app->Vx_drift;
+
+  // Set drift velocity.
+  fout[0] = Vx_drift;
+}
+
+void
+evalNu(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
+{
+  struct sodshock_ctx *app = ctx;
+
+  double nu = app->nu;
+
+  // Set collision frequency.
+  fout[0] = nu;
+}
+
+void
+write_data(struct gkyl_tm_trigger* iot, gkyl_vlasov_app* app, double t_curr, bool force_write)
+{
+  if (gkyl_tm_trigger_check_and_bump(iot, t_curr)) {
+    int frame = iot->curr - 1;
+    if (force_write) {
+      frame = iot->curr;
+    }
+
+    gkyl_vlasov_app_write(app, t_curr, iot->curr - 1);
+
+    gkyl_vlasov_app_calc_mom(app);
+    gkyl_vlasov_app_write_mom(app, t_curr, iot->curr - 1);
+  }
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) {
+    MPI_Init(&argc, &argv);
+  }
+#endif
+
+  if (app_args.trace_mem) {
+    gkyl_cu_dev_mem_debug_set(true);
+    gkyl_mem_debug_set(true);
+  }
+
+  struct sodshock_ctx ctx = create_ctx(); // Context for initialization functions.
+
+  int NX = APP_ARGS_CHOOSE(app_args.xcells[0], ctx.Nx);
+  int NVX = APP_ARGS_CHOOSE(app_args.vcells[0], ctx.Nvx);
+
+  int nrank = 1; // Number of processors in simulation.
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) {
+    MPI_Comm_size(MPI_COMM_WORLD, &nrank);
+  }
+#endif  
+
+  // Create global range.
+  int ccells[] = { NX };
+  int cdim = sizeof(ccells) / sizeof(ccells[0]);
+  struct gkyl_range cglobal_r;
+  gkyl_create_global_range(cdim, ccells, &cglobal_r);
+
+  // Create decomposition.
+  int cuts[cdim];
+#ifdef GKYL_HAVE_MPI  
+  for (int d = 0; d < cdim; d++) {
+    if (app_args.use_mpi) {
+      cuts[d] = app_args.cuts[d];
+    }
+    else {
+      cuts[d] = 1;
+    }
+  }
+#else
+  for (int d = 0; d < cdim; d++) {
+    cuts[d] = 1;
+  }
+#endif  
+    
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(cdim, cuts, &cglobal_r);
+
+  // Construct communicator for use in app.
+  struct gkyl_comm *comm;
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_gpu && app_args.use_mpi) {
+#ifdef GKYL_HAVE_NCCL
+    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+#else
+    printf(" Using -g and -M together requires NCCL.\n");
+    assert(0 == 1);
+#endif
+  }
+  else if (app_args.use_mpi) {
+    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+        .mpi_comm = MPI_COMM_WORLD,
+        .decomp = decomp
+      }
+    );
+  }
+  else {
+    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+        .decomp = decomp,
+        .use_gpu = app_args.use_gpu
+      }
+    );
+  }
+#else
+  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+      .decomp = decomp,
+      .use_gpu = app_args.use_gpu
+    }
+  );
+#endif
+
+  int my_rank;
+  gkyl_comm_get_rank(comm, &my_rank);
+  int comm_size;
+  gkyl_comm_get_size(comm, &comm_size);
+
+  int ncuts = 1;
+  for (int d = 0; d < cdim; d++) {
+    ncuts *= cuts[d];
+  }
+
+  if (ncuts != comm_size) {
+    if (my_rank == 0) {
+      fprintf(stderr, "*** Number of ranks, %d, does not match total cuts, %d!\n", comm_size, ncuts);
+    }
+    goto mpifinalize;
+  }
+
+  // Neutral species.
+  struct gkyl_vlasov_species neut = {
+    .name = "neut",
+    .model_id = GKYL_MODEL_CANONICAL_PB,
+    .charge = ctx.charge, .mass = ctx.mass,
+    .lower = { -ctx.vx_max },
+    .upper = { ctx.vx_max }, 
+    .cells = { NVX },
+    .hamil = hamil,
+    .h_ij_inv = h_ij_inv,
+    .det_h = det_h,
+    .hamil_ctx = &ctx,
+    .h_ij_inv_ctx = &ctx,
+    .det_h_ctx = &ctx,
+    .output_f_lte = true,
+
+    .projection = {
+      .proj_id = GKYL_PROJ_VLASOV_LTE,
+      .density = evalDensityInit,
+      .ctx_density = &ctx,
+      .temp = evalTempInit,
+      .ctx_temp = &ctx,
+      .V_drift = evalVDriftInit,
+      .ctx_V_drift = &ctx,
+      .correct_all_moms = true,
+    },
+    .collisions =  {
+      .collision_id = GKYL_BGK_COLLISIONS,
+      .self_nu = evalNu,
+      .ctx = &ctx,
+      .correct_all_moms = true,
+    },
+    
+    .num_diag_moments = 3,
+    .diag_moments = { "M0", "M1i", "LTEMoments" },
+  };
+
+  // Vlasov-Maxwell app.
+  struct gkyl_vm app_inp = {
+   .name = "can_pb_neut_bgk_sodshock_1x1v_p2",
+
+   .cdim = 1, .vdim = 1, 
+   .lower = { 0.0 },
+   .upper = { ctx.Lx },
+   .cells = { NX },
+
+   .poly_order = ctx.poly_order,
+   .basis_type = app_args.basis_type,
+   .cfl_frac = ctx.cfl_frac,
+
+   .num_periodic_dir = 0,
+   .periodic_dirs = { },
+
+   .num_species = 1,
+   .species = { neut },
+
+   .skip_field = true,
+
+   .use_gpu = app_args.use_gpu,
+
+   .has_low_inp = true,
+   .low_inp = {
+     .local_range = decomp->ranges[my_rank],
+     .comm = comm
+   }
+  };
+
+  // Create app object.
+  gkyl_vlasov_app *app = gkyl_vlasov_app_new(&app_inp);
+
+  // Initial and final simulation times.
+  double t_curr = 0.0, t_end = ctx.t_end;
+
+  // Create trigger for IO.
+  int num_frames = ctx.num_frames;
+  struct gkyl_tm_trigger io_trig = { .dt = t_end / num_frames };
+
+  // Initialize simulation.
+  gkyl_vlasov_app_apply_ic(app, t_curr);
+  write_data(&io_trig, app, t_curr, false);
+
+  // Compute initial guess of maximum stable time-step.
+  double dt = t_end - t_curr;
+
+  // Initialize small time-step check.
+  double dt_init = -1.0, dt_failure_tol = ctx.dt_failure_tol;
+  int num_failures = 0, num_failures_max = ctx.num_failures_max;
+
+  long step = 1;
+  while ((t_curr < t_end) && (step <= app_args.num_steps)) {
+    gkyl_vlasov_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, t_curr);
+    struct gkyl_update_status status = gkyl_vlasov_update(app, dt);
+    gkyl_vlasov_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
+    
+    if (!status.success) {
+      gkyl_vlasov_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+
+    t_curr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    write_data(&io_trig, app, t_curr, false);
+
+    if (dt_init < 0.0) {
+      dt_init = status.dt_actual;
+    }
+    else if (status.dt_actual < dt_failure_tol * dt_init) {
+      num_failures += 1;
+
+      gkyl_vlasov_app_cout(app, stdout, "WARNING: Time-step dt = %g", status.dt_actual);
+      gkyl_vlasov_app_cout(app, stdout, " is below %g*dt_init ...", dt_failure_tol);
+      gkyl_vlasov_app_cout(app, stdout, " num_failures = %d\n", num_failures);
+      if (num_failures >= num_failures_max) {
+        gkyl_vlasov_app_cout(app, stdout, "ERROR: Time-step was below %g*dt_init ", dt_failure_tol);
+        gkyl_vlasov_app_cout(app, stdout, "%d consecutive times. Aborting simulation ....\n", num_failures_max);
+        break;
+      }
+    }
+    else {
+      num_failures = 0;
+    }
+
+    step += 1;
+  }
+
+  write_data(&io_trig, app, t_curr, false);
+  gkyl_vlasov_app_stat_write(app);
+
+  struct gkyl_vlasov_stat stat = gkyl_vlasov_app_stat(app);
+
+  gkyl_vlasov_app_cout(app, stdout, "\n");
+  gkyl_vlasov_app_cout(app, stdout, "Number of update calls %ld\n", stat.nup);
+  gkyl_vlasov_app_cout(app, stdout, "Number of forward-Euler calls %ld\n", stat.nfeuler);
+  gkyl_vlasov_app_cout(app, stdout, "Number of RK stage-2 failures %ld\n", stat.nstage_2_fail);
+  if (stat.nstage_2_fail > 0) {
+    gkyl_vlasov_app_cout(app, stdout, "  Max rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[1]);
+    gkyl_vlasov_app_cout(app, stdout, "  Min rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[0]);
+  }  
+  gkyl_vlasov_app_cout(app, stdout, "Number of RK stage-3 failures %ld\n", stat.nstage_3_fail);
+  gkyl_vlasov_app_cout(app, stdout, "Species RHS calc took %g secs\n", stat.species_rhs_tm);
+  gkyl_vlasov_app_cout(app, stdout, "Species collisions RHS calc took %g secs\n", stat.species_coll_tm);
+  gkyl_vlasov_app_cout(app, stdout, "Field RHS calc took %g secs\n", stat.field_rhs_tm);
+  gkyl_vlasov_app_cout(app, stdout, "Species collisional moments took %g secs\n", stat.species_coll_mom_tm);
+  gkyl_vlasov_app_cout(app, stdout, "Total updates took %g secs\n", stat.total_tm);
+
+  gkyl_vlasov_app_cout(app, stdout, "Number of write calls %ld\n", stat.nio);
+  gkyl_vlasov_app_cout(app, stdout, "IO time took %g secs \n", stat.io_tm);
+
+  // Free resources after simulation completion.
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_vlasov_app_release(app);
+
+mpifinalize:
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) {
+    MPI_Finalize();
+  }
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
DR: [https://github.com/ammarhakim/gkylzero/issues/414](url) 

Description: 
This branch primarily does the following: 
-	Creates a new structure vm_lte, used within gkyl_vm_species to store moments/projection object/f_lte
-	Used in two places currently: (NEW) io of f_lte, and in the BGK collision routine to create f_lte.
-	New io flag (in the vm_species): output_f_lte 

Additions:
New file: vm_species_lte. This contains the functions: (no gkyl_... since they are private to vm)
```
// Initialize species lte object.
void vm_species_lte_init(…);

// Compute necessary moments for f-lte creation
void vm_species_lte_moms(…);

// Compute f-lte
void vm_species_lte(…);
```

With the new struct:
```
struct vm_lte {  
  struct gkyl_array *f_lte;

  struct vm_species_moment moms; // moments needed in the equilibrium

  // LTE distribution function projection object
  // also corrects the density of projected distribution function
  struct gkyl_vlasov_lte_proj_on_basis *proj_lte; 

  long self_niter; // total number of iterations correcting self collisions

  // Correction updater for insuring LTE distribution has desired LTE (n, V_drift, T/m) moments
  bool correct_all_moms; // boolean if we are correcting all the moments
  struct gkyl_vlasov_lte_correct *corr_lte; 
  gkyl_dynvec corr_stat;
  bool is_first_corr_status_write_call;
};
```

Tests:
- The regression test has been added: rt_can_pb_neut_bgk_sodshock_1x1v_p2, this outputs f_lte

Other Notes:
-	Moments for f_lte are now calculated inside the f. This is to guarantee the moments are always populated and updated before creating f_lte.
-	No longer used for BGK: species_coll_mom_tm : 0
-      self_niter, used to compute the total number of corrective iterations taken when creating the f_lte distribution, has been changed to niter
