### PR TITLE
gk-g0-app emission header fix

### DIFF
--- a/zero/bc_emission_elastic.c
+++ b/zero/bc_emission_elastic.c
@@ -1,4 +1,5 @@
 #include <gkyl_bc_emission_elastic.h>
+#include <gkyl_bc_emission_elastic_priv.h>
 #include <gkyl_dg_bin_ops.h>
 #include <gkyl_proj_on_basis.h>
 #include <gkyl_alloc.h>

--- a/zero/gkyl_bc_emission_elastic.h
+++ b/zero/gkyl_bc_emission_elastic.h
@@ -5,7 +5,6 @@
 #include <gkyl_array.h>
 #include <gkyl_rect_grid.h>
 #include <gkyl_emission_elastic_model.h>
-#include <gkyl_bc_emission_elastic_priv.h>
 
 // Object type
 typedef struct gkyl_bc_emission_elastic gkyl_bc_emission_elastic;


### PR DESCRIPTION
An inclusion call to the private header `gkyl_bc_emission_elastic_priv` in the public header of the same object was causing build issues. This inclusion call has been moved to `bc_emission_elastic`.