### PR TITLE
Caught a bug in the ion ionization collision term

### DIFF
--- a/apps/gk_species_react.c
+++ b/apps/gk_species_react.c
@@ -270,7 +270,7 @@ gk_species_react_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *s,
       }
       else if (react->type_self[i] == GKYL_SELF_ION) {
         gkyl_array_set_offset(react->prim_vars_proj_inp[i], 1.0, react->m0_donor[i], 0*app->confBasis.num_basis);
-        gkyl_array_set_offset(react->prim_vars_proj_inp[i], 1.0, react->prim_vars[i], 1*app->confBasis.num_basis);        
+        gkyl_array_set_offset(react->prim_vars_proj_inp[i], 1.0, react->prim_vars_donor[i], 1*app->confBasis.num_basis);        
         gkyl_proj_gkmaxwellian_on_basis_prim_mom(react->proj_max, &s->local, &app->local,
 	  react->prim_vars_proj_inp[i], 
           app->gk_geom->bmag, app->gk_geom->jacobtot, s->info.mass, react->f_react);


### PR DESCRIPTION
Electron prim moms were accidentally being used to project the Maxwellian for the ion ionization collision term, leading to unexpected ion heating. 