### PR TITLE
gk-g0-app cross-species emission fixes

### DIFF
--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -244,6 +244,7 @@ struct vm_emitting_wall {
   double *scale_ptr;
   double t_bound;
   bool elastic;
+  bool write;
 
   struct gkyl_spectrum_model *spectrum_model[GKYL_MAX_SPECIES];
   struct gkyl_yield_model *yield_model[GKYL_MAX_SPECIES];
@@ -791,6 +792,18 @@ void vm_species_emission_cross_init(struct gkyl_vlasov_app *app, struct vm_speci
  */
 void vm_species_emission_apply_bc(struct gkyl_vlasov_app *app, const struct vm_emitting_wall *emit,
   struct gkyl_array *fout, double tcurr);
+
+/**
+ * Write emission spectrum distribution function
+ *
+ * @param app Vlasov app object
+ * @param s Species object
+ * @param emit Pointer to emission object
+ * @param mt Write meta
+ * @param frame Current frame
+ */
+void vm_species_emission_write(struct gkyl_vlasov_app *app, struct vm_species *s,
+  struct vm_emitting_wall *emit, struct gkyl_array_meta *mt, int frame);
 
 /**
  * Release species emission object.

--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -638,6 +638,11 @@ gkyl_vlasov_app_write_species(gkyl_vlasov_app* app, int sidx, double tm, int fra
     }
   }
 
+  if (app->species[sidx].emit_lo)
+    vm_species_emission_write(app, vm_s, &vm_s->bc_emission_lo, mt, frame);
+  if (app->species[sidx].emit_up)
+    vm_species_emission_write(app, vm_s, &vm_s->bc_emission_up, mt, frame);
+
   vlasov_array_meta_release(mt);  
 }
 

--- a/apps/vm_species_emission.c
+++ b/apps/vm_species_emission.c
@@ -86,7 +86,7 @@ vm_species_emission_apply_bc(struct gkyl_vlasov_app *app, const struct vm_emitti
 {
   // Optional scaling of emission with time
   double t_scale = 1.0;
-  if (emit->t_bound)
+  if (tcurr < emit->t_bound)
     t_scale = sin(M_PI*tcurr/(2.0*emit->t_bound));
 
   gkyl_array_clear(emit->f_emit, 0.0); // Zero emitted distribution before beginning accumulate

--- a/apps/vm_species_emission.c
+++ b/apps/vm_species_emission.c
@@ -30,6 +30,12 @@ vm_species_emission_cross_init(struct gkyl_vlasov_app *app, struct vm_species *s
     ghost[cdim+d] = 0;
   }
 
+  if (emit->edge == GKYL_LOWER_EDGE) {
+    emit->write = gkyl_range_is_on_lower_edge(emit->dir, &s->lower_skin[emit->dir], &s->global);
+  } else {
+    emit->write = gkyl_range_is_on_upper_edge(emit->dir, &s->upper_skin[emit->dir], &s->global);
+  }
+
   emit->emit_grid = &s->bflux.boundary_grid[bdir];
   emit->emit_buff_r = &s->bflux.flux_r[bdir];
   emit->emit_ghost_r = (emit->edge == GKYL_LOWER_EDGE) ? &s->lower_ghost[emit->dir] : &s->upper_ghost[emit->dir];
@@ -111,6 +117,22 @@ vm_species_emission_apply_bc(struct gkyl_vlasov_app *app, const struct vm_emitti
   }
   gkyl_array_set_range_to_range(fout, t_scale, emit->f_emit, emit->emit_ghost_r,
     emit->emit_buff_r);
+}
+
+
+// KB - The write function only works in 1x at the moment.
+// It expects a single rank to own the whole emit range.
+void
+vm_species_emission_write(struct gkyl_vlasov_app *app, struct vm_species *s, struct vm_emitting_wall *emit, struct gkyl_array_meta *mt, int frame)
+{
+  const char *fmt = (emit->edge == GKYL_LOWER_EDGE) ? "%s-%s_bc_lo_%d.gkyl" : "%s-%s_bc_up_%d.gkyl";
+  int sz = gkyl_calc_strlen(fmt, app->name, s->info.name, frame);
+  char fileNm[sz+1]; // ensures no buffer overflow
+  snprintf(fileNm, sizeof fileNm, fmt, app->name, s->info.name, frame);
+
+  if (emit->write) {
+    gkyl_grid_sub_array_write(emit->emit_grid, emit->emit_buff_r, mt, emit->f_emit, fileNm);
+  }
 }
 
 void

--- a/apps/vm_species_emission.c
+++ b/apps/vm_species_emission.c
@@ -74,8 +74,9 @@ vm_species_emission_cross_init(struct gkyl_vlasov_app *app, struct vm_species *s
     
     emit->update[i] = gkyl_bc_emission_spectrum_new(emit->params->spectrum_model[i],
       emit->params->yield_model[i], emit->yield[i], emit->spectrum[i], emit->dir, emit->edge,
-      cdim, vdim, emit->impact_species[i]->info.mass, s->info.mass, emit->impact_buff_r[i], emit->emit_buff_r, emit->impact_grid[i], app->poly_order,
-      &app->basis,  proj_buffer, app->use_gpu);
+      cdim, vdim, emit->impact_species[i]->info.mass, s->info.mass, emit->impact_buff_r[i],
+      emit->emit_buff_r, emit->impact_grid[i], emit->emit_grid, app->poly_order,
+      &app->basis, proj_buffer, app->use_gpu);
   }
   gkyl_array_release(proj_buffer);
 }

--- a/zero/bc_emission.c
+++ b/zero/bc_emission.c
@@ -132,6 +132,37 @@ gkyl_bc_emission_secondary_electron_lithium_clean_new(int num_species, double t_
   return ctx;
 }
 
+// Ion-impact SEE copper preset
+struct gkyl_bc_emission_ctx*
+gkyl_bc_emission_ion_impact_copper_new(int num_species, double t_bound,
+  char in_species[][128], bool use_gpu)
+{
+  struct gkyl_bc_emission_ctx *ctx = gkyl_malloc(sizeof(struct gkyl_bc_emission_ctx));
+  
+  double q0 = 1.602e-19;
+  double E_0 = 2.80670245635625;
+  double tau = 1.21017574095341;
+
+  double A2 = 4.194;  // a2-5 are empirical fits for ion stopping power
+  double A3 = 4.649e3;  // Starting at a2 to match source and prevent confusion
+  double A4 = 8.113e1;
+  double A5 = 2.242e-2;
+  double nw = 8.491231742083982e28;  // Number density of the wall material (m^-3). Calculated a priori using rho/m/u where rho is density in kg/m^3, m is mass in amu, and u is the unified atomic mass unit
+  double int_wall = 6.33665090954913e7;  // Integration of wall term (J/m).  See the paper for more info on this.
+
+  ctx->num_species = num_species;
+  ctx->t_bound = t_bound;
+  ctx->elastic = false;
+
+  for (int i=0; i<num_species; ++i) {
+    ctx->spectrum_model[i] = gkyl_spectrum_gaussian_new(q0, E_0, tau, use_gpu);
+    ctx->yield_model[i] = gkyl_yield_schou_new(q0, int_wall, A2, A3, A4, A5, nw, use_gpu);
+    strcpy(ctx->in_species[i], in_species[i]);
+  }
+
+  return ctx;
+}
+
 void gkyl_bc_emission_release(struct gkyl_bc_emission_ctx *ctx)
 {
   for (int i=0; i<ctx->num_species; ++i) {

--- a/zero/bc_emission.c
+++ b/zero/bc_emission.c
@@ -155,8 +155,8 @@ gkyl_bc_emission_ion_impact_copper_new(int num_species, double t_bound,
   ctx->elastic = false;
 
   for (int i=0; i<num_species; ++i) {
-    ctx->spectrum_model[i] = gkyl_spectrum_gaussian_new(q0, E_0, tau, use_gpu);
-    ctx->yield_model[i] = gkyl_yield_schou_new(q0, int_wall, A2, A3, A4, A5, nw, use_gpu);
+    ctx->spectrum_model[i] = gkyl_emission_spectrum_gaussian_new(q0, E_0, tau, use_gpu);
+    ctx->yield_model[i] = gkyl_emission_yield_schou_new(q0, int_wall, A2, A3, A4, A5, nw, use_gpu);
     strcpy(ctx->in_species[i], in_species[i]);
   }
 

--- a/zero/bc_emission_spectrum.c
+++ b/zero/bc_emission_spectrum.c
@@ -70,8 +70,8 @@ struct gkyl_bc_emission_spectrum*
 gkyl_bc_emission_spectrum_new(struct gkyl_emission_spectrum_model *spectrum_model,
   struct gkyl_emission_yield_model *yield_model, struct gkyl_array *yield,
   struct gkyl_array *spectrum, int dir, enum gkyl_edge_loc edge, int cdim, int vdim,
-  double mass_in, double mass_out, struct gkyl_range *impact_buff_r,
-  struct gkyl_range *emit_buff_r, struct gkyl_rect_grid *grid, int poly_order,
+  double mass_in, double mass_out, struct gkyl_range *impact_buff_r, struct gkyl_range *emit_buff_r,
+  struct gkyl_rect_grid *impact_grid, struct gkyl_rect_grid *emit_grid, int poly_order,
   struct gkyl_basis *basis, struct gkyl_array *proj_buffer, bool use_gpu)
 {
   // Allocate space for new updater.
@@ -82,7 +82,7 @@ gkyl_bc_emission_spectrum_new(struct gkyl_emission_spectrum_model *spectrum_mode
   up->vdim = vdim;
   up->edge = edge;
   up->use_gpu = use_gpu;
-  up->grid = grid;
+  up->grid = impact_grid;
 
   int ghost[GKYL_MAX_DIM];
   for (int d=0; d<cdim; ++d) {
@@ -101,7 +101,7 @@ gkyl_bc_emission_spectrum_new(struct gkyl_emission_spectrum_model *spectrum_mode
   up->yield_model->vdim = vdim;
   up->yield_model->mass = mass_in;
 
-  gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(grid, basis, poly_order + 1, 1,
+  gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(emit_grid, basis, poly_order + 1, 1,
       up->spectrum_model->distribution, up->spectrum_model);
 
 #ifdef GKYL_HAVE_CUDA
@@ -116,7 +116,7 @@ gkyl_bc_emission_spectrum_new(struct gkyl_emission_spectrum_model *spectrum_mode
 #else
   gkyl_proj_on_basis_advance(proj, 0.0, emit_buff_r, spectrum);
 #endif
-  gkyl_bc_emission_spectrum_sey_calc(up, yield, grid, impact_buff_r);
+  gkyl_bc_emission_spectrum_sey_calc(up, yield, impact_grid, impact_buff_r);
   gkyl_proj_on_basis_release(proj);
   
   return up;
@@ -157,7 +157,7 @@ gkyl_bc_emission_spectrum_advance(const struct gkyl_bc_emission_spectrum *up,
   while (gkyl_range_iter_next(&conf_iter)) {
     long midx = gkyl_range_idx(impact_cbuff_r, conf_iter.idx);
 
-    gkyl_range_deflate(&vel_buff_r, emit_buff_r, rem_dir, conf_iter.idx);
+    gkyl_range_deflate(&vel_buff_r, impact_buff_r, rem_dir, conf_iter.idx);
     gkyl_range_iter_no_split_init(&vel_iter, &vel_buff_r);
 
     double *w = gkyl_array_fetch(weight, midx);

--- a/zero/gkyl_bc_emission.h
+++ b/zero/gkyl_bc_emission.h
@@ -73,7 +73,17 @@ struct gkyl_bc_emission_ctx*
 gkyl_bc_emission_secondary_electron_lithium_clean_new(int num_species, double t_bound,
   char in_species[][128], bool use_gpu);
 
-struct gkyl_bc_emission_ctx* gkyl_bc_emission_ion_impact_copper_new(int num_species, double t_bound,
+/**
+ * Copper preset for ion-impact secondary electron emission
+ *
+ * @param num_species Number of impacting species causing emission
+ * @param t_bound Time scaling factor for the emission
+ * @param in_species Table of impacting species names
+ * @param use_gpu bool to determine if on GPU
+ * @return New ctx structure
+ */
+struct gkyl_bc_emission_ctx*
+gkyl_bc_emission_ion_impact_copper_new(int num_species, double t_bound,
   char in_species[][128], bool use_gpu);
 
 /**

--- a/zero/gkyl_bc_emission.h
+++ b/zero/gkyl_bc_emission.h
@@ -73,6 +73,9 @@ struct gkyl_bc_emission_ctx*
 gkyl_bc_emission_secondary_electron_lithium_clean_new(int num_species, double t_bound,
   char in_species[][128], bool use_gpu);
 
+struct gkyl_bc_emission_ctx* gkyl_bc_emission_ion_impact_copper_new(int num_species, double t_bound,
+  char in_species[][128], bool use_gpu);
+
 /**
  * Free memory associated with bc_emission struct.
  *

--- a/zero/gkyl_bc_emission_spectrum.h
+++ b/zero/gkyl_bc_emission_spectrum.h
@@ -26,7 +26,8 @@ typedef struct gkyl_bc_emission_spectrum gkyl_bc_emission_spectrum;
  * @param mass_out Emitted species mass
  * @param impact_buff_r Range over the impacting species buffer array
  * @param emit_buff_r Range over the emitting species buffer array
- * @param grid Impacting species boundary grid
+ * @param impact_grid Impacting species boundary grid
+ * @param emit_grid Emitted species boundary grid
  * @param poly_order Polynomial order of basis functions.
  * @param basis Basis functions
  * @param proj_buffer Host array to temporarily store projection of emission spectrum
@@ -37,8 +38,8 @@ struct gkyl_bc_emission_spectrum*
 gkyl_bc_emission_spectrum_new(struct gkyl_emission_spectrum_model *spectrum_model,
   struct gkyl_emission_yield_model *yield_model, struct gkyl_array *yield,
   struct gkyl_array *spectrum, int dir, enum gkyl_edge_loc edge, int cdim, int vdim,
-  double mass_in, double mass_out, struct gkyl_range *impact_buff_r,
-  struct gkyl_range *emit_buff_r, struct gkyl_rect_grid *grid, int poly_order,
+  double mass_in, double mass_out, struct gkyl_range *impact_buff_r, struct gkyl_range *emit_buff_r,
+  struct gkyl_rect_grid *impact_grid, struct gkyl_rect_grid *emit_grid, int poly_order,
   struct gkyl_basis *basis, struct gkyl_array *proj_buffer, bool use_gpu);
 
 /**

--- a/zero/rect_grid.c
+++ b/zero/rect_grid.c
@@ -140,7 +140,7 @@ gkyl_rect_grid_write(const struct gkyl_rect_grid *grid, FILE *fp)
   uint64_t cells[GKYL_MAX_DIM];
   for (int d=0; d<grid->ndim; ++d)
     cells[d] = grid->cells[d];
-  
+
   fwrite(&ndim, sizeof(uint64_t), 1, fp);
   fwrite(cells, sizeof(uint64_t), grid->ndim, fp);
   fwrite(grid->lower, sizeof(double), grid->ndim, fp);


### PR DESCRIPTION
A number of minor modifications to the emission BC are necessary for it to work properly when the impacting species and emitted species are different and have different boundary grids.

- The emission spectrum was being projected onto the impacting grid instead of the emitting grid, this has been fixed with both grids being passed to the updater.
- The update range was using the emitted boundary range for the weighting of the yield instead of the impacting boundary range.
- A diagnostic was added to output the emitted distribution in the ghost cell in a separate file `bc_up` or `bc_lo`.
- The relaxation of the BC using `t_bound` wasn't quite working, a check was added to correctly cut off the scaling at the appropriate time.
- A preset for the ion-impact secondary electron emission of copper was added.