### PR TITLE
Fix a bug in the positivity shift diagnostics and in proj_bimaxwellian_on_basis, and implement FourMoments

### DIFF
--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -394,7 +394,7 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
       gks->grid, gks->info.mass, app->gk_geom, gks->vel_map, &app->local_ext, app->use_gpu);
 
     // Allocate data for diagnostic moments
-    gk_species_moment_init(app, gks, &gks->ps_moms, "ThreeMoments");
+    gk_species_moment_init(app, gks, &gks->ps_moms, "FourMoments");
 
     gks->ps_integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, gks->ps_moms.num_mom);
     gks->is_first_ps_integ_write_call = true;

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -393,13 +393,10 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
     gks->pos_shift_op = gkyl_positivity_shift_gyrokinetic_new(app->confBasis, app->basis,
       gks->grid, gks->info.mass, app->gk_geom, gks->vel_map, &app->local_ext, app->use_gpu);
 
-    // allocate data for diagnostic moments
-    int ndm = gks->info.num_diag_moments;
-    gks->ps_moms = gkyl_malloc(sizeof(struct gk_species_moment[ndm]));
-    for (int m=0; m<ndm; ++m)
-      gk_species_moment_init(app, gks, &gks->ps_moms[m], gks->info.diag_moments[m]);
+    // Allocate data for diagnostic moments
+    gk_species_moment_init(app, gks, &gks->ps_moms, "ThreeMoments");
 
-    gks->ps_integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, vdim+2);
+    gks->ps_integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, gks->ps_moms.num_mom);
     gks->is_first_ps_integ_write_call = true;
   }
 }
@@ -693,9 +690,7 @@ gk_species_release(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
   if (app->enforce_positivity) {
     gkyl_array_release(s->ps_delta_m0);
     gkyl_positivity_shift_gyrokinetic_release(s->pos_shift_op);
-    for (int i=0; i<s->info.num_diag_moments; ++i)
-      gk_species_moment_release(app, &s->ps_moms[i]);
-    gkyl_free(s->ps_moms);
+    gk_species_moment_release(app, &s->ps_moms);
     gkyl_dynvec_release(s->ps_integ_diag);
   }
 }

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -554,7 +554,7 @@ struct gk_species {
   // Updater that enforces positivity by shifting f.
   struct gkyl_positivity_shift_gyrokinetic *pos_shift_op;
   struct gkyl_array *ps_delta_m0; // Number density of the positivity shift.
-  struct gk_species_moment *ps_moms; // Positivity shift diagnostic moments.
+  struct gk_species_moment ps_moms; // Positivity shift diagnostic moments.
   gkyl_dynvec ps_integ_diag; // Integrated moments of the positivity shift.
   bool is_first_ps_integ_write_call; // Flag first time writing ps_integ_diag.
 

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -104,6 +104,7 @@ static const char *const valid_moment_names[] = {
   "M3par",
   "M3perp",
   "ThreeMoments",
+  "FourMoments",
   "MaxwellianMoments", // internal flag for whether we are computing (n, u_par, T/m)
   "BiMaxwellianMoments", // internal flag for whether we are computing (n, u_par, T_par/m, T_perp/m)
   "Integrated", // this is an internal flag, not for passing to moment type

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -1381,7 +1381,7 @@ gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
     }
 
     if (app->enforce_positivity) {
-      const char *fmt = "%s-%s_positivity_shift_ThreeMoments_%d.gkyl";
+      const char *fmt = "%s-%s_positivity_shift_FourMoments_%d.gkyl";
       int sz = gkyl_calc_strlen(fmt, app->name, app->species[i].info.name, frame);
       char fileNm[sz+1]; // ensures no buffer overflow
       snprintf(fileNm, sizeof fileNm, fmt, app->name, app->species[i].info.name, frame);

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -585,11 +585,9 @@ gkyl_gyrokinetic_app_calc_mom(gkyl_gyrokinetic_app* app)
     }
 
     if (app->enforce_positivity) {
-      for (int m=0; m<gk_s->info.num_diag_moments; ++m) {
-        // We placed the change in f from the positivity shift in fnew.
-        gk_species_moment_calc(&gk_s->ps_moms[m], gk_s->local, app->local, gk_s->fnew);
-        app->stat.nmom += 1;
-      }
+      // We placed the change in f from the positivity shift in fnew.
+      gk_species_moment_calc(&gk_s->ps_moms, gk_s->local, app->local, gk_s->fnew);
+      app->stat.nmom += 1;
     }
   }
 
@@ -1380,28 +1378,25 @@ gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
       gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
         app->species[i].moms[m].marr_host, fileNm);
 
-      if (app->enforce_positivity) {
-        const char *fmt = "%s-%s_positivity_shift_%s_%d.gkyl";
-        int sz = gkyl_calc_strlen(fmt, app->name, app->species[i].info.name,
-          app->species[i].info.diag_moments[m], frame);
-        char fileNm[sz+1]; // ensures no buffer overflow
-        snprintf(fileNm, sizeof fileNm, fmt, app->name, app->species[i].info.name,
-          app->species[i].info.diag_moments[m], frame);
+    }
 
-        // Rescale moment by inverse of Jacobian if not already re-scaled 
-        if (!app->species[i].ps_moms[m].is_bimaxwellian_moms && !app->species[i].ps_moms[m].is_maxwellian_moms) {
-          gkyl_dg_div_op_range(app->species[i].ps_moms[m].mem_geo, app->confBasis, 
-            0, app->species[i].ps_moms[m].marr, 0, app->species[i].ps_moms[m].marr, 0, 
-            app->gk_geom->jacobgeo, &app->local);  
-        }    
+    if (app->enforce_positivity) {
+      const char *fmt = "%s-%s_positivity_shift_ThreeMoments_%d.gkyl";
+      int sz = gkyl_calc_strlen(fmt, app->name, app->species[i].info.name, frame);
+      char fileNm[sz+1]; // ensures no buffer overflow
+      snprintf(fileNm, sizeof fileNm, fmt, app->name, app->species[i].info.name, frame);
 
-        if (app->use_gpu) {
-          gkyl_array_copy(app->species[i].ps_moms[m].marr_host, app->species[i].ps_moms[m].marr);
-        }
+      // Rescale moment by inverse of Jacobian.
+      gkyl_dg_div_op_range(app->species[i].ps_moms.mem_geo, app->confBasis, 
+        0, app->species[i].ps_moms.marr, 0, app->species[i].ps_moms.marr, 0, 
+        app->gk_geom->jacobgeo, &app->local);  
 
-        gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
-          app->species[i].ps_moms[m].marr_host, fileNm);
+      if (app->use_gpu) {
+        gkyl_array_copy(app->species[i].ps_moms.marr_host, app->species[i].ps_moms.marr);
       }
+
+      gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
+        app->species[i].ps_moms.marr_host, fileNm);
     }
   }
 

--- a/kernels/gyrokinetic/gkyl_mom_gyrokinetic_kernels.h
+++ b/kernels/gyrokinetic/gkyl_mom_gyrokinetic_kernels.h
@@ -9,6 +9,7 @@ GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p1(const double *dxv, const double *
 GKYL_CU_DH void gyrokinetic_M2_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 
 GKYL_CU_DH void gyrokinetic_M0_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -17,6 +18,7 @@ GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p2(const double *dxv, const double *
 GKYL_CU_DH void gyrokinetic_M2_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 
 GKYL_CU_DH void gyrokinetic_M0_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -27,6 +29,7 @@ GKYL_CU_DH void gyrokinetic_M2_1x2v_ser_p1(const double *dxv, const double *vmap
 GKYL_CU_DH void gyrokinetic_M3_par_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_perp_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step1_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step2_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -39,6 +42,7 @@ GKYL_CU_DH void gyrokinetic_M2_1x2v_ser_p2(const double *dxv, const double *vmap
 GKYL_CU_DH void gyrokinetic_M3_par_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_perp_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step1_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step2_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -51,6 +55,7 @@ GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p1(const double *dxv, const double *vmap
 GKYL_CU_DH void gyrokinetic_M3_par_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_perp_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step1_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step2_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -63,6 +68,7 @@ GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p2(const double *dxv, const double *vmap
 GKYL_CU_DH void gyrokinetic_M3_par_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_perp_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step1_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step2_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
@@ -75,6 +81,7 @@ GKYL_CU_DH void gyrokinetic_M2_3x2v_ser_p1(const double *dxv, const double *vmap
 GKYL_CU_DH void gyrokinetic_M3_par_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M3_perp_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_three_moments_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
+GKYL_CU_DH void gyrokinetic_four_moments_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step1_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_M0_step2_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 
 GKYL_CU_DH void gyrokinetic_int_mom_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out); 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_1x1v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_1x1v_ser_p1.c
@@ -7,6 +7,6 @@ GKYL_CU_DH void gyrokinetic_int_mom_1x1v_ser_p1(const double *dxv, const double 
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 2.0*f[0]*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
   out[2] += (0.8944271909999159*vmap1R2*f[4]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_1x1v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_1x1v_ser_p2.c
@@ -7,6 +7,6 @@ GKYL_CU_DH void gyrokinetic_int_mom_1x1v_ser_p2(const double *dxv, const double 
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 2.0*f[0]*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
   out[2] += (0.8944271909999159*vmap1R2*f[5]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_1x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_1x2v_ser_p1.c
@@ -1,17 +1,17 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_int_mom_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = M_PI/m_*0.25*dxv[0]*dxv[1]*dxv[2]; 
+  const double volFact = 0.7853981633974483*dxv[0]*dxv[1]*dxv[2]/m_; 
  
   double tmp[2]; 
-  tmp[0] = (2.828427124746191*f[3]*vmap[3])/m_+(2.828427124746191*f[0]*vmap[2])/m_; 
-  tmp[1] = (2.828427124746191*vmap[3]*f[5])/m_+(2.828427124746191*f[1]*vmap[2])/m_; 
+  tmp[0] = (2.8284271247461907*f[3]*vmap[3])/m_+(2.8284271247461907*f[0]*vmap[2])/m_; 
+  tmp[1] = (2.8284271247461907*vmap[3]*f[5])/m_+(2.8284271247461907*f[1]*vmap[2])/m_; 
  
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += 2.828427124746191*f[0]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
   out[1] += (2.0*vmap[1]*f[2]+2.0*f[0]*vmap[0])*volFact; 
-  out[2] += (1.264911064067352*vmap1R2*f[8]+2.828427124746191*vmap[0]*vmap[1]*f[2]+1.414213562373095*f[0]*vmap1R2+1.414213562373095*f[0]*vmap0R2)*volFact; 
+  out[2] += (1.264911064067352*vmap1R2*f[8]+2.8284271247461907*vmap[0]*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap1R2+1.4142135623730951*f[0]*vmap0R2)*volFact; 
   out[3] += (bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_1x2v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_1x2v_ser_p2.c
@@ -1,18 +1,18 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_int_mom_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = M_PI/m_*0.25*dxv[0]*dxv[1]*dxv[2]; 
+  const double volFact = 0.7853981633974483*dxv[0]*dxv[1]*dxv[2]/m_; 
  
   double tmp[3]; 
-  tmp[0] = (2.828427124746191*f[3]*vmap[3])/m_+(2.828427124746191*f[0]*vmap[2])/m_; 
-  tmp[1] = (2.828427124746191*vmap[3]*f[5])/m_+(2.828427124746191*f[1]*vmap[2])/m_; 
-  tmp[2] = (2.828427124746191*vmap[3]*f[13])/m_+(2.828427124746191*vmap[2]*f[7])/m_; 
+  tmp[0] = (2.8284271247461907*f[3]*vmap[3])/m_+(2.8284271247461907*f[0]*vmap[2])/m_; 
+  tmp[1] = (2.8284271247461907*vmap[3]*f[5])/m_+(2.8284271247461907*f[1]*vmap[2])/m_; 
+  tmp[2] = (2.828427124746191*vmap[3]*f[13])/m_+(2.8284271247461907*vmap[2]*f[7])/m_; 
  
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += 2.828427124746191*f[0]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
   out[1] += (2.0*vmap[1]*f[2]+2.0*f[0]*vmap[0])*volFact; 
-  out[2] += (1.264911064067352*vmap1R2*f[8]+2.828427124746191*vmap[0]*vmap[1]*f[2]+1.414213562373095*f[0]*vmap1R2+1.414213562373095*f[0]*vmap0R2)*volFact; 
+  out[2] += (1.264911064067352*vmap1R2*f[8]+2.8284271247461907*vmap[0]*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap1R2+1.4142135623730951*f[0]*vmap0R2)*volFact; 
   out[3] += (bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_2x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_2x2v_ser_p1.c
@@ -1,19 +1,19 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_int_mom_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = M_PI/m_*0.125*dxv[0]*dxv[1]*dxv[2]*dxv[3]; 
+  const double volFact = 0.39269908169872414*dxv[0]*dxv[1]*dxv[2]*dxv[3]/m_; 
  
   double tmp[4]; 
-  tmp[0] = (2.828427124746191*vmap[3]*f[4])/m_+(2.828427124746191*f[0]*vmap[2])/m_; 
-  tmp[1] = (2.828427124746191*vmap[3]*f[8])/m_+(2.828427124746191*f[1]*vmap[2])/m_; 
-  tmp[2] = (2.828427124746191*vmap[3]*f[9])/m_+(2.828427124746191*f[2]*vmap[2])/m_; 
-  tmp[3] = (2.828427124746191*vmap[3]*f[12])/m_+(2.828427124746191*vmap[2]*f[5])/m_; 
+  tmp[0] = (2.8284271247461907*vmap[3]*f[4])/m_+(2.8284271247461907*f[0]*vmap[2])/m_; 
+  tmp[1] = (2.8284271247461907*vmap[3]*f[8])/m_+(2.8284271247461907*f[1]*vmap[2])/m_; 
+  tmp[2] = (2.8284271247461907*vmap[3]*f[9])/m_+(2.8284271247461907*f[2]*vmap[2])/m_; 
+  tmp[3] = (2.8284271247461907*vmap[3]*f[12])/m_+(2.8284271247461907*vmap[2]*f[5])/m_; 
  
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 4.0*f[0]*volFact; 
-  out[1] += (2.828427124746191*vmap[1]*f[3]+2.828427124746191*f[0]*vmap[0])*volFact; 
-  out[2] += (1.788854381999832*vmap1R2*f[16]+4.0*vmap[0]*vmap[1]*f[3]+2.0*f[0]*vmap1R2+2.0*f[0]*vmap0R2)*volFact; 
+  out[1] += (2.8284271247461907*vmap[1]*f[3]+2.8284271247461907*f[0]*vmap[0])*volFact; 
+  out[2] += (1.7888543819998317*vmap1R2*f[16]+4.0*vmap[0]*vmap[1]*f[3]+2.0*f[0]*vmap1R2+2.0*f[0]*vmap0R2)*volFact; 
   out[3] += (bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_2x2v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_2x2v_ser_p2.c
@@ -1,23 +1,23 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_int_mom_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = M_PI/m_*0.125*dxv[0]*dxv[1]*dxv[2]*dxv[3]; 
+  const double volFact = 0.39269908169872414*dxv[0]*dxv[1]*dxv[2]*dxv[3]/m_; 
  
   double tmp[8]; 
-  tmp[0] = (2.828427124746191*vmap[3]*f[4])/m_+(2.828427124746191*f[0]*vmap[2])/m_; 
-  tmp[1] = (2.828427124746191*vmap[3]*f[8])/m_+(2.828427124746191*f[1]*vmap[2])/m_; 
-  tmp[2] = (2.828427124746191*vmap[3]*f[9])/m_+(2.828427124746191*f[2]*vmap[2])/m_; 
-  tmp[3] = (2.828427124746191*vmap[3]*f[16])/m_+(2.828427124746191*vmap[2]*f[5])/m_; 
-  tmp[4] = (2.828427124746191*vmap[3]*f[25])/m_+(2.828427124746191*vmap[2]*f[11])/m_; 
-  tmp[5] = (2.828427124746191*vmap[3]*f[26])/m_+(2.828427124746191*vmap[2]*f[12])/m_; 
-  tmp[6] = (2.828427124746191*vmap[3]*f[35])/m_+(2.828427124746191*vmap[2]*f[19])/m_; 
-  tmp[7] = (2.828427124746191*vmap[3]*f[36])/m_+(2.828427124746191*vmap[2]*f[20])/m_; 
+  tmp[0] = (2.8284271247461907*vmap[3]*f[4])/m_+(2.8284271247461907*f[0]*vmap[2])/m_; 
+  tmp[1] = (2.8284271247461907*vmap[3]*f[8])/m_+(2.8284271247461907*f[1]*vmap[2])/m_; 
+  tmp[2] = (2.8284271247461907*vmap[3]*f[9])/m_+(2.8284271247461907*f[2]*vmap[2])/m_; 
+  tmp[3] = (2.8284271247461907*vmap[3]*f[16])/m_+(2.8284271247461907*vmap[2]*f[5])/m_; 
+  tmp[4] = (2.828427124746191*vmap[3]*f[25])/m_+(2.8284271247461907*vmap[2]*f[11])/m_; 
+  tmp[5] = (2.828427124746191*vmap[3]*f[26])/m_+(2.8284271247461907*vmap[2]*f[12])/m_; 
+  tmp[6] = (2.828427124746191*vmap[3]*f[35])/m_+(2.8284271247461907*vmap[2]*f[19])/m_; 
+  tmp[7] = (2.828427124746191*vmap[3]*f[36])/m_+(2.8284271247461907*vmap[2]*f[20])/m_; 
  
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 4.0*f[0]*volFact; 
-  out[1] += (2.828427124746191*vmap[1]*f[3]+2.828427124746191*f[0]*vmap[0])*volFact; 
-  out[2] += (1.788854381999832*vmap1R2*f[13]+4.0*vmap[0]*vmap[1]*f[3]+2.0*f[0]*vmap1R2+2.0*f[0]*vmap0R2)*volFact; 
+  out[1] += (2.8284271247461907*vmap[1]*f[3]+2.8284271247461907*f[0]*vmap[0])*volFact; 
+  out[2] += (1.7888543819998317*vmap1R2*f[13]+4.0*vmap[0]*vmap[1]*f[3]+2.0*f[0]*vmap1R2+2.0*f[0]*vmap0R2)*volFact; 
   out[3] += (bmag[7]*tmp[7]+bmag[6]*tmp[6]+bmag[5]*tmp[5]+bmag[4]*tmp[4]+bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_int_mom_3x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_int_mom_3x2v_ser_p1.c
@@ -1,23 +1,23 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_int_mom_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = M_PI/m_*0.0625*dxv[0]*dxv[1]*dxv[2]*dxv[3]*dxv[4]; 
+  const double volFact = 0.19634954084936207*dxv[0]*dxv[1]*dxv[2]*dxv[3]*dxv[4]/m_; 
  
   double tmp[8]; 
-  tmp[0] = (2.828427124746191*vmap[3]*f[5])/m_+(2.828427124746191*f[0]*vmap[2])/m_; 
-  tmp[1] = (2.828427124746191*vmap[3]*f[12])/m_+(2.828427124746191*f[1]*vmap[2])/m_; 
-  tmp[2] = (2.828427124746191*vmap[3]*f[13])/m_+(2.828427124746191*f[2]*vmap[2])/m_; 
-  tmp[3] = (2.828427124746191*vmap[3]*f[14])/m_+(2.828427124746191*vmap[2]*f[3])/m_; 
-  tmp[4] = (2.828427124746191*vmap[3]*f[20])/m_+(2.828427124746191*vmap[2]*f[6])/m_; 
-  tmp[5] = (2.828427124746191*vmap[3]*f[21])/m_+(2.828427124746191*vmap[2]*f[7])/m_; 
-  tmp[6] = (2.828427124746191*vmap[3]*f[22])/m_+(2.828427124746191*vmap[2]*f[8])/m_; 
-  tmp[7] = (2.828427124746191*vmap[3]*f[27])/m_+(2.828427124746191*vmap[2]*f[16])/m_; 
+  tmp[0] = (2.8284271247461907*vmap[3]*f[5])/m_+(2.8284271247461907*f[0]*vmap[2])/m_; 
+  tmp[1] = (2.8284271247461907*vmap[3]*f[12])/m_+(2.8284271247461907*f[1]*vmap[2])/m_; 
+  tmp[2] = (2.8284271247461907*vmap[3]*f[13])/m_+(2.8284271247461907*f[2]*vmap[2])/m_; 
+  tmp[3] = (2.8284271247461907*vmap[3]*f[14])/m_+(2.8284271247461907*vmap[2]*f[3])/m_; 
+  tmp[4] = (2.8284271247461907*vmap[3]*f[20])/m_+(2.8284271247461907*vmap[2]*f[6])/m_; 
+  tmp[5] = (2.8284271247461907*vmap[3]*f[21])/m_+(2.8284271247461907*vmap[2]*f[7])/m_; 
+  tmp[6] = (2.8284271247461907*vmap[3]*f[22])/m_+(2.8284271247461907*vmap[2]*f[8])/m_; 
+  tmp[7] = (2.8284271247461907*vmap[3]*f[27])/m_+(2.8284271247461907*vmap[2]*f[16])/m_; 
  
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 5.656854249492382*f[0]*volFact; 
   out[1] += (4.0*vmap[1]*f[4]+4.0*f[0]*vmap[0])*volFact; 
-  out[2] += (2.529822128134704*vmap1R2*f[32]+5.656854249492382*vmap[0]*vmap[1]*f[4]+2.828427124746191*f[0]*vmap1R2+2.828427124746191*f[0]*vmap0R2)*volFact; 
+  out[2] += (2.5298221281347044*vmap1R2*f[32]+5.656854249492382*vmap[0]*vmap[1]*f[4]+2.8284271247461907*f[0]*vmap1R2+2.8284271247461907*f[0]*vmap0R2)*volFact; 
   out[3] += (bmag[7]*tmp[7]+bmag[6]*tmp[6]+bmag[5]*tmp[5]+bmag[4]*tmp[4]+bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_mom_1x1v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_1x1v_ser_p1.c
@@ -2,8 +2,8 @@
 GKYL_CU_DH void gyrokinetic_M0_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 0.5*dxv[1]; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M1_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -17,8 +17,8 @@ GKYL_CU_DH void gyrokinetic_M2_1x1v_ser_p1(const double *dxv, const double *vmap
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += (0.6324555320336759*vmap1R2*f[4]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[1] += (0.632455532033676*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[0] += (0.6324555320336759*vmap1R2*f[4]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[1] += (0.632455532033676*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -26,8 +26,8 @@ GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p1(const double *dxv, const double *
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += (0.6324555320336759*vmap1R2*f[4]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[1] += (0.632455532033676*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[0] += (0.6324555320336759*vmap1R2*f[4]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[1] += (0.632455532033676*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -37,8 +37,8 @@ GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p1(const double *dxv, const double *
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.341640786499874*vmap[0]*vmap1R2*f[4]+0.9*vmap1R3*f[2]+1.5*vmap0R2*vmap[1]*f[2]+1.5*f[0]*vmap[0]*vmap1R2+0.5*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.341640786499874*vmap[0]*vmap1R2*f[5]+0.9*vmap1R3*f[3]+1.5*vmap0R2*vmap[1]*f[3]+1.5*vmap[0]*f[1]*vmap1R2+0.5*vmap0R3*f[1])*volFact; 
+  out[0] += (1.3416407864998738*vmap[0]*vmap1R2*f[4]+0.9*vmap1R3*f[2]+1.5*vmap0R2*vmap[1]*f[2]+1.5*f[0]*vmap[0]*vmap1R2+0.5*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.3416407864998738*vmap[0]*vmap1R2*f[5]+0.9*vmap1R3*f[3]+1.5*vmap0R2*vmap[1]*f[3]+1.5*vmap[0]*f[1]*vmap1R2+0.5*vmap0R3*f[1])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -46,11 +46,25 @@ GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p1(const double *dxv, const d
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
   out[2] += (vmap[1]*f[2]+f[0]*vmap[0])*volFact; 
   out[3] += (vmap[1]*f[3]+vmap[0]*f[1])*volFact; 
-  out[4] += (0.6324555320336759*vmap1R2*f[4]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[5] += (0.632455532033676*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[4] += (0.6324555320336759*vmap1R2*f[4]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[5] += (0.632455532033676*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+} 
+
+GKYL_CU_DH void gyrokinetic_four_moments_1x1v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 0.5*dxv[1]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += (vmap[1]*f[2]+f[0]*vmap[0])*volFact; 
+  out[3] += (vmap[1]*f[3]+vmap[0]*f[1])*volFact; 
+  out[4] += (0.6324555320336759*vmap1R2*f[4]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[5] += (0.632455532033676*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
 } 
 

--- a/kernels/gyrokinetic/gyrokinetic_mom_1x1v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_1x1v_ser_p2.c
@@ -2,16 +2,16 @@
 GKYL_CU_DH void gyrokinetic_M0_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 0.5*dxv[1]; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[4]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[4]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M1_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 0.5*dxv[1]; 
   out[0] += (vmap[1]*f[2]+f[0]*vmap[0])*volFact; 
   out[1] += (vmap[1]*f[3]+vmap[0]*f[1])*volFact; 
-  out[2] += (1.0*vmap[1]*f[6]+vmap[0]*f[4])*volFact; 
+  out[2] += (1.0000000000000002*vmap[1]*f[6]+vmap[0]*f[4])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -19,9 +19,9 @@ GKYL_CU_DH void gyrokinetic_M2_1x1v_ser_p2(const double *dxv, const double *vmap
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += (0.6324555320336759*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[1] += (0.632455532033676*vmap1R2*f[7]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
+  out[0] += (0.6324555320336759*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[1] += (0.632455532033676*vmap1R2*f[7]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -29,9 +29,9 @@ GKYL_CU_DH void gyrokinetic_M2_par_1x1v_ser_p2(const double *dxv, const double *
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += (0.6324555320336759*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[1] += (0.632455532033676*vmap1R2*f[7]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
+  out[0] += (0.6324555320336759*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[1] += (0.632455532033676*vmap1R2*f[7]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
@@ -41,8 +41,8 @@ GKYL_CU_DH void gyrokinetic_M3_par_1x1v_ser_p2(const double *dxv, const double *
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.341640786499874*vmap[0]*vmap1R2*f[5]+0.9*vmap1R3*f[2]+1.5*vmap0R2*vmap[1]*f[2]+1.5*f[0]*vmap[0]*vmap1R2+0.5*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.341640786499874*vmap[0]*vmap1R2*f[7]+0.9*vmap1R3*f[3]+1.5*vmap0R2*vmap[1]*f[3]+1.5*vmap[0]*f[1]*vmap1R2+0.5*vmap0R3*f[1])*volFact; 
+  out[0] += (1.3416407864998738*vmap[0]*vmap1R2*f[5]+0.9*vmap1R3*f[2]+1.5*vmap0R2*vmap[1]*f[2]+1.5*f[0]*vmap[0]*vmap1R2+0.5*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.3416407864998738*vmap[0]*vmap1R2*f[7]+0.9*vmap1R3*f[3]+1.5*vmap0R2*vmap[1]*f[3]+1.5*vmap[0]*f[1]*vmap1R2+0.5*vmap0R3*f[1])*volFact; 
   out[2] += (0.8999999999999998*vmap1R3*f[6]+1.5*vmap0R2*vmap[1]*f[6]+1.5*vmap[0]*vmap1R2*f[4]+0.5*vmap0R3*f[4])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
@@ -51,14 +51,31 @@ GKYL_CU_DH void gyrokinetic_three_moments_1x1v_ser_p2(const double *dxv, const d
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[4]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[4]*volFact; 
   out[3] += (vmap[1]*f[2]+f[0]*vmap[0])*volFact; 
   out[4] += (vmap[1]*f[3]+vmap[0]*f[1])*volFact; 
-  out[5] += (1.0*vmap[1]*f[6]+vmap[0]*f[4])*volFact; 
-  out[6] += (0.6324555320336759*vmap1R2*f[5]+1.414213562373095*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
-  out[7] += (0.632455532033676*vmap1R2*f[7]+1.414213562373095*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
-  out[8] += (1.414213562373095*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
+  out[5] += (1.0000000000000002*vmap[1]*f[6]+vmap[0]*f[4])*volFact; 
+  out[6] += (0.6324555320336759*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[7] += (0.632455532033676*vmap1R2*f[7]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[8] += (1.4142135623730951*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
+} 
+
+GKYL_CU_DH void gyrokinetic_four_moments_1x1v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 0.5*dxv[1]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[4]*volFact; 
+  out[3] += (vmap[1]*f[2]+f[0]*vmap[0])*volFact; 
+  out[4] += (vmap[1]*f[3]+vmap[0]*f[1])*volFact; 
+  out[5] += (1.0000000000000002*vmap[1]*f[6]+vmap[0]*f[4])*volFact; 
+  out[6] += (0.6324555320336759*vmap1R2*f[5]+1.4142135623730951*vmap[0]*vmap[1]*f[2]+0.7071067811865475*f[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R2)*volFact; 
+  out[7] += (0.632455532033676*vmap1R2*f[7]+1.4142135623730951*vmap[0]*vmap[1]*f[3]+0.7071067811865475*f[1]*vmap1R2+0.7071067811865475*vmap0R2*f[1])*volFact; 
+  out[8] += (1.4142135623730951*vmap[0]*vmap[1]*f[6]+0.7071067811865475*vmap1R2*f[4]+0.7071067811865475*vmap0R2*f[4])*volFact; 
 } 
 

--- a/kernels/gyrokinetic/gyrokinetic_mom_1x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_1x2v_ser_p1.c
@@ -1,33 +1,33 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_M0_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M1_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
-  out[0] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*vmap[0]*f[1])*volFact; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
+  out[0] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += (0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
   out[1] += (0.8944271909999161*vmap1R2*f[9]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
   double tmp[2]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
   out[0] += (2.0*(0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -36,59 +36,78 @@ GKYL_CU_DH void gyrokinetic_M2_par_1x2v_ser_p1(const double *dxv, const double *
 } 
 GKYL_CU_DH void gyrokinetic_M2_perp_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   double tmp[2]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
   out[0] += (2.0*(0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap0R3 = pow(vmap[0],3);
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.897366596101028*vmap[0]*vmap1R2*f[8]+1.272792206135785*vmap1R3*f[2]+2.121320343559642*vmap0R2*vmap[1]*f[2]+2.121320343559642*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[9]+1.272792206135785*vmap1R3*f[4]+2.121320343559642*vmap0R2*vmap[1]*f[4]+2.121320343559642*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
+  out[0] += (1.8973665961010278*vmap[0]*vmap1R2*f[8]+1.2727922061357855*vmap1R3*f[2]+2.1213203435596424*vmap0R2*vmap[1]*f[2]+2.1213203435596424*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[9]+1.2727922061357855*vmap1R3*f[4]+2.1213203435596424*vmap0R2*vmap[1]*f[4]+2.1213203435596424*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_perp_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
 
-  out[0] += ((1.414213562373095*bmag[1]*vmap[1]*vmap[3]*f[7]+1.414213562373095*bmag[0]*vmap[1]*vmap[3]*f[6]+1.414213562373095*vmap[0]*bmag[1]*vmap[3]*f[5]+1.414213562373095*bmag[1]*vmap[1]*vmap[2]*f[4]+1.414213562373095*bmag[0]*vmap[0]*f[3]*vmap[3]+1.414213562373095*bmag[0]*vmap[1]*f[2]*vmap[2]+1.414213562373095*vmap[0]*bmag[1]*f[1]*vmap[2]+1.414213562373095*bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
-  out[1] += ((1.414213562373095*bmag[0]*vmap[1]*vmap[3]*f[7]+1.414213562373095*bmag[1]*vmap[1]*vmap[3]*f[6]+1.414213562373095*bmag[0]*vmap[0]*vmap[3]*f[5]+1.414213562373095*bmag[0]*vmap[1]*vmap[2]*f[4]+1.414213562373095*vmap[0]*bmag[1]*f[3]*vmap[3]+1.414213562373095*bmag[1]*vmap[1]*f[2]*vmap[2]+1.414213562373095*bmag[0]*vmap[0]*f[1]*vmap[2]+1.414213562373095*f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
+  out[0] += ((1.4142135623730951*bmag[1]*vmap[1]*vmap[3]*f[7]+1.4142135623730951*bmag[0]*vmap[1]*vmap[3]*f[6]+1.4142135623730951*vmap[0]*bmag[1]*vmap[3]*f[5]+1.4142135623730951*bmag[1]*vmap[1]*vmap[2]*f[4]+1.4142135623730951*bmag[0]*vmap[0]*f[3]*vmap[3]+1.4142135623730951*bmag[0]*vmap[1]*f[2]*vmap[2]+1.4142135623730951*vmap[0]*bmag[1]*f[1]*vmap[2]+1.4142135623730951*bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
+  out[1] += ((1.4142135623730951*bmag[0]*vmap[1]*vmap[3]*f[7]+1.4142135623730951*bmag[1]*vmap[1]*vmap[3]*f[6]+1.4142135623730951*bmag[0]*vmap[0]*vmap[3]*f[5]+1.4142135623730951*bmag[0]*vmap[1]*vmap[2]*f[4]+1.4142135623730951*vmap[0]*bmag[1]*f[3]*vmap[3]+1.4142135623730951*bmag[1]*vmap[1]*f[2]*vmap[2]+1.4142135623730951*bmag[0]*vmap[0]*f[1]*vmap[2]+1.4142135623730951*f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   double tmp[2]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
-  out[2] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[3] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[4] += ((1.414213562373095*bmag[1]*tmp[1]+1.414213562373095*bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
-  out[5] += ((1.414213562373095*bmag[0]*tmp[1]+1.414213562373095*tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[9]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[4] += ((1.4142135623730951*bmag[1]*tmp[1]+1.4142135623730951*bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[5] += ((1.4142135623730951*bmag[0]*tmp[1]+1.4142135623730951*tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[9]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+} 
+
+GKYL_CU_DH void gyrokinetic_four_moments_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
+  double tmp[2]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 2.0*f[0]*volFact; 
+  out[1] += 2.0*f[1]*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[4] += (0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[5] += (0.8944271909999161*vmap1R2*f[9]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[6] += ((1.4142135623730951*bmag[1]*tmp[1]+1.4142135623730951*bmag[0]*tmp[0])*volFact)/m_; 
+  out[7] += ((1.4142135623730951*bmag[0]*tmp[1]+1.4142135623730951*tmp[0]*bmag[1])*volFact)/m_; 
 } 
 
 GKYL_CU_DH void gyrokinetic_M0_step1_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = dxv[1]/2; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[3]*volFact; 
-  out[3] += 1.414213562373095*f[5]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[3]*volFact; 
+  out[3] += 1.4142135623730951*f[5]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M0_step2_1x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 2.0*M_PI/m_*dxv[2]/2; 
-  out[0] += 2.828427124746191*f[0]*volFact; 
-  out[1] += 2.828427124746191*f[1]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
+  out[1] += 2.8284271247461907*f[1]*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_mom_1x2v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_1x2v_ser_p2.c
@@ -1,113 +1,137 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_M0_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[7]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M1_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
-  out[0] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[7])*volFact; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
+  out[0] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[7])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += (0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
   out[1] += (0.8944271909999161*vmap1R2*f[12]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
-  out[2] += (2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+  out[2] += (2.0000000000000004*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
   double tmp[3]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*vmap[2]*f[7]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*vmap[2]*f[7]; 
   out[0] += (2.0*(0.7071067811865475*bmag[2]*tmp[2]+0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.6324555320336759*bmag[1]*tmp[2]+0.6324555320336759*tmp[1]*bmag[2]+0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_; 
-  out[2] += (2.0*(0.4517539514526256*bmag[2]*tmp[2]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2]+0.6324555320336759*bmag[1]*tmp[1])*volFact)/m_; 
+  out[2] += (2.0*(0.45175395145262565*bmag[2]*tmp[2]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2]+0.6324555320336759*bmag[1]*tmp[1])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += (0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
   out[1] += (0.8944271909999161*vmap1R2*f[12]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
-  out[2] += (2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+  out[2] += (2.0000000000000004*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_perp_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   double tmp[3]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*vmap[2]*f[7]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*vmap[2]*f[7]; 
   out[0] += (2.0*(0.7071067811865475*bmag[2]*tmp[2]+0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.6324555320336759*bmag[1]*tmp[2]+0.6324555320336759*tmp[1]*bmag[2]+0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_; 
-  out[2] += (2.0*(0.4517539514526256*bmag[2]*tmp[2]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2]+0.6324555320336759*bmag[1]*tmp[1])*volFact)/m_; 
+  out[2] += (2.0*(0.45175395145262565*bmag[2]*tmp[2]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2]+0.6324555320336759*bmag[1]*tmp[1])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap0R3 = pow(vmap[0],3);
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.897366596101028*vmap[0]*vmap1R2*f[8]+1.272792206135785*vmap1R3*f[2]+2.121320343559642*vmap0R2*vmap[1]*f[2]+2.121320343559642*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[12]+1.272792206135785*vmap1R3*f[4]+2.121320343559642*vmap0R2*vmap[1]*f[4]+2.121320343559642*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
-  out[2] += (1.272792206135785*vmap1R3*f[11]+2.121320343559642*vmap0R2*vmap[1]*f[11]+2.121320343559642*vmap[0]*vmap1R2*f[7]+0.7071067811865475*vmap0R3*f[7])*volFact; 
+  out[0] += (1.8973665961010278*vmap[0]*vmap1R2*f[8]+1.2727922061357855*vmap1R3*f[2]+2.1213203435596424*vmap0R2*vmap[1]*f[2]+2.1213203435596424*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[12]+1.2727922061357855*vmap1R3*f[4]+2.1213203435596424*vmap0R2*vmap[1]*f[4]+2.1213203435596424*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
+  out[2] += (1.2727922061357853*vmap1R3*f[11]+2.1213203435596424*vmap0R2*vmap[1]*f[11]+2.1213203435596424*vmap[0]*vmap1R2*f[7]+0.7071067811865475*vmap0R3*f[7])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_perp_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
 
-  out[0] += ((1.414213562373095*vmap[1]*bmag[2]*vmap[3]*f[17]+1.414213562373095*vmap[0]*bmag[2]*vmap[3]*f[13]+1.414213562373095*vmap[1]*bmag[2]*vmap[2]*f[11]+1.414213562373095*bmag[1]*vmap[1]*vmap[3]*f[10]+1.414213562373095*vmap[0]*bmag[2]*vmap[2]*f[7]+1.414213562373095*bmag[0]*vmap[1]*vmap[3]*f[6]+1.414213562373095*vmap[0]*bmag[1]*vmap[3]*f[5]+1.414213562373095*bmag[1]*vmap[1]*vmap[2]*f[4]+1.414213562373095*bmag[0]*vmap[0]*f[3]*vmap[3]+1.414213562373095*bmag[0]*vmap[1]*f[2]*vmap[2]+1.414213562373095*vmap[0]*bmag[1]*f[1]*vmap[2]+1.414213562373095*bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
-  out[1] += ((1.264911064067352*bmag[1]*vmap[1]*vmap[3]*f[17]+1.264911064067352*vmap[0]*bmag[1]*vmap[3]*f[13]+1.264911064067352*bmag[1]*vmap[1]*vmap[2]*f[11]+1.264911064067352*vmap[1]*bmag[2]*vmap[3]*f[10]+1.414213562373095*bmag[0]*vmap[1]*vmap[3]*f[10]+1.264911064067352*vmap[0]*bmag[1]*vmap[2]*f[7]+1.414213562373095*bmag[1]*vmap[1]*vmap[3]*f[6]+1.264911064067352*vmap[0]*bmag[2]*vmap[3]*f[5]+1.414213562373095*bmag[0]*vmap[0]*vmap[3]*f[5]+1.264911064067352*vmap[1]*bmag[2]*vmap[2]*f[4]+1.414213562373095*bmag[0]*vmap[1]*vmap[2]*f[4]+1.414213562373095*vmap[0]*bmag[1]*f[3]*vmap[3]+1.414213562373095*bmag[1]*vmap[1]*f[2]*vmap[2]+1.264911064067352*vmap[0]*f[1]*bmag[2]*vmap[2]+1.414213562373095*bmag[0]*vmap[0]*f[1]*vmap[2]+1.414213562373095*f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
-  out[2] += ((0.9035079029052515*vmap[1]*bmag[2]*vmap[3]*f[17]+1.414213562373095*bmag[0]*vmap[1]*vmap[3]*f[17]+0.9035079029052515*vmap[0]*bmag[2]*vmap[3]*f[13]+1.414213562373095*bmag[0]*vmap[0]*vmap[3]*f[13]+0.9035079029052515*vmap[1]*bmag[2]*vmap[2]*f[11]+1.414213562373095*bmag[0]*vmap[1]*vmap[2]*f[11]+1.264911064067352*bmag[1]*vmap[1]*vmap[3]*f[10]+0.9035079029052515*vmap[0]*bmag[2]*vmap[2]*f[7]+1.414213562373095*bmag[0]*vmap[0]*vmap[2]*f[7]+1.414213562373095*vmap[1]*bmag[2]*vmap[3]*f[6]+1.264911064067352*vmap[0]*bmag[1]*vmap[3]*f[5]+1.264911064067352*bmag[1]*vmap[1]*vmap[2]*f[4]+1.414213562373095*vmap[0]*bmag[2]*f[3]*vmap[3]+1.414213562373095*vmap[1]*bmag[2]*f[2]*vmap[2]+1.414213562373095*f[0]*vmap[0]*bmag[2]*vmap[2]+1.264911064067352*vmap[0]*bmag[1]*f[1]*vmap[2])*volFact)/m_; 
+  out[0] += ((1.4142135623730951*vmap[1]*bmag[2]*vmap[3]*f[17]+1.4142135623730951*vmap[0]*bmag[2]*vmap[3]*f[13]+1.4142135623730951*vmap[1]*bmag[2]*vmap[2]*f[11]+1.4142135623730951*bmag[1]*vmap[1]*vmap[3]*f[10]+1.4142135623730951*vmap[0]*bmag[2]*vmap[2]*f[7]+1.4142135623730951*bmag[0]*vmap[1]*vmap[3]*f[6]+1.4142135623730951*vmap[0]*bmag[1]*vmap[3]*f[5]+1.4142135623730951*bmag[1]*vmap[1]*vmap[2]*f[4]+1.4142135623730951*bmag[0]*vmap[0]*f[3]*vmap[3]+1.4142135623730951*bmag[0]*vmap[1]*f[2]*vmap[2]+1.4142135623730951*vmap[0]*bmag[1]*f[1]*vmap[2]+1.4142135623730951*bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
+  out[1] += ((1.264911064067352*bmag[1]*vmap[1]*vmap[3]*f[17]+1.264911064067352*vmap[0]*bmag[1]*vmap[3]*f[13]+1.264911064067352*bmag[1]*vmap[1]*vmap[2]*f[11]+1.264911064067352*vmap[1]*bmag[2]*vmap[3]*f[10]+1.4142135623730951*bmag[0]*vmap[1]*vmap[3]*f[10]+1.264911064067352*vmap[0]*bmag[1]*vmap[2]*f[7]+1.4142135623730951*bmag[1]*vmap[1]*vmap[3]*f[6]+1.264911064067352*vmap[0]*bmag[2]*vmap[3]*f[5]+1.4142135623730951*bmag[0]*vmap[0]*vmap[3]*f[5]+1.264911064067352*vmap[1]*bmag[2]*vmap[2]*f[4]+1.4142135623730951*bmag[0]*vmap[1]*vmap[2]*f[4]+1.4142135623730951*vmap[0]*bmag[1]*f[3]*vmap[3]+1.4142135623730951*bmag[1]*vmap[1]*f[2]*vmap[2]+1.264911064067352*vmap[0]*f[1]*bmag[2]*vmap[2]+1.4142135623730951*bmag[0]*vmap[0]*f[1]*vmap[2]+1.4142135623730951*f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
+  out[2] += ((0.9035079029052515*vmap[1]*bmag[2]*vmap[3]*f[17]+1.4142135623730951*bmag[0]*vmap[1]*vmap[3]*f[17]+0.9035079029052515*vmap[0]*bmag[2]*vmap[3]*f[13]+1.4142135623730951*bmag[0]*vmap[0]*vmap[3]*f[13]+0.9035079029052515*vmap[1]*bmag[2]*vmap[2]*f[11]+1.4142135623730951*bmag[0]*vmap[1]*vmap[2]*f[11]+1.264911064067352*bmag[1]*vmap[1]*vmap[3]*f[10]+0.9035079029052515*vmap[0]*bmag[2]*vmap[2]*f[7]+1.4142135623730951*bmag[0]*vmap[0]*vmap[2]*f[7]+1.4142135623730951*vmap[1]*bmag[2]*vmap[3]*f[6]+1.264911064067352*vmap[0]*bmag[1]*vmap[3]*f[5]+1.264911064067352*bmag[1]*vmap[1]*vmap[2]*f[4]+1.4142135623730951*vmap[0]*bmag[2]*f[3]*vmap[3]+1.4142135623730951*vmap[1]*bmag[2]*f[2]*vmap[2]+1.4142135623730951*f[0]*vmap[0]*bmag[2]*vmap[2]+1.264911064067352*vmap[0]*bmag[1]*f[1]*vmap[2])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[1]*dxv[2]/m_; 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
   double tmp[3]; 
-  tmp[0] = 1.414213562373095*f[3]*vmap[3]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*vmap[2]*f[7]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*vmap[2]*f[7]; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[7]*volFact; 
-  out[3] += (1.414213562373095*vmap[1]*f[2]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[4] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[5] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[7])*volFact; 
-  out[6] += ((1.414213562373095*bmag[2]*tmp[2]+1.414213562373095*bmag[1]*tmp[1]+1.414213562373095*bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
-  out[7] += ((1.264911064067352*bmag[1]*tmp[2]+1.264911064067352*tmp[1]*bmag[2]+1.414213562373095*bmag[0]*tmp[1]+1.414213562373095*tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[12]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
-  out[8] += ((0.9035079029052515*bmag[2]*tmp[2]+1.414213562373095*bmag[0]*tmp[2]+1.414213562373095*tmp[0]*bmag[2]+1.264911064067352*bmag[1]*tmp[1])*volFact)/m_+(2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[7])*volFact; 
+  out[6] += ((1.4142135623730951*bmag[2]*tmp[2]+1.4142135623730951*bmag[1]*tmp[1]+1.4142135623730951*bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[7] += ((1.264911064067352*bmag[1]*tmp[2]+1.264911064067352*tmp[1]*bmag[2]+1.4142135623730951*bmag[0]*tmp[1]+1.4142135623730951*tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[12]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[8] += ((0.9035079029052515*bmag[2]*tmp[2]+1.4142135623730951*bmag[0]*tmp[2]+1.4142135623730951*tmp[0]*bmag[2]+1.264911064067352*bmag[1]*tmp[1])*volFact)/m_+(2.0000000000000004*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+} 
+
+GKYL_CU_DH void gyrokinetic_four_moments_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 1.5707963267948966*dxv[1]*dxv[2]/m_; 
+  double tmp[3]; 
+  tmp[0] = 1.4142135623730951*f[3]*vmap[3]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*vmap[2]*f[7]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 2.0*f[0]*volFact; 
+  out[1] += 2.0*f[1]*volFact; 
+  out[2] += 2.0*f[7]*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[2]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[7])*volFact; 
+  out[6] += (0.8944271909999159*vmap1R2*f[8]+2.0*vmap[0]*vmap[1]*f[2]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[7] += (0.8944271909999161*vmap1R2*f[12]+2.0*vmap[0]*vmap[1]*f[4]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[8] += (2.0000000000000004*vmap[0]*vmap[1]*f[11]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+  out[9] += ((1.4142135623730951*bmag[2]*tmp[2]+1.4142135623730951*bmag[1]*tmp[1]+1.4142135623730951*bmag[0]*tmp[0])*volFact)/m_; 
+  out[10] += ((1.264911064067352*bmag[1]*tmp[2]+1.264911064067352*tmp[1]*bmag[2]+1.4142135623730951*bmag[0]*tmp[1]+1.4142135623730951*tmp[0]*bmag[1])*volFact)/m_; 
+  out[11] += ((0.9035079029052515*bmag[2]*tmp[2]+1.4142135623730951*bmag[0]*tmp[2]+1.4142135623730951*tmp[0]*bmag[2]+1.264911064067352*bmag[1]*tmp[1])*volFact)/m_; 
 } 
 
 GKYL_CU_DH void gyrokinetic_M0_step1_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = dxv[1]/2; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[3]*volFact; 
-  out[3] += 1.414213562373095*f[5]*volFact; 
-  out[4] += 1.414213562373095*f[7]*volFact; 
-  out[5] += 1.414213562373095*f[9]*volFact; 
-  out[6] += 1.414213562373095*f[13]*volFact; 
-  out[7] += 1.414213562373095*f[15]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[3]*volFact; 
+  out[3] += 1.4142135623730951*f[5]*volFact; 
+  out[4] += 1.4142135623730951*f[7]*volFact; 
+  out[5] += 1.4142135623730951*f[9]*volFact; 
+  out[6] += 1.4142135623730951*f[13]*volFact; 
+  out[7] += 1.4142135623730951*f[15]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M0_step2_1x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 2.0*M_PI/m_*dxv[2]/2; 
-  out[0] += 2.828427124746191*f[0]*volFact; 
-  out[1] += 2.828427124746191*f[1]*volFact; 
-  out[2] += 2.828427124746191*f[4]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
+  out[1] += 2.8284271247461907*f[1]*volFact; 
+  out[2] += 2.8284271247461907*f[4]*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_mom_2x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_2x2v_ser_p1.c
@@ -1,7 +1,7 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_M0_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[2]*volFact; 
@@ -9,15 +9,15 @@ GKYL_CU_DH void gyrokinetic_M0_2x2v_ser_p1(const double *dxv, const double *vmap
 } 
 GKYL_CU_DH void gyrokinetic_M1_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
-  out[0] += (1.414213562373095*vmap[1]*f[3]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[6]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[1]*f[7]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[3] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[5])*volFact; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
+  out[0] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[5])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -26,10 +26,10 @@ GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p1(const double *dxv, const double *vmap
   out[2] += (0.8944271909999161*vmap1R2*f[18]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
   out[3] += (0.8944271909999159*vmap1R2*f[20]+2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
   double tmp[4]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*vmap[2]*f[5]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*vmap[2]*f[5]; 
   out[0] += (2.0*(0.5*bmag[3]*tmp[3]+0.5*bmag[2]*tmp[2]+0.5*bmag[1]*tmp[1]+0.5*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
   out[2] += (2.0*(0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p1(const double *dxv, const double *vmap
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -48,12 +48,12 @@ GKYL_CU_DH void gyrokinetic_M2_par_2x2v_ser_p1(const double *dxv, const double *
 } 
 GKYL_CU_DH void gyrokinetic_M2_perp_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   double tmp[4]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*vmap[2]*f[5]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*vmap[2]*f[5]; 
   out[0] += (2.0*(0.5*bmag[3]*tmp[3]+0.5*bmag[2]*tmp[2]+0.5*bmag[1]*tmp[1]+0.5*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
   out[2] += (2.0*(0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
@@ -61,20 +61,20 @@ GKYL_CU_DH void gyrokinetic_M2_perp_2x2v_ser_p1(const double *dxv, const double 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap0R3 = pow(vmap[0],3);
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.897366596101028*vmap[0]*vmap1R2*f[16]+1.272792206135785*vmap1R3*f[3]+2.121320343559642*vmap0R2*vmap[1]*f[3]+2.121320343559642*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[17]+1.272792206135785*vmap1R3*f[6]+2.121320343559642*vmap0R2*vmap[1]*f[6]+2.121320343559642*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
-  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[18]+1.272792206135785*vmap1R3*f[7]+2.121320343559642*vmap0R2*vmap[1]*f[7]+2.121320343559642*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
-  out[3] += (1.897366596101028*vmap[0]*vmap1R2*f[20]+1.272792206135785*vmap1R3*f[11]+2.121320343559642*vmap0R2*vmap[1]*f[11]+2.121320343559642*vmap[0]*vmap1R2*f[5]+0.7071067811865475*vmap0R3*f[5])*volFact; 
+  out[0] += (1.8973665961010278*vmap[0]*vmap1R2*f[16]+1.2727922061357855*vmap1R3*f[3]+2.1213203435596424*vmap0R2*vmap[1]*f[3]+2.1213203435596424*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[17]+1.2727922061357855*vmap1R3*f[6]+2.1213203435596424*vmap0R2*vmap[1]*f[6]+2.1213203435596424*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
+  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[18]+1.2727922061357855*vmap1R3*f[7]+2.1213203435596424*vmap0R2*vmap[1]*f[7]+2.1213203435596424*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
+  out[3] += (1.8973665961010278*vmap[0]*vmap1R2*f[20]+1.2727922061357855*vmap1R3*f[11]+2.1213203435596424*vmap0R2*vmap[1]*f[11]+2.1213203435596424*vmap[0]*vmap1R2*f[5]+0.7071067811865475*vmap0R3*f[5])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_perp_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
 
   out[0] += ((vmap[1]*bmag[3]*vmap[3]*f[15]+vmap[1]*bmag[2]*vmap[3]*f[14]+bmag[1]*vmap[1]*vmap[3]*f[13]+vmap[0]*bmag[3]*vmap[3]*f[12]+vmap[1]*vmap[2]*bmag[3]*f[11]+bmag[0]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[2]*vmap[3]*f[9]+vmap[0]*bmag[1]*vmap[3]*f[8]+vmap[1]*bmag[2]*vmap[2]*f[7]+bmag[1]*vmap[1]*vmap[2]*f[6]+vmap[0]*vmap[2]*bmag[3]*f[5]+bmag[0]*vmap[0]*vmap[3]*f[4]+bmag[0]*vmap[1]*vmap[2]*f[3]+vmap[0]*bmag[2]*f[2]*vmap[2]+vmap[0]*bmag[1]*f[1]*vmap[2]+bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
   out[1] += ((vmap[1]*bmag[2]*vmap[3]*f[15]+vmap[1]*bmag[3]*vmap[3]*f[14]+bmag[0]*vmap[1]*vmap[3]*f[13]+vmap[0]*bmag[2]*vmap[3]*f[12]+vmap[1]*bmag[2]*vmap[2]*f[11]+bmag[1]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[3]*vmap[3]*f[9]+bmag[0]*vmap[0]*vmap[3]*f[8]+vmap[1]*vmap[2]*bmag[3]*f[7]+bmag[0]*vmap[1]*vmap[2]*f[6]+vmap[0]*bmag[2]*vmap[2]*f[5]+vmap[0]*bmag[1]*vmap[3]*f[4]+bmag[1]*vmap[1]*vmap[2]*f[3]+vmap[0]*f[2]*vmap[2]*bmag[3]+bmag[0]*vmap[0]*f[1]*vmap[2]+f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
@@ -83,12 +83,12 @@ GKYL_CU_DH void gyrokinetic_M3_perp_2x2v_ser_p1(const double *dxv, const double 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   double tmp[4]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*vmap[2]*f[5]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*vmap[2]*f[5]; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -96,33 +96,62 @@ GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p1(const double *dxv, const d
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[2]*volFact; 
   out[3] += 2.0*f[5]*volFact; 
-  out[4] += (1.414213562373095*vmap[1]*f[3]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[5] += (1.414213562373095*vmap[1]*f[6]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[6] += (1.414213562373095*vmap[1]*f[7]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[7] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[5])*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[6] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[7] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[5])*volFact; 
   out[8] += ((bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[16]+2.0*vmap[0]*vmap[1]*f[3]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
   out[9] += ((bmag[2]*tmp[3]+tmp[2]*bmag[3]+bmag[0]*tmp[1]+tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[17]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
   out[10] += ((bmag[1]*tmp[3]+tmp[1]*bmag[3]+bmag[0]*tmp[2]+tmp[0]*bmag[2])*volFact)/m_+(0.8944271909999161*vmap1R2*f[18]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
   out[11] += ((bmag[0]*tmp[3]+tmp[0]*bmag[3]+bmag[1]*tmp[2]+tmp[1]*bmag[2])*volFact)/m_+(0.8944271909999159*vmap1R2*f[20]+2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
 } 
 
+GKYL_CU_DH void gyrokinetic_four_moments_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
+  double tmp[4]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*vmap[2]*f[5]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 2.0*f[0]*volFact; 
+  out[1] += 2.0*f[1]*volFact; 
+  out[2] += 2.0*f[2]*volFact; 
+  out[3] += 2.0*f[5]*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[6] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[7] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[5])*volFact; 
+  out[8] += (0.8944271909999159*vmap1R2*f[16]+2.0*vmap[0]*vmap[1]*f[3]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[9] += (0.8944271909999161*vmap1R2*f[17]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[10] += (0.8944271909999161*vmap1R2*f[18]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
+  out[11] += (0.8944271909999159*vmap1R2*f[20]+2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
+  out[12] += ((bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact)/m_; 
+  out[13] += ((bmag[2]*tmp[3]+tmp[2]*bmag[3]+bmag[0]*tmp[1]+tmp[0]*bmag[1])*volFact)/m_; 
+  out[14] += ((bmag[1]*tmp[3]+tmp[1]*bmag[3]+bmag[0]*tmp[2]+tmp[0]*bmag[2])*volFact)/m_; 
+  out[15] += ((bmag[0]*tmp[3]+tmp[0]*bmag[3]+bmag[1]*tmp[2]+tmp[1]*bmag[2])*volFact)/m_; 
+} 
+
 GKYL_CU_DH void gyrokinetic_M0_step1_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = dxv[2]/2; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[2]*volFact; 
-  out[3] += 1.414213562373095*f[4]*volFact; 
-  out[4] += 1.414213562373095*f[5]*volFact; 
-  out[5] += 1.414213562373095*f[8]*volFact; 
-  out[6] += 1.414213562373095*f[9]*volFact; 
-  out[7] += 1.414213562373095*f[12]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[2]*volFact; 
+  out[3] += 1.4142135623730951*f[4]*volFact; 
+  out[4] += 1.4142135623730951*f[5]*volFact; 
+  out[5] += 1.4142135623730951*f[8]*volFact; 
+  out[6] += 1.4142135623730951*f[9]*volFact; 
+  out[7] += 1.4142135623730951*f[12]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M0_step2_2x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 2.0*M_PI/m_*dxv[3]/2; 
-  out[0] += 2.828427124746191*f[0]*volFact; 
-  out[1] += 2.828427124746191*f[1]*volFact; 
-  out[2] += 2.828427124746191*f[2]*volFact; 
-  out[3] += 2.828427124746191*f[4]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
+  out[1] += 2.8284271247461907*f[1]*volFact; 
+  out[2] += 2.8284271247461907*f[2]*volFact; 
+  out[3] += 2.8284271247461907*f[4]*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_mom_2x2v_ser_p2.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_2x2v_ser_p2.c
@@ -1,7 +1,7 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_M0_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[2]*volFact; 
@@ -13,19 +13,19 @@ GKYL_CU_DH void gyrokinetic_M0_2x2v_ser_p2(const double *dxv, const double *vmap
 } 
 GKYL_CU_DH void gyrokinetic_M1_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
-  out[0] += (1.414213562373095*vmap[1]*f[3]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[6]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[1]*f[7]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[3] += (1.414213562373095*vmap[1]*f[15]+1.414213562373095*vmap[0]*f[5])*volFact; 
-  out[4] += (1.414213562373095*vmap[1]*f[21]+1.414213562373095*vmap[0]*f[11])*volFact; 
-  out[5] += (1.414213562373095*vmap[1]*f[22]+1.414213562373095*vmap[0]*f[12])*volFact; 
-  out[6] += (1.414213562373095*vmap[1]*f[32]+1.414213562373095*vmap[0]*f[19])*volFact; 
-  out[7] += (1.414213562373095*vmap[1]*f[33]+1.414213562373095*vmap[0]*f[20])*volFact; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
+  out[0] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[15]+1.4142135623730951*vmap[0]*f[5])*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[21]+1.4142135623730951*vmap[0]*f[11])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[22]+1.4142135623730951*vmap[0]*f[12])*volFact; 
+  out[6] += (1.4142135623730951*vmap[1]*f[32]+1.4142135623730951*vmap[0]*f[19])*volFact; 
+  out[7] += (1.4142135623730951*vmap[1]*f[33]+1.4142135623730951*vmap[0]*f[20])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -33,31 +33,31 @@ GKYL_CU_DH void gyrokinetic_M2_2x2v_ser_p2(const double *dxv, const double *vmap
   out[1] += (0.8944271909999161*vmap1R2*f[23]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
   out[2] += (0.8944271909999161*vmap1R2*f[24]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
   out[3] += (0.8944271909999159*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[15]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
-  out[4] += (2.0*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
-  out[5] += (2.0*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
-  out[6] += (2.0*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
-  out[7] += (2.0*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
+  out[4] += (2.0000000000000004*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
+  out[5] += (2.0000000000000004*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
+  out[6] += (2.0000000000000004*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
+  out[7] += (2.0000000000000004*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[16]+1.414213562373095*vmap[2]*f[5]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[25]+1.414213562373095*vmap[2]*f[11]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[26]+1.414213562373095*vmap[2]*f[12]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[35]+1.414213562373095*vmap[2]*f[19]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[36]+1.414213562373095*vmap[2]*f[20]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[16]+1.4142135623730951*vmap[2]*f[5]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[25]+1.4142135623730951*vmap[2]*f[11]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[26]+1.4142135623730951*vmap[2]*f[12]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[35]+1.4142135623730951*vmap[2]*f[19]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[36]+1.4142135623730951*vmap[2]*f[20]; 
   out[0] += (2.0*(0.5*bmag[7]*tmp[7]+0.5*bmag[6]*tmp[6]+0.5*bmag[5]*tmp[5]+0.5*bmag[4]*tmp[4]+0.5*bmag[3]*tmp[3]+0.5*bmag[2]*tmp[2]+0.5*bmag[1]*tmp[1]+0.5*bmag[0]*tmp[0])*volFact)/m_; 
-  out[1] += (2.0*(0.5000000000000001*bmag[5]*tmp[7]+0.5000000000000001*tmp[5]*bmag[7]+0.447213595499958*bmag[3]*tmp[6]+0.447213595499958*tmp[3]*bmag[6]+0.4472135954999579*bmag[1]*tmp[4]+0.4472135954999579*tmp[1]*bmag[4]+0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
-  out[2] += (2.0*(0.447213595499958*bmag[3]*tmp[7]+0.447213595499958*tmp[3]*bmag[7]+0.5000000000000001*bmag[4]*tmp[6]+0.5000000000000001*tmp[4]*bmag[6]+0.4472135954999579*bmag[2]*tmp[5]+0.4472135954999579*tmp[2]*bmag[5]+0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
-  out[3] += (2.0*(0.4*bmag[6]*tmp[7]+0.447213595499958*bmag[2]*tmp[7]+0.4*tmp[6]*bmag[7]+0.447213595499958*tmp[2]*bmag[7]+0.447213595499958*bmag[1]*tmp[6]+0.447213595499958*tmp[1]*bmag[6]+0.4472135954999579*bmag[3]*tmp[5]+0.4472135954999579*tmp[3]*bmag[5]+0.4472135954999579*bmag[3]*tmp[4]+0.4472135954999579*tmp[3]*bmag[4]+0.5*bmag[0]*tmp[3]+0.5*tmp[0]*bmag[3]+0.5*bmag[1]*tmp[2]+0.5*tmp[1]*bmag[2])*volFact)/m_; 
-  out[4] += (2.0*(0.4472135954999579*bmag[7]*tmp[7]+0.31943828249997*bmag[6]*tmp[6]+0.5000000000000001*bmag[2]*tmp[6]+0.5000000000000001*tmp[2]*bmag[6]+0.31943828249997*bmag[4]*tmp[4]+0.5*bmag[0]*tmp[4]+0.5*tmp[0]*bmag[4]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[1]*tmp[1])*volFact)/m_; 
-  out[5] += (2.0*(0.31943828249997*bmag[7]*tmp[7]+0.5000000000000001*bmag[1]*tmp[7]+0.5000000000000001*tmp[1]*bmag[7]+0.4472135954999579*bmag[6]*tmp[6]+0.31943828249997*bmag[5]*tmp[5]+0.5*bmag[0]*tmp[5]+0.5*tmp[0]*bmag[5]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[2]*tmp[2])*volFact)/m_; 
-  out[6] += (2.0*(0.4*bmag[3]*tmp[7]+0.4*tmp[3]*bmag[7]+0.4472135954999579*bmag[5]*tmp[6]+0.31943828249997*bmag[4]*tmp[6]+0.5*bmag[0]*tmp[6]+0.4472135954999579*tmp[5]*bmag[6]+0.31943828249997*tmp[4]*bmag[6]+0.5*tmp[0]*bmag[6]+0.5000000000000001*bmag[2]*tmp[4]+0.5000000000000001*tmp[2]*bmag[4]+0.447213595499958*bmag[1]*tmp[3]+0.447213595499958*tmp[1]*bmag[3])*volFact)/m_; 
-  out[7] += (2.0*(0.31943828249997*bmag[5]*tmp[7]+0.4472135954999579*bmag[4]*tmp[7]+0.5*bmag[0]*tmp[7]+0.31943828249997*tmp[5]*bmag[7]+0.4472135954999579*tmp[4]*bmag[7]+0.5*tmp[0]*bmag[7]+0.4*bmag[3]*tmp[6]+0.4*tmp[3]*bmag[6]+0.5000000000000001*bmag[1]*tmp[5]+0.5000000000000001*tmp[1]*bmag[5]+0.447213595499958*bmag[2]*tmp[3]+0.447213595499958*tmp[2]*bmag[3])*volFact)/m_; 
+  out[1] += (2.0*(0.5000000000000001*bmag[5]*tmp[7]+0.5000000000000001*tmp[5]*bmag[7]+0.44721359549995804*bmag[3]*tmp[6]+0.44721359549995804*tmp[3]*bmag[6]+0.4472135954999579*bmag[1]*tmp[4]+0.4472135954999579*tmp[1]*bmag[4]+0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
+  out[2] += (2.0*(0.44721359549995804*bmag[3]*tmp[7]+0.44721359549995804*tmp[3]*bmag[7]+0.5000000000000001*bmag[4]*tmp[6]+0.5000000000000001*tmp[4]*bmag[6]+0.4472135954999579*bmag[2]*tmp[5]+0.4472135954999579*tmp[2]*bmag[5]+0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
+  out[3] += (2.0*(0.4*bmag[6]*tmp[7]+0.44721359549995804*bmag[2]*tmp[7]+0.4*tmp[6]*bmag[7]+0.44721359549995804*tmp[2]*bmag[7]+0.44721359549995804*bmag[1]*tmp[6]+0.44721359549995804*tmp[1]*bmag[6]+0.4472135954999579*bmag[3]*tmp[5]+0.4472135954999579*tmp[3]*bmag[5]+0.4472135954999579*bmag[3]*tmp[4]+0.4472135954999579*tmp[3]*bmag[4]+0.5*bmag[0]*tmp[3]+0.5*tmp[0]*bmag[3]+0.5*bmag[1]*tmp[2]+0.5*tmp[1]*bmag[2])*volFact)/m_; 
+  out[4] += (2.0*(0.4472135954999579*bmag[7]*tmp[7]+0.31943828249996997*bmag[6]*tmp[6]+0.5000000000000001*bmag[2]*tmp[6]+0.5000000000000001*tmp[2]*bmag[6]+0.31943828249996997*bmag[4]*tmp[4]+0.5*bmag[0]*tmp[4]+0.5*tmp[0]*bmag[4]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[1]*tmp[1])*volFact)/m_; 
+  out[5] += (2.0*(0.31943828249996997*bmag[7]*tmp[7]+0.5000000000000001*bmag[1]*tmp[7]+0.5000000000000001*tmp[1]*bmag[7]+0.4472135954999579*bmag[6]*tmp[6]+0.31943828249996997*bmag[5]*tmp[5]+0.5*bmag[0]*tmp[5]+0.5*tmp[0]*bmag[5]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[2]*tmp[2])*volFact)/m_; 
+  out[6] += (2.0*(0.4*bmag[3]*tmp[7]+0.4*tmp[3]*bmag[7]+0.4472135954999579*bmag[5]*tmp[6]+0.31943828249996997*bmag[4]*tmp[6]+0.5*bmag[0]*tmp[6]+0.4472135954999579*tmp[5]*bmag[6]+0.31943828249996997*tmp[4]*bmag[6]+0.5*tmp[0]*bmag[6]+0.5000000000000001*bmag[2]*tmp[4]+0.5000000000000001*tmp[2]*bmag[4]+0.44721359549995804*bmag[1]*tmp[3]+0.44721359549995804*tmp[1]*bmag[3])*volFact)/m_; 
+  out[7] += (2.0*(0.31943828249996997*bmag[5]*tmp[7]+0.4472135954999579*bmag[4]*tmp[7]+0.5*bmag[0]*tmp[7]+0.31943828249996997*tmp[5]*bmag[7]+0.4472135954999579*tmp[4]*bmag[7]+0.5*tmp[0]*bmag[7]+0.4*bmag[3]*tmp[6]+0.4*tmp[3]*bmag[6]+0.5000000000000001*bmag[1]*tmp[5]+0.5000000000000001*tmp[1]*bmag[5]+0.44721359549995804*bmag[2]*tmp[3]+0.44721359549995804*tmp[2]*bmag[3])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -65,74 +65,74 @@ GKYL_CU_DH void gyrokinetic_M2_par_2x2v_ser_p2(const double *dxv, const double *
   out[1] += (0.8944271909999161*vmap1R2*f[23]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
   out[2] += (0.8944271909999161*vmap1R2*f[24]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
   out[3] += (0.8944271909999159*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[15]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
-  out[4] += (2.0*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
-  out[5] += (2.0*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
-  out[6] += (2.0*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
-  out[7] += (2.0*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
+  out[4] += (2.0000000000000004*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
+  out[5] += (2.0000000000000004*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
+  out[6] += (2.0000000000000004*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
+  out[7] += (2.0000000000000004*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_perp_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[16]+1.414213562373095*vmap[2]*f[5]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[25]+1.414213562373095*vmap[2]*f[11]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[26]+1.414213562373095*vmap[2]*f[12]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[35]+1.414213562373095*vmap[2]*f[19]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[36]+1.414213562373095*vmap[2]*f[20]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[16]+1.4142135623730951*vmap[2]*f[5]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[25]+1.4142135623730951*vmap[2]*f[11]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[26]+1.4142135623730951*vmap[2]*f[12]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[35]+1.4142135623730951*vmap[2]*f[19]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[36]+1.4142135623730951*vmap[2]*f[20]; 
   out[0] += (2.0*(0.5*bmag[7]*tmp[7]+0.5*bmag[6]*tmp[6]+0.5*bmag[5]*tmp[5]+0.5*bmag[4]*tmp[4]+0.5*bmag[3]*tmp[3]+0.5*bmag[2]*tmp[2]+0.5*bmag[1]*tmp[1]+0.5*bmag[0]*tmp[0])*volFact)/m_; 
-  out[1] += (2.0*(0.5000000000000001*bmag[5]*tmp[7]+0.5000000000000001*tmp[5]*bmag[7]+0.447213595499958*bmag[3]*tmp[6]+0.447213595499958*tmp[3]*bmag[6]+0.4472135954999579*bmag[1]*tmp[4]+0.4472135954999579*tmp[1]*bmag[4]+0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
-  out[2] += (2.0*(0.447213595499958*bmag[3]*tmp[7]+0.447213595499958*tmp[3]*bmag[7]+0.5000000000000001*bmag[4]*tmp[6]+0.5000000000000001*tmp[4]*bmag[6]+0.4472135954999579*bmag[2]*tmp[5]+0.4472135954999579*tmp[2]*bmag[5]+0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
-  out[3] += (2.0*(0.4*bmag[6]*tmp[7]+0.447213595499958*bmag[2]*tmp[7]+0.4*tmp[6]*bmag[7]+0.447213595499958*tmp[2]*bmag[7]+0.447213595499958*bmag[1]*tmp[6]+0.447213595499958*tmp[1]*bmag[6]+0.4472135954999579*bmag[3]*tmp[5]+0.4472135954999579*tmp[3]*bmag[5]+0.4472135954999579*bmag[3]*tmp[4]+0.4472135954999579*tmp[3]*bmag[4]+0.5*bmag[0]*tmp[3]+0.5*tmp[0]*bmag[3]+0.5*bmag[1]*tmp[2]+0.5*tmp[1]*bmag[2])*volFact)/m_; 
-  out[4] += (2.0*(0.4472135954999579*bmag[7]*tmp[7]+0.31943828249997*bmag[6]*tmp[6]+0.5000000000000001*bmag[2]*tmp[6]+0.5000000000000001*tmp[2]*bmag[6]+0.31943828249997*bmag[4]*tmp[4]+0.5*bmag[0]*tmp[4]+0.5*tmp[0]*bmag[4]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[1]*tmp[1])*volFact)/m_; 
-  out[5] += (2.0*(0.31943828249997*bmag[7]*tmp[7]+0.5000000000000001*bmag[1]*tmp[7]+0.5000000000000001*tmp[1]*bmag[7]+0.4472135954999579*bmag[6]*tmp[6]+0.31943828249997*bmag[5]*tmp[5]+0.5*bmag[0]*tmp[5]+0.5*tmp[0]*bmag[5]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[2]*tmp[2])*volFact)/m_; 
-  out[6] += (2.0*(0.4*bmag[3]*tmp[7]+0.4*tmp[3]*bmag[7]+0.4472135954999579*bmag[5]*tmp[6]+0.31943828249997*bmag[4]*tmp[6]+0.5*bmag[0]*tmp[6]+0.4472135954999579*tmp[5]*bmag[6]+0.31943828249997*tmp[4]*bmag[6]+0.5*tmp[0]*bmag[6]+0.5000000000000001*bmag[2]*tmp[4]+0.5000000000000001*tmp[2]*bmag[4]+0.447213595499958*bmag[1]*tmp[3]+0.447213595499958*tmp[1]*bmag[3])*volFact)/m_; 
-  out[7] += (2.0*(0.31943828249997*bmag[5]*tmp[7]+0.4472135954999579*bmag[4]*tmp[7]+0.5*bmag[0]*tmp[7]+0.31943828249997*tmp[5]*bmag[7]+0.4472135954999579*tmp[4]*bmag[7]+0.5*tmp[0]*bmag[7]+0.4*bmag[3]*tmp[6]+0.4*tmp[3]*bmag[6]+0.5000000000000001*bmag[1]*tmp[5]+0.5000000000000001*tmp[1]*bmag[5]+0.447213595499958*bmag[2]*tmp[3]+0.447213595499958*tmp[2]*bmag[3])*volFact)/m_; 
+  out[1] += (2.0*(0.5000000000000001*bmag[5]*tmp[7]+0.5000000000000001*tmp[5]*bmag[7]+0.44721359549995804*bmag[3]*tmp[6]+0.44721359549995804*tmp[3]*bmag[6]+0.4472135954999579*bmag[1]*tmp[4]+0.4472135954999579*tmp[1]*bmag[4]+0.5*bmag[2]*tmp[3]+0.5*tmp[2]*bmag[3]+0.5*bmag[0]*tmp[1]+0.5*tmp[0]*bmag[1])*volFact)/m_; 
+  out[2] += (2.0*(0.44721359549995804*bmag[3]*tmp[7]+0.44721359549995804*tmp[3]*bmag[7]+0.5000000000000001*bmag[4]*tmp[6]+0.5000000000000001*tmp[4]*bmag[6]+0.4472135954999579*bmag[2]*tmp[5]+0.4472135954999579*tmp[2]*bmag[5]+0.5*bmag[1]*tmp[3]+0.5*tmp[1]*bmag[3]+0.5*bmag[0]*tmp[2]+0.5*tmp[0]*bmag[2])*volFact)/m_; 
+  out[3] += (2.0*(0.4*bmag[6]*tmp[7]+0.44721359549995804*bmag[2]*tmp[7]+0.4*tmp[6]*bmag[7]+0.44721359549995804*tmp[2]*bmag[7]+0.44721359549995804*bmag[1]*tmp[6]+0.44721359549995804*tmp[1]*bmag[6]+0.4472135954999579*bmag[3]*tmp[5]+0.4472135954999579*tmp[3]*bmag[5]+0.4472135954999579*bmag[3]*tmp[4]+0.4472135954999579*tmp[3]*bmag[4]+0.5*bmag[0]*tmp[3]+0.5*tmp[0]*bmag[3]+0.5*bmag[1]*tmp[2]+0.5*tmp[1]*bmag[2])*volFact)/m_; 
+  out[4] += (2.0*(0.4472135954999579*bmag[7]*tmp[7]+0.31943828249996997*bmag[6]*tmp[6]+0.5000000000000001*bmag[2]*tmp[6]+0.5000000000000001*tmp[2]*bmag[6]+0.31943828249996997*bmag[4]*tmp[4]+0.5*bmag[0]*tmp[4]+0.5*tmp[0]*bmag[4]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[1]*tmp[1])*volFact)/m_; 
+  out[5] += (2.0*(0.31943828249996997*bmag[7]*tmp[7]+0.5000000000000001*bmag[1]*tmp[7]+0.5000000000000001*tmp[1]*bmag[7]+0.4472135954999579*bmag[6]*tmp[6]+0.31943828249996997*bmag[5]*tmp[5]+0.5*bmag[0]*tmp[5]+0.5*tmp[0]*bmag[5]+0.4472135954999579*bmag[3]*tmp[3]+0.4472135954999579*bmag[2]*tmp[2])*volFact)/m_; 
+  out[6] += (2.0*(0.4*bmag[3]*tmp[7]+0.4*tmp[3]*bmag[7]+0.4472135954999579*bmag[5]*tmp[6]+0.31943828249996997*bmag[4]*tmp[6]+0.5*bmag[0]*tmp[6]+0.4472135954999579*tmp[5]*bmag[6]+0.31943828249996997*tmp[4]*bmag[6]+0.5*tmp[0]*bmag[6]+0.5000000000000001*bmag[2]*tmp[4]+0.5000000000000001*tmp[2]*bmag[4]+0.44721359549995804*bmag[1]*tmp[3]+0.44721359549995804*tmp[1]*bmag[3])*volFact)/m_; 
+  out[7] += (2.0*(0.31943828249996997*bmag[5]*tmp[7]+0.4472135954999579*bmag[4]*tmp[7]+0.5*bmag[0]*tmp[7]+0.31943828249996997*tmp[5]*bmag[7]+0.4472135954999579*tmp[4]*bmag[7]+0.5*tmp[0]*bmag[7]+0.4*bmag[3]*tmp[6]+0.4*tmp[3]*bmag[6]+0.5000000000000001*bmag[1]*tmp[5]+0.5000000000000001*tmp[1]*bmag[5]+0.44721359549995804*bmag[2]*tmp[3]+0.44721359549995804*tmp[2]*bmag[3])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap0R3 = pow(vmap[0],3);
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.897366596101028*vmap[0]*vmap1R2*f[13]+1.272792206135785*vmap1R3*f[3]+2.121320343559642*vmap0R2*vmap[1]*f[3]+2.121320343559642*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[23]+1.272792206135785*vmap1R3*f[6]+2.121320343559642*vmap0R2*vmap[1]*f[6]+2.121320343559642*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
-  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[24]+1.272792206135785*vmap1R3*f[7]+2.121320343559642*vmap0R2*vmap[1]*f[7]+2.121320343559642*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
-  out[3] += (1.897366596101028*vmap[0]*vmap1R2*f[34]+1.272792206135785*vmap1R3*f[15]+2.121320343559642*vmap0R2*vmap[1]*f[15]+2.121320343559642*vmap[0]*vmap1R2*f[5]+0.7071067811865475*vmap0R3*f[5])*volFact; 
-  out[4] += (1.272792206135785*vmap1R3*f[21]+2.121320343559642*vmap0R2*vmap[1]*f[21]+2.121320343559642*vmap[0]*vmap1R2*f[11]+0.7071067811865475*vmap0R3*f[11])*volFact; 
-  out[5] += (1.272792206135785*vmap1R3*f[22]+2.121320343559642*vmap0R2*vmap[1]*f[22]+2.121320343559642*vmap[0]*vmap1R2*f[12]+0.7071067811865475*vmap0R3*f[12])*volFact; 
-  out[6] += (1.272792206135785*vmap1R3*f[32]+2.121320343559642*vmap0R2*vmap[1]*f[32]+2.121320343559642*vmap[0]*vmap1R2*f[19]+0.7071067811865475*vmap0R3*f[19])*volFact; 
-  out[7] += (1.272792206135785*vmap1R3*f[33]+2.121320343559642*vmap0R2*vmap[1]*f[33]+2.121320343559642*vmap[0]*vmap1R2*f[20]+0.7071067811865475*vmap0R3*f[20])*volFact; 
+  out[0] += (1.8973665961010278*vmap[0]*vmap1R2*f[13]+1.2727922061357855*vmap1R3*f[3]+2.1213203435596424*vmap0R2*vmap[1]*f[3]+2.1213203435596424*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[23]+1.2727922061357855*vmap1R3*f[6]+2.1213203435596424*vmap0R2*vmap[1]*f[6]+2.1213203435596424*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
+  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[24]+1.2727922061357855*vmap1R3*f[7]+2.1213203435596424*vmap0R2*vmap[1]*f[7]+2.1213203435596424*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
+  out[3] += (1.8973665961010278*vmap[0]*vmap1R2*f[34]+1.2727922061357855*vmap1R3*f[15]+2.1213203435596424*vmap0R2*vmap[1]*f[15]+2.1213203435596424*vmap[0]*vmap1R2*f[5]+0.7071067811865475*vmap0R3*f[5])*volFact; 
+  out[4] += (1.2727922061357853*vmap1R3*f[21]+2.1213203435596424*vmap0R2*vmap[1]*f[21]+2.1213203435596424*vmap[0]*vmap1R2*f[11]+0.7071067811865475*vmap0R3*f[11])*volFact; 
+  out[5] += (1.2727922061357853*vmap1R3*f[22]+2.1213203435596424*vmap0R2*vmap[1]*f[22]+2.1213203435596424*vmap[0]*vmap1R2*f[12]+0.7071067811865475*vmap0R3*f[12])*volFact; 
+  out[6] += (1.2727922061357853*vmap1R3*f[32]+2.1213203435596424*vmap0R2*vmap[1]*f[32]+2.1213203435596424*vmap[0]*vmap1R2*f[19]+0.7071067811865475*vmap0R3*f[19])*volFact; 
+  out[7] += (1.2727922061357853*vmap1R3*f[33]+2.1213203435596424*vmap0R2*vmap[1]*f[33]+2.1213203435596424*vmap[0]*vmap1R2*f[20]+0.7071067811865475*vmap0R3*f[20])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_perp_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
 
-  out[0] += ((vmap[1]*vmap[3]*bmag[7]*f[45]+vmap[1]*vmap[3]*bmag[6]*f[44]+vmap[1]*vmap[3]*bmag[5]*f[38]+vmap[1]*vmap[3]*bmag[4]*f[37]+1.0*vmap[0]*vmap[3]*bmag[7]*f[36]+1.0*vmap[0]*vmap[3]*bmag[6]*f[35]+1.0*vmap[1]*vmap[2]*bmag[7]*f[33]+1.0*vmap[1]*vmap[2]*bmag[6]*f[32]+vmap[1]*bmag[3]*vmap[3]*f[31]+1.0*vmap[0]*vmap[3]*bmag[5]*f[26]+1.0*vmap[0]*vmap[3]*bmag[4]*f[25]+1.0*vmap[1]*vmap[2]*bmag[5]*f[22]+1.0*vmap[1]*vmap[2]*bmag[4]*f[21]+vmap[0]*vmap[2]*bmag[7]*f[20]+vmap[0]*vmap[2]*bmag[6]*f[19]+vmap[1]*bmag[2]*vmap[3]*f[18]+bmag[1]*vmap[1]*vmap[3]*f[17]+vmap[0]*bmag[3]*vmap[3]*f[16]+vmap[1]*vmap[2]*bmag[3]*f[15]+vmap[0]*vmap[2]*bmag[5]*f[12]+vmap[0]*vmap[2]*bmag[4]*f[11]+bmag[0]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[2]*vmap[3]*f[9]+vmap[0]*bmag[1]*vmap[3]*f[8]+vmap[1]*bmag[2]*vmap[2]*f[7]+bmag[1]*vmap[1]*vmap[2]*f[6]+vmap[0]*vmap[2]*bmag[3]*f[5]+bmag[0]*vmap[0]*vmap[3]*f[4]+bmag[0]*vmap[1]*vmap[2]*f[3]+vmap[0]*bmag[2]*f[2]*vmap[2]+vmap[0]*bmag[1]*f[1]*vmap[2]+bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
-  out[1] += ((1.0*vmap[1]*vmap[3]*bmag[5]*f[45]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[44]+1.0*vmap[1]*vmap[3]*bmag[7]*f[38]+0.8944271909999159*bmag[1]*vmap[1]*vmap[3]*f[37]+vmap[0]*vmap[3]*bmag[5]*f[36]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[35]+vmap[1]*vmap[2]*bmag[5]*f[33]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[32]+0.8944271909999161*vmap[1]*vmap[3]*bmag[6]*f[31]+vmap[1]*bmag[2]*vmap[3]*f[31]+vmap[0]*vmap[3]*bmag[7]*f[26]+0.8944271909999161*vmap[0]*bmag[1]*vmap[3]*f[25]+vmap[1]*vmap[2]*bmag[7]*f[22]+0.8944271909999161*bmag[1]*vmap[1]*vmap[2]*f[21]+1.0*vmap[0]*vmap[2]*bmag[5]*f[20]+0.8944271909999161*vmap[0]*vmap[2]*bmag[3]*f[19]+vmap[1]*bmag[3]*vmap[3]*f[18]+0.8944271909999159*vmap[1]*vmap[3]*bmag[4]*f[17]+bmag[0]*vmap[1]*vmap[3]*f[17]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[16]+vmap[0]*bmag[2]*vmap[3]*f[16]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[15]+vmap[1]*bmag[2]*vmap[2]*f[15]+1.0*vmap[0]*vmap[2]*bmag[7]*f[12]+0.8944271909999159*vmap[0]*bmag[1]*vmap[2]*f[11]+bmag[1]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[3]*vmap[3]*f[9]+0.8944271909999159*vmap[0]*vmap[3]*bmag[4]*f[8]+bmag[0]*vmap[0]*vmap[3]*f[8]+vmap[1]*vmap[2]*bmag[3]*f[7]+0.8944271909999159*vmap[1]*vmap[2]*bmag[4]*f[6]+bmag[0]*vmap[1]*vmap[2]*f[6]+0.8944271909999161*vmap[0]*vmap[2]*f[5]*bmag[6]+vmap[0]*bmag[2]*vmap[2]*f[5]+vmap[0]*bmag[1]*vmap[3]*f[4]+0.8944271909999159*vmap[0]*f[1]*vmap[2]*bmag[4]+bmag[1]*vmap[1]*vmap[2]*f[3]+vmap[0]*f[2]*vmap[2]*bmag[3]+bmag[0]*vmap[0]*f[1]*vmap[2]+f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
-  out[2] += ((0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[45]+1.0*vmap[1]*vmap[3]*bmag[4]*f[44]+0.8944271909999159*vmap[1]*bmag[2]*vmap[3]*f[38]+1.0*vmap[1]*vmap[3]*bmag[6]*f[37]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[36]+vmap[0]*vmap[3]*bmag[4]*f[35]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[33]+vmap[1]*vmap[2]*bmag[4]*f[32]+0.8944271909999161*vmap[1]*vmap[3]*bmag[7]*f[31]+bmag[1]*vmap[1]*vmap[3]*f[31]+0.8944271909999161*vmap[0]*bmag[2]*vmap[3]*f[26]+vmap[0]*vmap[3]*bmag[6]*f[25]+0.8944271909999161*vmap[1]*bmag[2]*vmap[2]*f[22]+vmap[1]*vmap[2]*bmag[6]*f[21]+0.8944271909999161*vmap[0]*vmap[2]*bmag[3]*f[20]+1.0*vmap[0]*vmap[2]*bmag[4]*f[19]+0.8944271909999159*vmap[1]*vmap[3]*bmag[5]*f[18]+bmag[0]*vmap[1]*vmap[3]*f[18]+vmap[1]*bmag[3]*vmap[3]*f[17]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[16]+vmap[0]*bmag[1]*vmap[3]*f[16]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[15]+bmag[1]*vmap[1]*vmap[2]*f[15]+0.8944271909999159*vmap[0]*bmag[2]*vmap[2]*f[12]+1.0*vmap[0]*vmap[2]*bmag[6]*f[11]+vmap[1]*bmag[2]*vmap[3]*f[10]+0.8944271909999159*vmap[0]*vmap[3]*bmag[5]*f[9]+bmag[0]*vmap[0]*vmap[3]*f[9]+vmap[0]*bmag[3]*vmap[3]*f[8]+0.8944271909999159*vmap[1]*vmap[2]*bmag[5]*f[7]+bmag[0]*vmap[1]*vmap[2]*f[7]+0.8944271909999161*vmap[0]*vmap[2]*f[5]*bmag[7]+vmap[1]*vmap[2]*bmag[3]*f[6]+vmap[0]*bmag[1]*vmap[2]*f[5]+0.8944271909999159*vmap[0]*f[2]*vmap[2]*bmag[5]+vmap[0]*bmag[2]*vmap[3]*f[4]+vmap[1]*bmag[2]*vmap[2]*f[3]+vmap[0]*f[1]*vmap[2]*bmag[3]+bmag[0]*vmap[0]*f[2]*vmap[2]+f[0]*vmap[0]*bmag[2]*vmap[2])*volFact)/m_; 
+  out[0] += ((vmap[1]*vmap[3]*bmag[7]*f[45]+vmap[1]*vmap[3]*bmag[6]*f[44]+vmap[1]*vmap[3]*bmag[5]*f[38]+vmap[1]*vmap[3]*bmag[4]*f[37]+1.0000000000000002*vmap[0]*vmap[3]*bmag[7]*f[36]+1.0000000000000002*vmap[0]*vmap[3]*bmag[6]*f[35]+1.0000000000000002*vmap[1]*vmap[2]*bmag[7]*f[33]+1.0000000000000002*vmap[1]*vmap[2]*bmag[6]*f[32]+vmap[1]*bmag[3]*vmap[3]*f[31]+1.0000000000000002*vmap[0]*vmap[3]*bmag[5]*f[26]+1.0000000000000002*vmap[0]*vmap[3]*bmag[4]*f[25]+1.0000000000000002*vmap[1]*vmap[2]*bmag[5]*f[22]+1.0000000000000002*vmap[1]*vmap[2]*bmag[4]*f[21]+vmap[0]*vmap[2]*bmag[7]*f[20]+vmap[0]*vmap[2]*bmag[6]*f[19]+vmap[1]*bmag[2]*vmap[3]*f[18]+bmag[1]*vmap[1]*vmap[3]*f[17]+vmap[0]*bmag[3]*vmap[3]*f[16]+vmap[1]*vmap[2]*bmag[3]*f[15]+vmap[0]*vmap[2]*bmag[5]*f[12]+vmap[0]*vmap[2]*bmag[4]*f[11]+bmag[0]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[2]*vmap[3]*f[9]+vmap[0]*bmag[1]*vmap[3]*f[8]+vmap[1]*bmag[2]*vmap[2]*f[7]+bmag[1]*vmap[1]*vmap[2]*f[6]+vmap[0]*vmap[2]*bmag[3]*f[5]+bmag[0]*vmap[0]*vmap[3]*f[4]+bmag[0]*vmap[1]*vmap[2]*f[3]+vmap[0]*bmag[2]*f[2]*vmap[2]+vmap[0]*bmag[1]*f[1]*vmap[2]+bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
+  out[1] += ((1.0000000000000002*vmap[1]*vmap[3]*bmag[5]*f[45]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[44]+1.0000000000000002*vmap[1]*vmap[3]*bmag[7]*f[38]+0.8944271909999159*bmag[1]*vmap[1]*vmap[3]*f[37]+vmap[0]*vmap[3]*bmag[5]*f[36]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[35]+vmap[1]*vmap[2]*bmag[5]*f[33]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[32]+0.8944271909999161*vmap[1]*vmap[3]*bmag[6]*f[31]+vmap[1]*bmag[2]*vmap[3]*f[31]+vmap[0]*vmap[3]*bmag[7]*f[26]+0.8944271909999161*vmap[0]*bmag[1]*vmap[3]*f[25]+vmap[1]*vmap[2]*bmag[7]*f[22]+0.8944271909999161*bmag[1]*vmap[1]*vmap[2]*f[21]+1.0000000000000002*vmap[0]*vmap[2]*bmag[5]*f[20]+0.8944271909999161*vmap[0]*vmap[2]*bmag[3]*f[19]+vmap[1]*bmag[3]*vmap[3]*f[18]+0.8944271909999159*vmap[1]*vmap[3]*bmag[4]*f[17]+bmag[0]*vmap[1]*vmap[3]*f[17]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[16]+vmap[0]*bmag[2]*vmap[3]*f[16]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[15]+vmap[1]*bmag[2]*vmap[2]*f[15]+1.0000000000000002*vmap[0]*vmap[2]*bmag[7]*f[12]+0.8944271909999159*vmap[0]*bmag[1]*vmap[2]*f[11]+bmag[1]*vmap[1]*vmap[3]*f[10]+vmap[0]*bmag[3]*vmap[3]*f[9]+0.8944271909999159*vmap[0]*vmap[3]*bmag[4]*f[8]+bmag[0]*vmap[0]*vmap[3]*f[8]+vmap[1]*vmap[2]*bmag[3]*f[7]+0.8944271909999159*vmap[1]*vmap[2]*bmag[4]*f[6]+bmag[0]*vmap[1]*vmap[2]*f[6]+0.8944271909999161*vmap[0]*vmap[2]*f[5]*bmag[6]+vmap[0]*bmag[2]*vmap[2]*f[5]+vmap[0]*bmag[1]*vmap[3]*f[4]+0.8944271909999159*vmap[0]*f[1]*vmap[2]*bmag[4]+bmag[1]*vmap[1]*vmap[2]*f[3]+vmap[0]*f[2]*vmap[2]*bmag[3]+bmag[0]*vmap[0]*f[1]*vmap[2]+f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
+  out[2] += ((0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[45]+1.0000000000000002*vmap[1]*vmap[3]*bmag[4]*f[44]+0.8944271909999159*vmap[1]*bmag[2]*vmap[3]*f[38]+1.0000000000000002*vmap[1]*vmap[3]*bmag[6]*f[37]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[36]+vmap[0]*vmap[3]*bmag[4]*f[35]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[33]+vmap[1]*vmap[2]*bmag[4]*f[32]+0.8944271909999161*vmap[1]*vmap[3]*bmag[7]*f[31]+bmag[1]*vmap[1]*vmap[3]*f[31]+0.8944271909999161*vmap[0]*bmag[2]*vmap[3]*f[26]+vmap[0]*vmap[3]*bmag[6]*f[25]+0.8944271909999161*vmap[1]*bmag[2]*vmap[2]*f[22]+vmap[1]*vmap[2]*bmag[6]*f[21]+0.8944271909999161*vmap[0]*vmap[2]*bmag[3]*f[20]+1.0000000000000002*vmap[0]*vmap[2]*bmag[4]*f[19]+0.8944271909999159*vmap[1]*vmap[3]*bmag[5]*f[18]+bmag[0]*vmap[1]*vmap[3]*f[18]+vmap[1]*bmag[3]*vmap[3]*f[17]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[16]+vmap[0]*bmag[1]*vmap[3]*f[16]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[15]+bmag[1]*vmap[1]*vmap[2]*f[15]+0.8944271909999159*vmap[0]*bmag[2]*vmap[2]*f[12]+1.0000000000000002*vmap[0]*vmap[2]*bmag[6]*f[11]+vmap[1]*bmag[2]*vmap[3]*f[10]+0.8944271909999159*vmap[0]*vmap[3]*bmag[5]*f[9]+bmag[0]*vmap[0]*vmap[3]*f[9]+vmap[0]*bmag[3]*vmap[3]*f[8]+0.8944271909999159*vmap[1]*vmap[2]*bmag[5]*f[7]+bmag[0]*vmap[1]*vmap[2]*f[7]+0.8944271909999161*vmap[0]*vmap[2]*f[5]*bmag[7]+vmap[1]*vmap[2]*bmag[3]*f[6]+vmap[0]*bmag[1]*vmap[2]*f[5]+0.8944271909999159*vmap[0]*f[2]*vmap[2]*bmag[5]+vmap[0]*bmag[2]*vmap[3]*f[4]+vmap[1]*bmag[2]*vmap[2]*f[3]+vmap[0]*f[1]*vmap[2]*bmag[3]+bmag[0]*vmap[0]*f[2]*vmap[2]+f[0]*vmap[0]*bmag[2]*vmap[2])*volFact)/m_; 
   out[3] += ((0.8*vmap[1]*vmap[3]*bmag[6]*f[45]+0.8944271909999161*vmap[1]*bmag[2]*vmap[3]*f[45]+0.8*vmap[1]*vmap[3]*bmag[7]*f[44]+0.8944271909999161*bmag[1]*vmap[1]*vmap[3]*f[44]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[38]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[37]+0.8*vmap[0]*vmap[3]*bmag[6]*f[36]+0.8944271909999159*vmap[0]*bmag[2]*vmap[3]*f[36]+0.8*vmap[0]*vmap[3]*bmag[7]*f[35]+0.8944271909999159*vmap[0]*bmag[1]*vmap[3]*f[35]+0.8*vmap[1]*vmap[2]*bmag[6]*f[33]+0.8944271909999159*vmap[1]*bmag[2]*vmap[2]*f[33]+0.8*vmap[1]*vmap[2]*bmag[7]*f[32]+0.8944271909999159*bmag[1]*vmap[1]*vmap[2]*f[32]+0.8944271909999159*vmap[1]*vmap[3]*bmag[5]*f[31]+0.8944271909999159*vmap[1]*vmap[3]*bmag[4]*f[31]+bmag[0]*vmap[1]*vmap[3]*f[31]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[26]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[25]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[22]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[21]+0.8*vmap[0]*vmap[2]*bmag[6]*f[20]+0.8944271909999161*vmap[0]*bmag[2]*vmap[2]*f[20]+0.8*vmap[0]*vmap[2]*bmag[7]*f[19]+0.8944271909999161*vmap[0]*bmag[1]*vmap[2]*f[19]+0.8944271909999161*vmap[1]*vmap[3]*bmag[7]*f[18]+bmag[1]*vmap[1]*vmap[3]*f[18]+0.8944271909999161*vmap[1]*vmap[3]*bmag[6]*f[17]+vmap[1]*bmag[2]*vmap[3]*f[17]+0.8944271909999159*vmap[0]*vmap[3]*bmag[5]*f[16]+0.8944271909999159*vmap[0]*vmap[3]*bmag[4]*f[16]+bmag[0]*vmap[0]*vmap[3]*f[16]+0.8944271909999159*vmap[1]*vmap[2]*bmag[5]*f[15]+0.8944271909999159*vmap[1]*vmap[2]*bmag[4]*f[15]+bmag[0]*vmap[1]*vmap[2]*f[15]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[12]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[11]+vmap[1]*bmag[3]*vmap[3]*f[10]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[9]+vmap[0]*bmag[1]*vmap[3]*f[9]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[8]+vmap[0]*bmag[2]*vmap[3]*f[8]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[7]+bmag[1]*vmap[1]*vmap[2]*f[7]+0.8944271909999161*vmap[0]*f[2]*vmap[2]*bmag[7]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[6]+vmap[1]*bmag[2]*vmap[2]*f[6]+0.8944271909999161*vmap[0]*f[1]*vmap[2]*bmag[6]+0.8944271909999159*vmap[0]*vmap[2]*bmag[5]*f[5]+0.8944271909999159*vmap[0]*vmap[2]*bmag[4]*f[5]+bmag[0]*vmap[0]*vmap[2]*f[5]+vmap[0]*bmag[3]*vmap[3]*f[4]+vmap[1]*vmap[2]*bmag[3]*f[3]+f[0]*vmap[0]*vmap[2]*bmag[3]+vmap[0]*bmag[1]*f[2]*vmap[2]+vmap[0]*f[1]*bmag[2]*vmap[2])*volFact)/m_; 
-  out[4] += ((0.8944271909999159*vmap[1]*vmap[3]*bmag[7]*f[45]+0.6388765649999399*vmap[1]*vmap[3]*bmag[6]*f[44]+1.0*vmap[1]*bmag[2]*vmap[3]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[4]*f[37]+bmag[0]*vmap[1]*vmap[3]*f[37]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[36]+0.63887656499994*vmap[0]*vmap[3]*bmag[6]*f[35]+vmap[0]*bmag[2]*vmap[3]*f[35]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[33]+0.63887656499994*vmap[1]*vmap[2]*bmag[6]*f[32]+vmap[1]*bmag[2]*vmap[2]*f[32]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[4]*f[25]+1.0*bmag[0]*vmap[0]*vmap[3]*f[25]+0.63887656499994*vmap[1]*vmap[2]*bmag[4]*f[21]+1.0*bmag[0]*vmap[1]*vmap[2]*f[21]+0.8944271909999159*vmap[0]*vmap[2]*bmag[7]*f[20]+0.6388765649999399*vmap[0]*vmap[2]*bmag[6]*f[19]+1.0*vmap[0]*bmag[2]*vmap[2]*f[19]+1.0*vmap[1]*vmap[3]*bmag[6]*f[18]+0.8944271909999159*bmag[1]*vmap[1]*vmap[3]*f[17]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[16]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[4]*f[11]+bmag[0]*vmap[0]*vmap[2]*f[11]+vmap[1]*vmap[3]*bmag[4]*f[10]+1.0*vmap[0]*vmap[3]*bmag[6]*f[9]+0.8944271909999159*vmap[0]*bmag[1]*vmap[3]*f[8]+1.0*vmap[1]*vmap[2]*bmag[6]*f[7]+0.8944271909999159*bmag[1]*vmap[1]*vmap[2]*f[6]+1.0*vmap[0]*f[2]*vmap[2]*bmag[6]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[5]+vmap[0]*vmap[3]*bmag[4]*f[4]+vmap[1]*vmap[2]*f[3]*bmag[4]+f[0]*vmap[0]*vmap[2]*bmag[4]+0.8944271909999159*vmap[0]*bmag[1]*f[1]*vmap[2])*volFact)/m_; 
-  out[5] += ((0.6388765649999399*vmap[1]*vmap[3]*bmag[7]*f[45]+1.0*bmag[1]*vmap[1]*vmap[3]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[6]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[5]*f[38]+bmag[0]*vmap[1]*vmap[3]*f[38]+0.63887656499994*vmap[0]*vmap[3]*bmag[7]*f[36]+vmap[0]*bmag[1]*vmap[3]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[35]+0.63887656499994*vmap[1]*vmap[2]*bmag[7]*f[33]+bmag[1]*vmap[1]*vmap[2]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[32]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[5]*f[26]+1.0*bmag[0]*vmap[0]*vmap[3]*f[26]+0.63887656499994*vmap[1]*vmap[2]*bmag[5]*f[22]+1.0*bmag[0]*vmap[1]*vmap[2]*f[22]+0.6388765649999399*vmap[0]*vmap[2]*bmag[7]*f[20]+1.0*vmap[0]*bmag[1]*vmap[2]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[6]*f[19]+0.8944271909999159*vmap[1]*bmag[2]*vmap[3]*f[18]+1.0*vmap[1]*vmap[3]*bmag[7]*f[17]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[16]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[5]*f[12]+bmag[0]*vmap[0]*vmap[2]*f[12]+vmap[1]*vmap[3]*bmag[5]*f[10]+0.8944271909999159*vmap[0]*bmag[2]*vmap[3]*f[9]+1.0*vmap[0]*vmap[3]*bmag[7]*f[8]+0.8944271909999159*vmap[1]*bmag[2]*vmap[2]*f[7]+1.0*vmap[1]*vmap[2]*f[6]*bmag[7]+1.0*vmap[0]*f[1]*vmap[2]*bmag[7]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[5]+vmap[0]*vmap[3]*f[4]*bmag[5]+vmap[1]*vmap[2]*f[3]*bmag[5]+f[0]*vmap[0]*vmap[2]*bmag[5]+0.8944271909999159*vmap[0]*bmag[2]*f[2]*vmap[2])*volFact)/m_; 
-  out[6] += ((0.8*vmap[1]*bmag[3]*vmap[3]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[5]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[4]*f[44]+bmag[0]*vmap[1]*vmap[3]*f[44]+0.8944271909999159*vmap[1]*vmap[3]*bmag[6]*f[38]+0.6388765649999399*vmap[1]*vmap[3]*bmag[6]*f[37]+1.0*vmap[1]*bmag[2]*vmap[3]*f[37]+0.8*vmap[0]*bmag[3]*vmap[3]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[5]*f[35]+0.63887656499994*vmap[0]*vmap[3]*bmag[4]*f[35]+1.0*bmag[0]*vmap[0]*vmap[3]*f[35]+0.8*vmap[1]*vmap[2]*bmag[3]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[5]*f[32]+0.63887656499994*vmap[1]*vmap[2]*bmag[4]*f[32]+1.0*bmag[0]*vmap[1]*vmap[2]*f[32]+0.8*vmap[1]*vmap[3]*bmag[7]*f[31]+0.8944271909999161*bmag[1]*vmap[1]*vmap[3]*f[31]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[26]+0.63887656499994*vmap[0]*vmap[3]*bmag[6]*f[25]+vmap[0]*bmag[2]*vmap[3]*f[25]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[22]+0.63887656499994*vmap[1]*vmap[2]*bmag[6]*f[21]+vmap[1]*bmag[2]*vmap[2]*f[21]+0.8*vmap[0]*vmap[2]*bmag[3]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[5]*f[19]+0.6388765649999399*vmap[0]*vmap[2]*bmag[4]*f[19]+bmag[0]*vmap[0]*vmap[2]*f[19]+1.0*vmap[1]*vmap[3]*bmag[4]*f[18]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[17]+0.8*vmap[0]*vmap[3]*bmag[7]*f[16]+0.8944271909999161*vmap[0]*bmag[1]*vmap[3]*f[16]+0.8*vmap[1]*vmap[2]*bmag[7]*f[15]+0.8944271909999161*bmag[1]*vmap[1]*vmap[2]*f[15]+0.8944271909999159*vmap[0]*vmap[2]*bmag[6]*f[12]+0.6388765649999399*vmap[0]*vmap[2]*bmag[6]*f[11]+1.0*vmap[0]*bmag[2]*vmap[2]*f[11]+vmap[1]*vmap[3]*bmag[6]*f[10]+1.0*vmap[0]*vmap[3]*bmag[4]*f[9]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[8]+1.0*vmap[1]*vmap[2]*bmag[4]*f[7]+0.8*vmap[0]*vmap[2]*f[5]*bmag[7]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[6]+vmap[0]*vmap[3]*f[4]*bmag[6]+vmap[1]*vmap[2]*f[3]*bmag[6]+f[0]*vmap[0]*vmap[2]*bmag[6]+0.8944271909999161*vmap[0]*bmag[1]*vmap[2]*f[5]+1.0*vmap[0]*f[2]*vmap[2]*bmag[4]+0.8944271909999161*vmap[0]*f[1]*vmap[2]*bmag[3])*volFact)/m_; 
-  out[7] += ((0.6388765649999399*vmap[1]*vmap[3]*bmag[5]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[4]*f[45]+bmag[0]*vmap[1]*vmap[3]*f[45]+0.8*vmap[1]*bmag[3]*vmap[3]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[7]*f[38]+1.0*bmag[1]*vmap[1]*vmap[3]*f[38]+0.8944271909999159*vmap[1]*vmap[3]*bmag[7]*f[37]+0.63887656499994*vmap[0]*vmap[3]*bmag[5]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[4]*f[36]+1.0*bmag[0]*vmap[0]*vmap[3]*f[36]+0.8*vmap[0]*bmag[3]*vmap[3]*f[35]+0.63887656499994*vmap[1]*vmap[2]*bmag[5]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[4]*f[33]+1.0*bmag[0]*vmap[1]*vmap[2]*f[33]+0.8*vmap[1]*vmap[2]*bmag[3]*f[32]+0.8*vmap[1]*vmap[3]*bmag[6]*f[31]+0.8944271909999161*vmap[1]*bmag[2]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[7]*f[26]+vmap[0]*bmag[1]*vmap[3]*f[26]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[25]+0.63887656499994*vmap[1]*vmap[2]*bmag[7]*f[22]+bmag[1]*vmap[1]*vmap[2]*f[22]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[21]+0.6388765649999399*vmap[0]*vmap[2]*bmag[5]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[4]*f[20]+bmag[0]*vmap[0]*vmap[2]*f[20]+0.8*vmap[0]*vmap[2]*bmag[3]*f[19]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[18]+1.0*vmap[1]*vmap[3]*bmag[5]*f[17]+0.8*vmap[0]*vmap[3]*bmag[6]*f[16]+0.8944271909999161*vmap[0]*bmag[2]*vmap[3]*f[16]+0.8*vmap[1]*vmap[2]*bmag[6]*f[15]+0.8944271909999161*vmap[1]*bmag[2]*vmap[2]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[7]*f[12]+1.0*vmap[0]*bmag[1]*vmap[2]*f[12]+0.8944271909999159*vmap[0]*vmap[2]*bmag[7]*f[11]+vmap[1]*vmap[3]*bmag[7]*f[10]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[9]+1.0*vmap[0]*vmap[3]*bmag[5]*f[8]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[7]+vmap[0]*vmap[3]*f[4]*bmag[7]+vmap[1]*vmap[2]*f[3]*bmag[7]+f[0]*vmap[0]*vmap[2]*bmag[7]+1.0*vmap[1]*vmap[2]*bmag[5]*f[6]+0.8*vmap[0]*vmap[2]*f[5]*bmag[6]+0.8944271909999161*vmap[0]*bmag[2]*vmap[2]*f[5]+1.0*vmap[0]*f[1]*vmap[2]*bmag[5]+0.8944271909999161*vmap[0]*f[2]*vmap[2]*bmag[3])*volFact)/m_; 
+  out[4] += ((0.8944271909999159*vmap[1]*vmap[3]*bmag[7]*f[45]+0.6388765649999399*vmap[1]*vmap[3]*bmag[6]*f[44]+1.0000000000000002*vmap[1]*bmag[2]*vmap[3]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[4]*f[37]+bmag[0]*vmap[1]*vmap[3]*f[37]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[36]+0.63887656499994*vmap[0]*vmap[3]*bmag[6]*f[35]+vmap[0]*bmag[2]*vmap[3]*f[35]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[33]+0.63887656499994*vmap[1]*vmap[2]*bmag[6]*f[32]+vmap[1]*bmag[2]*vmap[2]*f[32]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[4]*f[25]+1.0000000000000002*bmag[0]*vmap[0]*vmap[3]*f[25]+0.63887656499994*vmap[1]*vmap[2]*bmag[4]*f[21]+1.0000000000000002*bmag[0]*vmap[1]*vmap[2]*f[21]+0.8944271909999159*vmap[0]*vmap[2]*bmag[7]*f[20]+0.6388765649999399*vmap[0]*vmap[2]*bmag[6]*f[19]+1.0000000000000002*vmap[0]*bmag[2]*vmap[2]*f[19]+1.0000000000000002*vmap[1]*vmap[3]*bmag[6]*f[18]+0.8944271909999159*bmag[1]*vmap[1]*vmap[3]*f[17]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[16]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[4]*f[11]+bmag[0]*vmap[0]*vmap[2]*f[11]+vmap[1]*vmap[3]*bmag[4]*f[10]+1.0000000000000002*vmap[0]*vmap[3]*bmag[6]*f[9]+0.8944271909999159*vmap[0]*bmag[1]*vmap[3]*f[8]+1.0000000000000002*vmap[1]*vmap[2]*bmag[6]*f[7]+0.8944271909999159*bmag[1]*vmap[1]*vmap[2]*f[6]+1.0000000000000002*vmap[0]*f[2]*vmap[2]*bmag[6]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[5]+vmap[0]*vmap[3]*bmag[4]*f[4]+vmap[1]*vmap[2]*f[3]*bmag[4]+f[0]*vmap[0]*vmap[2]*bmag[4]+0.8944271909999159*vmap[0]*bmag[1]*f[1]*vmap[2])*volFact)/m_; 
+  out[5] += ((0.6388765649999399*vmap[1]*vmap[3]*bmag[7]*f[45]+1.0000000000000002*bmag[1]*vmap[1]*vmap[3]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[6]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[5]*f[38]+bmag[0]*vmap[1]*vmap[3]*f[38]+0.63887656499994*vmap[0]*vmap[3]*bmag[7]*f[36]+vmap[0]*bmag[1]*vmap[3]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[35]+0.63887656499994*vmap[1]*vmap[2]*bmag[7]*f[33]+bmag[1]*vmap[1]*vmap[2]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[32]+0.8944271909999159*vmap[1]*bmag[3]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[5]*f[26]+1.0000000000000002*bmag[0]*vmap[0]*vmap[3]*f[26]+0.63887656499994*vmap[1]*vmap[2]*bmag[5]*f[22]+1.0000000000000002*bmag[0]*vmap[1]*vmap[2]*f[22]+0.6388765649999399*vmap[0]*vmap[2]*bmag[7]*f[20]+1.0000000000000002*vmap[0]*bmag[1]*vmap[2]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[6]*f[19]+0.8944271909999159*vmap[1]*bmag[2]*vmap[3]*f[18]+1.0000000000000002*vmap[1]*vmap[3]*bmag[7]*f[17]+0.8944271909999159*vmap[0]*bmag[3]*vmap[3]*f[16]+0.8944271909999159*vmap[1]*vmap[2]*bmag[3]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[5]*f[12]+bmag[0]*vmap[0]*vmap[2]*f[12]+vmap[1]*vmap[3]*bmag[5]*f[10]+0.8944271909999159*vmap[0]*bmag[2]*vmap[3]*f[9]+1.0000000000000002*vmap[0]*vmap[3]*bmag[7]*f[8]+0.8944271909999159*vmap[1]*bmag[2]*vmap[2]*f[7]+1.0000000000000002*vmap[1]*vmap[2]*f[6]*bmag[7]+1.0000000000000002*vmap[0]*f[1]*vmap[2]*bmag[7]+0.8944271909999159*vmap[0]*vmap[2]*bmag[3]*f[5]+vmap[0]*vmap[3]*f[4]*bmag[5]+vmap[1]*vmap[2]*f[3]*bmag[5]+f[0]*vmap[0]*vmap[2]*bmag[5]+0.8944271909999159*vmap[0]*bmag[2]*f[2]*vmap[2])*volFact)/m_; 
+  out[6] += ((0.8*vmap[1]*bmag[3]*vmap[3]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[5]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[4]*f[44]+bmag[0]*vmap[1]*vmap[3]*f[44]+0.8944271909999159*vmap[1]*vmap[3]*bmag[6]*f[38]+0.6388765649999399*vmap[1]*vmap[3]*bmag[6]*f[37]+1.0000000000000002*vmap[1]*bmag[2]*vmap[3]*f[37]+0.8*vmap[0]*bmag[3]*vmap[3]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[5]*f[35]+0.63887656499994*vmap[0]*vmap[3]*bmag[4]*f[35]+1.0000000000000002*bmag[0]*vmap[0]*vmap[3]*f[35]+0.8*vmap[1]*vmap[2]*bmag[3]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[5]*f[32]+0.63887656499994*vmap[1]*vmap[2]*bmag[4]*f[32]+1.0000000000000002*bmag[0]*vmap[1]*vmap[2]*f[32]+0.8*vmap[1]*vmap[3]*bmag[7]*f[31]+0.8944271909999161*bmag[1]*vmap[1]*vmap[3]*f[31]+0.8944271909999161*vmap[0]*vmap[3]*bmag[6]*f[26]+0.63887656499994*vmap[0]*vmap[3]*bmag[6]*f[25]+vmap[0]*bmag[2]*vmap[3]*f[25]+0.8944271909999161*vmap[1]*vmap[2]*bmag[6]*f[22]+0.63887656499994*vmap[1]*vmap[2]*bmag[6]*f[21]+vmap[1]*bmag[2]*vmap[2]*f[21]+0.8*vmap[0]*vmap[2]*bmag[3]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[5]*f[19]+0.6388765649999399*vmap[0]*vmap[2]*bmag[4]*f[19]+bmag[0]*vmap[0]*vmap[2]*f[19]+1.0000000000000002*vmap[1]*vmap[3]*bmag[4]*f[18]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[17]+0.8*vmap[0]*vmap[3]*bmag[7]*f[16]+0.8944271909999161*vmap[0]*bmag[1]*vmap[3]*f[16]+0.8*vmap[1]*vmap[2]*bmag[7]*f[15]+0.8944271909999161*bmag[1]*vmap[1]*vmap[2]*f[15]+0.8944271909999159*vmap[0]*vmap[2]*bmag[6]*f[12]+0.6388765649999399*vmap[0]*vmap[2]*bmag[6]*f[11]+1.0000000000000002*vmap[0]*bmag[2]*vmap[2]*f[11]+vmap[1]*vmap[3]*bmag[6]*f[10]+1.0000000000000002*vmap[0]*vmap[3]*bmag[4]*f[9]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[8]+1.0000000000000002*vmap[1]*vmap[2]*bmag[4]*f[7]+0.8*vmap[0]*vmap[2]*f[5]*bmag[7]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[6]+vmap[0]*vmap[3]*f[4]*bmag[6]+vmap[1]*vmap[2]*f[3]*bmag[6]+f[0]*vmap[0]*vmap[2]*bmag[6]+0.8944271909999161*vmap[0]*bmag[1]*vmap[2]*f[5]+1.0000000000000002*vmap[0]*f[2]*vmap[2]*bmag[4]+0.8944271909999161*vmap[0]*f[1]*vmap[2]*bmag[3])*volFact)/m_; 
+  out[7] += ((0.6388765649999399*vmap[1]*vmap[3]*bmag[5]*f[45]+0.8944271909999159*vmap[1]*vmap[3]*bmag[4]*f[45]+bmag[0]*vmap[1]*vmap[3]*f[45]+0.8*vmap[1]*bmag[3]*vmap[3]*f[44]+0.6388765649999399*vmap[1]*vmap[3]*bmag[7]*f[38]+1.0000000000000002*bmag[1]*vmap[1]*vmap[3]*f[38]+0.8944271909999159*vmap[1]*vmap[3]*bmag[7]*f[37]+0.63887656499994*vmap[0]*vmap[3]*bmag[5]*f[36]+0.8944271909999161*vmap[0]*vmap[3]*bmag[4]*f[36]+1.0000000000000002*bmag[0]*vmap[0]*vmap[3]*f[36]+0.8*vmap[0]*bmag[3]*vmap[3]*f[35]+0.63887656499994*vmap[1]*vmap[2]*bmag[5]*f[33]+0.8944271909999161*vmap[1]*vmap[2]*bmag[4]*f[33]+1.0000000000000002*bmag[0]*vmap[1]*vmap[2]*f[33]+0.8*vmap[1]*vmap[2]*bmag[3]*f[32]+0.8*vmap[1]*vmap[3]*bmag[6]*f[31]+0.8944271909999161*vmap[1]*bmag[2]*vmap[3]*f[31]+0.63887656499994*vmap[0]*vmap[3]*bmag[7]*f[26]+vmap[0]*bmag[1]*vmap[3]*f[26]+0.8944271909999161*vmap[0]*vmap[3]*bmag[7]*f[25]+0.63887656499994*vmap[1]*vmap[2]*bmag[7]*f[22]+bmag[1]*vmap[1]*vmap[2]*f[22]+0.8944271909999161*vmap[1]*vmap[2]*bmag[7]*f[21]+0.6388765649999399*vmap[0]*vmap[2]*bmag[5]*f[20]+0.8944271909999159*vmap[0]*vmap[2]*bmag[4]*f[20]+bmag[0]*vmap[0]*vmap[2]*f[20]+0.8*vmap[0]*vmap[2]*bmag[3]*f[19]+0.8944271909999161*vmap[1]*bmag[3]*vmap[3]*f[18]+1.0000000000000002*vmap[1]*vmap[3]*bmag[5]*f[17]+0.8*vmap[0]*vmap[3]*bmag[6]*f[16]+0.8944271909999161*vmap[0]*bmag[2]*vmap[3]*f[16]+0.8*vmap[1]*vmap[2]*bmag[6]*f[15]+0.8944271909999161*vmap[1]*bmag[2]*vmap[2]*f[15]+0.6388765649999399*vmap[0]*vmap[2]*bmag[7]*f[12]+1.0000000000000002*vmap[0]*bmag[1]*vmap[2]*f[12]+0.8944271909999159*vmap[0]*vmap[2]*bmag[7]*f[11]+vmap[1]*vmap[3]*bmag[7]*f[10]+0.8944271909999161*vmap[0]*bmag[3]*vmap[3]*f[9]+1.0000000000000002*vmap[0]*vmap[3]*bmag[5]*f[8]+0.8944271909999161*vmap[1]*vmap[2]*bmag[3]*f[7]+vmap[0]*vmap[3]*f[4]*bmag[7]+vmap[1]*vmap[2]*f[3]*bmag[7]+f[0]*vmap[0]*vmap[2]*bmag[7]+1.0000000000000002*vmap[1]*vmap[2]*bmag[5]*f[6]+0.8*vmap[0]*vmap[2]*f[5]*bmag[6]+0.8944271909999161*vmap[0]*bmag[2]*vmap[2]*f[5]+1.0000000000000002*vmap[0]*f[1]*vmap[2]*bmag[5]+0.8944271909999161*vmap[0]*f[2]*vmap[2]*bmag[3])*volFact)/m_; 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[2]*dxv[3]/m_; 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[4]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[8]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[9]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[16]+1.414213562373095*vmap[2]*f[5]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[25]+1.414213562373095*vmap[2]*f[11]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[26]+1.414213562373095*vmap[2]*f[12]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[35]+1.414213562373095*vmap[2]*f[19]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[36]+1.414213562373095*vmap[2]*f[20]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[16]+1.4142135623730951*vmap[2]*f[5]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[25]+1.4142135623730951*vmap[2]*f[11]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[26]+1.4142135623730951*vmap[2]*f[12]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[35]+1.4142135623730951*vmap[2]*f[19]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[36]+1.4142135623730951*vmap[2]*f[20]; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -144,57 +144,106 @@ GKYL_CU_DH void gyrokinetic_three_moments_2x2v_ser_p2(const double *dxv, const d
   out[5] += 2.0*f[12]*volFact; 
   out[6] += 2.0*f[19]*volFact; 
   out[7] += 2.0*f[20]*volFact; 
-  out[8] += (1.414213562373095*vmap[1]*f[3]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[9] += (1.414213562373095*vmap[1]*f[6]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[10] += (1.414213562373095*vmap[1]*f[7]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[11] += (1.414213562373095*vmap[1]*f[15]+1.414213562373095*vmap[0]*f[5])*volFact; 
-  out[12] += (1.414213562373095*vmap[1]*f[21]+1.414213562373095*vmap[0]*f[11])*volFact; 
-  out[13] += (1.414213562373095*vmap[1]*f[22]+1.414213562373095*vmap[0]*f[12])*volFact; 
-  out[14] += (1.414213562373095*vmap[1]*f[32]+1.414213562373095*vmap[0]*f[19])*volFact; 
-  out[15] += (1.414213562373095*vmap[1]*f[33]+1.414213562373095*vmap[0]*f[20])*volFact; 
+  out[8] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[9] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[10] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[11] += (1.4142135623730951*vmap[1]*f[15]+1.4142135623730951*vmap[0]*f[5])*volFact; 
+  out[12] += (1.4142135623730951*vmap[1]*f[21]+1.4142135623730951*vmap[0]*f[11])*volFact; 
+  out[13] += (1.4142135623730951*vmap[1]*f[22]+1.4142135623730951*vmap[0]*f[12])*volFact; 
+  out[14] += (1.4142135623730951*vmap[1]*f[32]+1.4142135623730951*vmap[0]*f[19])*volFact; 
+  out[15] += (1.4142135623730951*vmap[1]*f[33]+1.4142135623730951*vmap[0]*f[20])*volFact; 
   out[16] += ((bmag[7]*tmp[7]+bmag[6]*tmp[6]+bmag[5]*tmp[5]+bmag[4]*tmp[4]+bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[13]+2.0*vmap[0]*vmap[1]*f[3]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
-  out[17] += ((1.0*bmag[5]*tmp[7]+1.0*tmp[5]*bmag[7]+0.8944271909999161*bmag[3]*tmp[6]+0.8944271909999161*tmp[3]*bmag[6]+0.8944271909999159*bmag[1]*tmp[4]+0.8944271909999159*tmp[1]*bmag[4]+bmag[2]*tmp[3]+tmp[2]*bmag[3]+bmag[0]*tmp[1]+tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[23]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
-  out[18] += ((0.8944271909999161*bmag[3]*tmp[7]+0.8944271909999161*tmp[3]*bmag[7]+1.0*bmag[4]*tmp[6]+1.0*tmp[4]*bmag[6]+0.8944271909999159*bmag[2]*tmp[5]+0.8944271909999159*tmp[2]*bmag[5]+bmag[1]*tmp[3]+tmp[1]*bmag[3]+bmag[0]*tmp[2]+tmp[0]*bmag[2])*volFact)/m_+(0.8944271909999161*vmap1R2*f[24]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
+  out[17] += ((1.0000000000000002*bmag[5]*tmp[7]+1.0000000000000002*tmp[5]*bmag[7]+0.8944271909999161*bmag[3]*tmp[6]+0.8944271909999161*tmp[3]*bmag[6]+0.8944271909999159*bmag[1]*tmp[4]+0.8944271909999159*tmp[1]*bmag[4]+bmag[2]*tmp[3]+tmp[2]*bmag[3]+bmag[0]*tmp[1]+tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[23]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[18] += ((0.8944271909999161*bmag[3]*tmp[7]+0.8944271909999161*tmp[3]*bmag[7]+1.0000000000000002*bmag[4]*tmp[6]+1.0000000000000002*tmp[4]*bmag[6]+0.8944271909999159*bmag[2]*tmp[5]+0.8944271909999159*tmp[2]*bmag[5]+bmag[1]*tmp[3]+tmp[1]*bmag[3]+bmag[0]*tmp[2]+tmp[0]*bmag[2])*volFact)/m_+(0.8944271909999161*vmap1R2*f[24]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
   out[19] += ((0.8*bmag[6]*tmp[7]+0.8944271909999161*bmag[2]*tmp[7]+0.8*tmp[6]*bmag[7]+0.8944271909999161*tmp[2]*bmag[7]+0.8944271909999161*bmag[1]*tmp[6]+0.8944271909999161*tmp[1]*bmag[6]+0.8944271909999159*bmag[3]*tmp[5]+0.8944271909999159*tmp[3]*bmag[5]+0.8944271909999159*bmag[3]*tmp[4]+0.8944271909999159*tmp[3]*bmag[4]+bmag[0]*tmp[3]+tmp[0]*bmag[3]+bmag[1]*tmp[2]+tmp[1]*bmag[2])*volFact)/m_+(0.8944271909999159*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[15]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
-  out[20] += ((0.8944271909999159*bmag[7]*tmp[7]+0.6388765649999399*bmag[6]*tmp[6]+1.0*bmag[2]*tmp[6]+1.0*tmp[2]*bmag[6]+0.6388765649999399*bmag[4]*tmp[4]+bmag[0]*tmp[4]+tmp[0]*bmag[4]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[1]*tmp[1])*volFact)/m_+(2.0*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
-  out[21] += ((0.6388765649999399*bmag[7]*tmp[7]+1.0*bmag[1]*tmp[7]+1.0*tmp[1]*bmag[7]+0.8944271909999159*bmag[6]*tmp[6]+0.6388765649999399*bmag[5]*tmp[5]+bmag[0]*tmp[5]+tmp[0]*bmag[5]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[2]*tmp[2])*volFact)/m_+(2.0*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
-  out[22] += ((0.8*bmag[3]*tmp[7]+0.8*tmp[3]*bmag[7]+0.8944271909999159*bmag[5]*tmp[6]+0.6388765649999399*bmag[4]*tmp[6]+bmag[0]*tmp[6]+0.8944271909999159*tmp[5]*bmag[6]+0.6388765649999399*tmp[4]*bmag[6]+tmp[0]*bmag[6]+1.0*bmag[2]*tmp[4]+1.0*tmp[2]*bmag[4]+0.8944271909999161*bmag[1]*tmp[3]+0.8944271909999161*tmp[1]*bmag[3])*volFact)/m_+(2.0*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
-  out[23] += ((0.6388765649999399*bmag[5]*tmp[7]+0.8944271909999159*bmag[4]*tmp[7]+bmag[0]*tmp[7]+0.6388765649999399*tmp[5]*bmag[7]+0.8944271909999159*tmp[4]*bmag[7]+tmp[0]*bmag[7]+0.8*bmag[3]*tmp[6]+0.8*tmp[3]*bmag[6]+1.0*bmag[1]*tmp[5]+1.0*tmp[1]*bmag[5]+0.8944271909999161*bmag[2]*tmp[3]+0.8944271909999161*tmp[2]*bmag[3])*volFact)/m_+(2.0*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
+  out[20] += ((0.8944271909999159*bmag[7]*tmp[7]+0.6388765649999399*bmag[6]*tmp[6]+1.0000000000000002*bmag[2]*tmp[6]+1.0000000000000002*tmp[2]*bmag[6]+0.6388765649999399*bmag[4]*tmp[4]+bmag[0]*tmp[4]+tmp[0]*bmag[4]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[1]*tmp[1])*volFact)/m_+(2.0000000000000004*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
+  out[21] += ((0.6388765649999399*bmag[7]*tmp[7]+1.0000000000000002*bmag[1]*tmp[7]+1.0000000000000002*tmp[1]*bmag[7]+0.8944271909999159*bmag[6]*tmp[6]+0.6388765649999399*bmag[5]*tmp[5]+bmag[0]*tmp[5]+tmp[0]*bmag[5]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[2]*tmp[2])*volFact)/m_+(2.0000000000000004*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
+  out[22] += ((0.8*bmag[3]*tmp[7]+0.8*tmp[3]*bmag[7]+0.8944271909999159*bmag[5]*tmp[6]+0.6388765649999399*bmag[4]*tmp[6]+bmag[0]*tmp[6]+0.8944271909999159*tmp[5]*bmag[6]+0.6388765649999399*tmp[4]*bmag[6]+tmp[0]*bmag[6]+1.0000000000000002*bmag[2]*tmp[4]+1.0000000000000002*tmp[2]*bmag[4]+0.8944271909999161*bmag[1]*tmp[3]+0.8944271909999161*tmp[1]*bmag[3])*volFact)/m_+(2.0000000000000004*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
+  out[23] += ((0.6388765649999399*bmag[5]*tmp[7]+0.8944271909999159*bmag[4]*tmp[7]+bmag[0]*tmp[7]+0.6388765649999399*tmp[5]*bmag[7]+0.8944271909999159*tmp[4]*bmag[7]+tmp[0]*bmag[7]+0.8*bmag[3]*tmp[6]+0.8*tmp[3]*bmag[6]+1.0000000000000002*bmag[1]*tmp[5]+1.0000000000000002*tmp[1]*bmag[5]+0.8944271909999161*bmag[2]*tmp[3]+0.8944271909999161*tmp[2]*bmag[3])*volFact)/m_+(2.0000000000000004*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
+} 
+
+GKYL_CU_DH void gyrokinetic_four_moments_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 1.5707963267948966*dxv[2]*dxv[3]/m_; 
+  double tmp[8]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[4]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[8]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[9]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[16]+1.4142135623730951*vmap[2]*f[5]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[25]+1.4142135623730951*vmap[2]*f[11]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[26]+1.4142135623730951*vmap[2]*f[12]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[35]+1.4142135623730951*vmap[2]*f[19]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[36]+1.4142135623730951*vmap[2]*f[20]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 2.0*f[0]*volFact; 
+  out[1] += 2.0*f[1]*volFact; 
+  out[2] += 2.0*f[2]*volFact; 
+  out[3] += 2.0*f[5]*volFact; 
+  out[4] += 2.0*f[11]*volFact; 
+  out[5] += 2.0*f[12]*volFact; 
+  out[6] += 2.0*f[19]*volFact; 
+  out[7] += 2.0*f[20]*volFact; 
+  out[8] += (1.4142135623730951*vmap[1]*f[3]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[9] += (1.4142135623730951*vmap[1]*f[6]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[10] += (1.4142135623730951*vmap[1]*f[7]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[11] += (1.4142135623730951*vmap[1]*f[15]+1.4142135623730951*vmap[0]*f[5])*volFact; 
+  out[12] += (1.4142135623730951*vmap[1]*f[21]+1.4142135623730951*vmap[0]*f[11])*volFact; 
+  out[13] += (1.4142135623730951*vmap[1]*f[22]+1.4142135623730951*vmap[0]*f[12])*volFact; 
+  out[14] += (1.4142135623730951*vmap[1]*f[32]+1.4142135623730951*vmap[0]*f[19])*volFact; 
+  out[15] += (1.4142135623730951*vmap[1]*f[33]+1.4142135623730951*vmap[0]*f[20])*volFact; 
+  out[16] += (0.8944271909999159*vmap1R2*f[13]+2.0*vmap[0]*vmap[1]*f[3]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[17] += (0.8944271909999161*vmap1R2*f[23]+2.0*vmap[0]*vmap[1]*f[6]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[18] += (0.8944271909999161*vmap1R2*f[24]+2.0*vmap[0]*vmap[1]*f[7]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
+  out[19] += (0.8944271909999159*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[15]+vmap1R2*f[5]+vmap0R2*f[5])*volFact; 
+  out[20] += (2.0000000000000004*vmap[0]*vmap[1]*f[21]+vmap1R2*f[11]+vmap0R2*f[11])*volFact; 
+  out[21] += (2.0000000000000004*vmap[0]*vmap[1]*f[22]+vmap1R2*f[12]+vmap0R2*f[12])*volFact; 
+  out[22] += (2.0000000000000004*vmap[0]*vmap[1]*f[32]+vmap1R2*f[19]+vmap0R2*f[19])*volFact; 
+  out[23] += (2.0000000000000004*vmap[0]*vmap[1]*f[33]+vmap1R2*f[20]+vmap0R2*f[20])*volFact; 
+  out[24] += ((bmag[7]*tmp[7]+bmag[6]*tmp[6]+bmag[5]*tmp[5]+bmag[4]*tmp[4]+bmag[3]*tmp[3]+bmag[2]*tmp[2]+bmag[1]*tmp[1]+bmag[0]*tmp[0])*volFact)/m_; 
+  out[25] += ((1.0000000000000002*bmag[5]*tmp[7]+1.0000000000000002*tmp[5]*bmag[7]+0.8944271909999161*bmag[3]*tmp[6]+0.8944271909999161*tmp[3]*bmag[6]+0.8944271909999159*bmag[1]*tmp[4]+0.8944271909999159*tmp[1]*bmag[4]+bmag[2]*tmp[3]+tmp[2]*bmag[3]+bmag[0]*tmp[1]+tmp[0]*bmag[1])*volFact)/m_; 
+  out[26] += ((0.8944271909999161*bmag[3]*tmp[7]+0.8944271909999161*tmp[3]*bmag[7]+1.0000000000000002*bmag[4]*tmp[6]+1.0000000000000002*tmp[4]*bmag[6]+0.8944271909999159*bmag[2]*tmp[5]+0.8944271909999159*tmp[2]*bmag[5]+bmag[1]*tmp[3]+tmp[1]*bmag[3]+bmag[0]*tmp[2]+tmp[0]*bmag[2])*volFact)/m_; 
+  out[27] += ((0.8*bmag[6]*tmp[7]+0.8944271909999161*bmag[2]*tmp[7]+0.8*tmp[6]*bmag[7]+0.8944271909999161*tmp[2]*bmag[7]+0.8944271909999161*bmag[1]*tmp[6]+0.8944271909999161*tmp[1]*bmag[6]+0.8944271909999159*bmag[3]*tmp[5]+0.8944271909999159*tmp[3]*bmag[5]+0.8944271909999159*bmag[3]*tmp[4]+0.8944271909999159*tmp[3]*bmag[4]+bmag[0]*tmp[3]+tmp[0]*bmag[3]+bmag[1]*tmp[2]+tmp[1]*bmag[2])*volFact)/m_; 
+  out[28] += ((0.8944271909999159*bmag[7]*tmp[7]+0.6388765649999399*bmag[6]*tmp[6]+1.0000000000000002*bmag[2]*tmp[6]+1.0000000000000002*tmp[2]*bmag[6]+0.6388765649999399*bmag[4]*tmp[4]+bmag[0]*tmp[4]+tmp[0]*bmag[4]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[1]*tmp[1])*volFact)/m_; 
+  out[29] += ((0.6388765649999399*bmag[7]*tmp[7]+1.0000000000000002*bmag[1]*tmp[7]+1.0000000000000002*tmp[1]*bmag[7]+0.8944271909999159*bmag[6]*tmp[6]+0.6388765649999399*bmag[5]*tmp[5]+bmag[0]*tmp[5]+tmp[0]*bmag[5]+0.8944271909999159*bmag[3]*tmp[3]+0.8944271909999159*bmag[2]*tmp[2])*volFact)/m_; 
+  out[30] += ((0.8*bmag[3]*tmp[7]+0.8*tmp[3]*bmag[7]+0.8944271909999159*bmag[5]*tmp[6]+0.6388765649999399*bmag[4]*tmp[6]+bmag[0]*tmp[6]+0.8944271909999159*tmp[5]*bmag[6]+0.6388765649999399*tmp[4]*bmag[6]+tmp[0]*bmag[6]+1.0000000000000002*bmag[2]*tmp[4]+1.0000000000000002*tmp[2]*bmag[4]+0.8944271909999161*bmag[1]*tmp[3]+0.8944271909999161*tmp[1]*bmag[3])*volFact)/m_; 
+  out[31] += ((0.6388765649999399*bmag[5]*tmp[7]+0.8944271909999159*bmag[4]*tmp[7]+bmag[0]*tmp[7]+0.6388765649999399*tmp[5]*bmag[7]+0.8944271909999159*tmp[4]*bmag[7]+tmp[0]*bmag[7]+0.8*bmag[3]*tmp[6]+0.8*tmp[3]*bmag[6]+1.0000000000000002*bmag[1]*tmp[5]+1.0000000000000002*tmp[1]*bmag[5]+0.8944271909999161*bmag[2]*tmp[3]+0.8944271909999161*tmp[2]*bmag[3])*volFact)/m_; 
 } 
 
 GKYL_CU_DH void gyrokinetic_M0_step1_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = dxv[2]/2; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[2]*volFact; 
-  out[3] += 1.414213562373095*f[4]*volFact; 
-  out[4] += 1.414213562373095*f[5]*volFact; 
-  out[5] += 1.414213562373095*f[8]*volFact; 
-  out[6] += 1.414213562373095*f[9]*volFact; 
-  out[7] += 1.414213562373095*f[11]*volFact; 
-  out[8] += 1.414213562373095*f[12]*volFact; 
-  out[9] += 1.414213562373095*f[14]*volFact; 
-  out[10] += 1.414213562373095*f[16]*volFact; 
-  out[11] += 1.414213562373095*f[19]*volFact; 
-  out[12] += 1.414213562373095*f[20]*volFact; 
-  out[13] += 1.414213562373095*f[25]*volFact; 
-  out[14] += 1.414213562373095*f[26]*volFact; 
-  out[15] += 1.414213562373095*f[28]*volFact; 
-  out[16] += 1.414213562373095*f[29]*volFact; 
-  out[17] += 1.414213562373095*f[35]*volFact; 
-  out[18] += 1.414213562373095*f[36]*volFact; 
-  out[19] += 1.414213562373095*f[41]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[2]*volFact; 
+  out[3] += 1.4142135623730951*f[4]*volFact; 
+  out[4] += 1.4142135623730951*f[5]*volFact; 
+  out[5] += 1.4142135623730951*f[8]*volFact; 
+  out[6] += 1.4142135623730951*f[9]*volFact; 
+  out[7] += 1.4142135623730951*f[11]*volFact; 
+  out[8] += 1.4142135623730951*f[12]*volFact; 
+  out[9] += 1.4142135623730951*f[14]*volFact; 
+  out[10] += 1.4142135623730951*f[16]*volFact; 
+  out[11] += 1.4142135623730951*f[19]*volFact; 
+  out[12] += 1.4142135623730951*f[20]*volFact; 
+  out[13] += 1.4142135623730951*f[25]*volFact; 
+  out[14] += 1.4142135623730951*f[26]*volFact; 
+  out[15] += 1.4142135623730951*f[28]*volFact; 
+  out[16] += 1.4142135623730951*f[29]*volFact; 
+  out[17] += 1.4142135623730951*f[35]*volFact; 
+  out[18] += 1.4142135623730951*f[36]*volFact; 
+  out[19] += 1.4142135623730951*f[41]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M0_step2_2x2v_ser_p2(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 2.0*M_PI/m_*dxv[3]/2; 
-  out[0] += 2.828427124746191*f[0]*volFact; 
-  out[1] += 2.828427124746191*f[1]*volFact; 
-  out[2] += 2.828427124746191*f[2]*volFact; 
-  out[3] += 2.828427124746191*f[4]*volFact; 
-  out[4] += 2.828427124746191*f[7]*volFact; 
-  out[5] += 2.828427124746191*f[8]*volFact; 
-  out[6] += 2.828427124746191*f[11]*volFact; 
-  out[7] += 2.828427124746191*f[12]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
+  out[1] += 2.8284271247461907*f[1]*volFact; 
+  out[2] += 2.8284271247461907*f[2]*volFact; 
+  out[3] += 2.8284271247461907*f[4]*volFact; 
+  out[4] += 2.8284271247461907*f[7]*volFact; 
+  out[5] += 2.8284271247461907*f[8]*volFact; 
+  out[6] += 2.8284271247461907*f[11]*volFact; 
+  out[7] += 2.8284271247461907*f[12]*volFact; 
 } 

--- a/kernels/gyrokinetic/gyrokinetic_mom_3x2v_ser_p1.c
+++ b/kernels/gyrokinetic/gyrokinetic_mom_3x2v_ser_p1.c
@@ -1,7 +1,7 @@
 #include <gkyl_mom_gyrokinetic_kernels.h> 
 GKYL_CU_DH void gyrokinetic_M0_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   out[0] += 2.0*f[0]*volFact; 
   out[1] += 2.0*f[1]*volFact; 
   out[2] += 2.0*f[2]*volFact; 
@@ -13,19 +13,19 @@ GKYL_CU_DH void gyrokinetic_M0_3x2v_ser_p1(const double *dxv, const double *vmap
 } 
 GKYL_CU_DH void gyrokinetic_M1_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
-  out[0] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[1] += (1.414213562373095*vmap[1]*f[9]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[2] += (1.414213562373095*vmap[1]*f[10]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[3] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[3])*volFact; 
-  out[4] += (1.414213562373095*vmap[1]*f[17]+1.414213562373095*vmap[0]*f[6])*volFact; 
-  out[5] += (1.414213562373095*vmap[1]*f[18]+1.414213562373095*vmap[0]*f[7])*volFact; 
-  out[6] += (1.414213562373095*vmap[1]*f[19]+1.414213562373095*vmap[0]*f[8])*volFact; 
-  out[7] += (1.414213562373095*vmap[1]*f[26]+1.414213562373095*vmap[0]*f[16])*volFact; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
+  out[0] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[1] += (1.4142135623730951*vmap[1]*f[9]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[2] += (1.4142135623730951*vmap[1]*f[10]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[3] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[3])*volFact; 
+  out[4] += (1.4142135623730951*vmap[1]*f[17]+1.4142135623730951*vmap[0]*f[6])*volFact; 
+  out[5] += (1.4142135623730951*vmap[1]*f[18]+1.4142135623730951*vmap[0]*f[7])*volFact; 
+  out[6] += (1.4142135623730951*vmap[1]*f[19]+1.4142135623730951*vmap[0]*f[8])*volFact; 
+  out[7] += (1.4142135623730951*vmap[1]*f[26]+1.4142135623730951*vmap[0]*f[16])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M2_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -38,14 +38,14 @@ GKYL_CU_DH void gyrokinetic_M2_3x2v_ser_p1(const double *dxv, const double *vmap
   out[6] += (0.8944271909999159*vmap1R2*f[39]+2.0*vmap[0]*vmap[1]*f[19]+vmap1R2*f[8]+vmap0R2*f[8])*volFact; 
   out[7] += (0.8944271909999161*vmap1R2*f[43]+2.0*vmap[0]*vmap[1]*f[26]+vmap1R2*f[16]+vmap0R2*f[16])*volFact; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[14]+1.414213562373095*vmap[2]*f[3]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[20]+1.414213562373095*vmap[2]*f[6]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[21]+1.414213562373095*vmap[2]*f[7]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[22]+1.414213562373095*vmap[2]*f[8]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[27]+1.414213562373095*vmap[2]*f[16]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[14]+1.4142135623730951*vmap[2]*f[3]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[20]+1.4142135623730951*vmap[2]*f[6]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[21]+1.4142135623730951*vmap[2]*f[7]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[22]+1.4142135623730951*vmap[2]*f[8]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[27]+1.4142135623730951*vmap[2]*f[16]; 
   out[0] += (2.0*(0.3535533905932737*bmag[7]*tmp[7]+0.3535533905932737*bmag[6]*tmp[6]+0.3535533905932737*bmag[5]*tmp[5]+0.3535533905932737*bmag[4]*tmp[4]+0.3535533905932737*bmag[3]*tmp[3]+0.3535533905932737*bmag[2]*tmp[2]+0.3535533905932737*bmag[1]*tmp[1]+0.3535533905932737*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.3535533905932737*bmag[6]*tmp[7]+0.3535533905932737*tmp[6]*bmag[7]+0.3535533905932737*bmag[3]*tmp[5]+0.3535533905932737*tmp[3]*bmag[5]+0.3535533905932737*bmag[2]*tmp[4]+0.3535533905932737*tmp[2]*bmag[4]+0.3535533905932737*bmag[0]*tmp[1]+0.3535533905932737*tmp[0]*bmag[1])*volFact)/m_; 
   out[2] += (2.0*(0.3535533905932737*bmag[5]*tmp[7]+0.3535533905932737*tmp[5]*bmag[7]+0.3535533905932737*bmag[3]*tmp[6]+0.3535533905932737*tmp[3]*bmag[6]+0.3535533905932737*bmag[1]*tmp[4]+0.3535533905932737*tmp[1]*bmag[4]+0.3535533905932737*bmag[0]*tmp[2]+0.3535533905932737*tmp[0]*bmag[2])*volFact)/m_; 
@@ -57,7 +57,7 @@ GKYL_CU_DH void gyrokinetic_M2_3x2v_ser_p1(const double *dxv, const double *vmap
 } 
 GKYL_CU_DH void gyrokinetic_M2_par_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -72,16 +72,16 @@ GKYL_CU_DH void gyrokinetic_M2_par_3x2v_ser_p1(const double *dxv, const double *
 } 
 GKYL_CU_DH void gyrokinetic_M2_perp_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[14]+1.414213562373095*vmap[2]*f[3]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[20]+1.414213562373095*vmap[2]*f[6]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[21]+1.414213562373095*vmap[2]*f[7]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[22]+1.414213562373095*vmap[2]*f[8]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[27]+1.414213562373095*vmap[2]*f[16]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[14]+1.4142135623730951*vmap[2]*f[3]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[20]+1.4142135623730951*vmap[2]*f[6]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[21]+1.4142135623730951*vmap[2]*f[7]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[22]+1.4142135623730951*vmap[2]*f[8]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[27]+1.4142135623730951*vmap[2]*f[16]; 
   out[0] += (2.0*(0.3535533905932737*bmag[7]*tmp[7]+0.3535533905932737*bmag[6]*tmp[6]+0.3535533905932737*bmag[5]*tmp[5]+0.3535533905932737*bmag[4]*tmp[4]+0.3535533905932737*bmag[3]*tmp[3]+0.3535533905932737*bmag[2]*tmp[2]+0.3535533905932737*bmag[1]*tmp[1]+0.3535533905932737*bmag[0]*tmp[0])*volFact)/m_; 
   out[1] += (2.0*(0.3535533905932737*bmag[6]*tmp[7]+0.3535533905932737*tmp[6]*bmag[7]+0.3535533905932737*bmag[3]*tmp[5]+0.3535533905932737*tmp[3]*bmag[5]+0.3535533905932737*bmag[2]*tmp[4]+0.3535533905932737*tmp[2]*bmag[4]+0.3535533905932737*bmag[0]*tmp[1]+0.3535533905932737*tmp[0]*bmag[1])*volFact)/m_; 
   out[2] += (2.0*(0.3535533905932737*bmag[5]*tmp[7]+0.3535533905932737*tmp[5]*bmag[7]+0.3535533905932737*bmag[3]*tmp[6]+0.3535533905932737*tmp[3]*bmag[6]+0.3535533905932737*bmag[1]*tmp[4]+0.3535533905932737*tmp[1]*bmag[4]+0.3535533905932737*bmag[0]*tmp[2]+0.3535533905932737*tmp[0]*bmag[2])*volFact)/m_; 
@@ -93,24 +93,24 @@ GKYL_CU_DH void gyrokinetic_M2_perp_3x2v_ser_p1(const double *dxv, const double 
 } 
 GKYL_CU_DH void gyrokinetic_M3_par_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap0R3 = pow(vmap[0],3);
   const double vmap1R2 = pow(vmap[1],2);
   const double vmap1R3 = pow(vmap[1],3);
 
-  out[0] += (1.897366596101028*vmap[0]*vmap1R2*f[32]+1.272792206135785*vmap1R3*f[4]+2.121320343559642*vmap0R2*vmap[1]*f[4]+2.121320343559642*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
-  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[33]+1.272792206135785*vmap1R3*f[9]+2.121320343559642*vmap0R2*vmap[1]*f[9]+2.121320343559642*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
-  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[34]+1.272792206135785*vmap1R3*f[10]+2.121320343559642*vmap0R2*vmap[1]*f[10]+2.121320343559642*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
-  out[3] += (1.897366596101028*vmap[0]*vmap1R2*f[35]+1.272792206135785*vmap1R3*f[11]+2.121320343559642*vmap0R2*vmap[1]*f[11]+2.121320343559642*vmap[0]*vmap1R2*f[3]+0.7071067811865475*vmap0R3*f[3])*volFact; 
-  out[4] += (1.897366596101028*vmap[0]*vmap1R2*f[37]+1.272792206135785*vmap1R3*f[17]+2.121320343559642*vmap0R2*vmap[1]*f[17]+2.121320343559642*vmap[0]*vmap1R2*f[6]+0.7071067811865475*vmap0R3*f[6])*volFact; 
-  out[5] += (1.897366596101028*vmap[0]*vmap1R2*f[38]+1.272792206135785*vmap1R3*f[18]+2.121320343559642*vmap0R2*vmap[1]*f[18]+2.121320343559642*vmap[0]*vmap1R2*f[7]+0.7071067811865475*vmap0R3*f[7])*volFact; 
-  out[6] += (1.897366596101028*vmap[0]*vmap1R2*f[39]+1.272792206135785*vmap1R3*f[19]+2.121320343559642*vmap0R2*vmap[1]*f[19]+2.121320343559642*vmap[0]*vmap1R2*f[8]+0.7071067811865475*vmap0R3*f[8])*volFact; 
-  out[7] += (1.897366596101028*vmap[0]*vmap1R2*f[43]+1.272792206135785*vmap1R3*f[26]+2.121320343559642*vmap0R2*vmap[1]*f[26]+2.121320343559642*vmap[0]*vmap1R2*f[16]+0.7071067811865475*vmap0R3*f[16])*volFact; 
+  out[0] += (1.8973665961010278*vmap[0]*vmap1R2*f[32]+1.2727922061357855*vmap1R3*f[4]+2.1213203435596424*vmap0R2*vmap[1]*f[4]+2.1213203435596424*f[0]*vmap[0]*vmap1R2+0.7071067811865475*f[0]*vmap0R3)*volFact; 
+  out[1] += (1.897366596101028*vmap[0]*vmap1R2*f[33]+1.2727922061357855*vmap1R3*f[9]+2.1213203435596424*vmap0R2*vmap[1]*f[9]+2.1213203435596424*vmap[0]*f[1]*vmap1R2+0.7071067811865475*vmap0R3*f[1])*volFact; 
+  out[2] += (1.897366596101028*vmap[0]*vmap1R2*f[34]+1.2727922061357855*vmap1R3*f[10]+2.1213203435596424*vmap0R2*vmap[1]*f[10]+2.1213203435596424*vmap[0]*vmap1R2*f[2]+0.7071067811865475*vmap0R3*f[2])*volFact; 
+  out[3] += (1.897366596101028*vmap[0]*vmap1R2*f[35]+1.2727922061357855*vmap1R3*f[11]+2.1213203435596424*vmap0R2*vmap[1]*f[11]+2.1213203435596424*vmap[0]*vmap1R2*f[3]+0.7071067811865475*vmap0R3*f[3])*volFact; 
+  out[4] += (1.8973665961010278*vmap[0]*vmap1R2*f[37]+1.2727922061357855*vmap1R3*f[17]+2.1213203435596424*vmap0R2*vmap[1]*f[17]+2.1213203435596424*vmap[0]*vmap1R2*f[6]+0.7071067811865475*vmap0R3*f[6])*volFact; 
+  out[5] += (1.8973665961010278*vmap[0]*vmap1R2*f[38]+1.2727922061357855*vmap1R3*f[18]+2.1213203435596424*vmap0R2*vmap[1]*f[18]+2.1213203435596424*vmap[0]*vmap1R2*f[7]+0.7071067811865475*vmap0R3*f[7])*volFact; 
+  out[6] += (1.8973665961010278*vmap[0]*vmap1R2*f[39]+1.2727922061357855*vmap1R3*f[19]+2.1213203435596424*vmap0R2*vmap[1]*f[19]+2.1213203435596424*vmap[0]*vmap1R2*f[8]+0.7071067811865475*vmap0R3*f[8])*volFact; 
+  out[7] += (1.897366596101028*vmap[0]*vmap1R2*f[43]+1.2727922061357855*vmap1R3*f[26]+2.1213203435596424*vmap0R2*vmap[1]*f[26]+2.1213203435596424*vmap[0]*vmap1R2*f[16]+0.7071067811865475*vmap0R3*f[16])*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M3_perp_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
 
   out[0] += ((0.7071067811865475*vmap[1]*vmap[3]*bmag[7]*f[31]+0.7071067811865475*vmap[1]*vmap[3]*bmag[6]*f[30]+0.7071067811865475*vmap[1]*vmap[3]*bmag[5]*f[29]+0.7071067811865475*vmap[1]*vmap[3]*bmag[4]*f[28]+0.7071067811865475*vmap[0]*vmap[3]*bmag[7]*f[27]+0.7071067811865475*vmap[1]*vmap[2]*bmag[7]*f[26]+0.7071067811865475*vmap[1]*bmag[3]*vmap[3]*f[25]+0.7071067811865475*vmap[1]*bmag[2]*vmap[3]*f[24]+0.7071067811865475*bmag[1]*vmap[1]*vmap[3]*f[23]+0.7071067811865475*vmap[0]*vmap[3]*bmag[6]*f[22]+0.7071067811865475*vmap[0]*vmap[3]*bmag[5]*f[21]+0.7071067811865475*vmap[0]*vmap[3]*bmag[4]*f[20]+0.7071067811865475*vmap[1]*vmap[2]*bmag[6]*f[19]+0.7071067811865475*vmap[1]*vmap[2]*bmag[5]*f[18]+0.7071067811865475*vmap[1]*vmap[2]*bmag[4]*f[17]+0.7071067811865475*vmap[0]*vmap[2]*bmag[7]*f[16]+0.7071067811865475*bmag[0]*vmap[1]*vmap[3]*f[15]+0.7071067811865475*vmap[0]*bmag[3]*vmap[3]*f[14]+0.7071067811865475*vmap[0]*bmag[2]*vmap[3]*f[13]+0.7071067811865475*vmap[0]*bmag[1]*vmap[3]*f[12]+0.7071067811865475*vmap[1]*vmap[2]*bmag[3]*f[11]+0.7071067811865475*vmap[1]*bmag[2]*vmap[2]*f[10]+0.7071067811865475*bmag[1]*vmap[1]*vmap[2]*f[9]+0.7071067811865475*vmap[0]*vmap[2]*bmag[6]*f[8]+0.7071067811865475*vmap[0]*vmap[2]*bmag[5]*f[7]+0.7071067811865475*vmap[0]*vmap[2]*bmag[4]*f[6]+0.7071067811865475*bmag[0]*vmap[0]*vmap[3]*f[5]+0.7071067811865475*bmag[0]*vmap[1]*vmap[2]*f[4]+0.7071067811865475*vmap[0]*vmap[2]*bmag[3]*f[3]+0.7071067811865475*vmap[0]*bmag[2]*f[2]*vmap[2]+0.7071067811865475*vmap[0]*bmag[1]*f[1]*vmap[2]+0.7071067811865475*bmag[0]*f[0]*vmap[0]*vmap[2])*volFact)/m_; 
   out[1] += ((0.7071067811865475*vmap[1]*vmap[3]*bmag[6]*f[31]+0.7071067811865475*vmap[1]*vmap[3]*bmag[7]*f[30]+0.7071067811865475*vmap[1]*bmag[3]*vmap[3]*f[29]+0.7071067811865475*vmap[1]*bmag[2]*vmap[3]*f[28]+0.7071067811865475*vmap[0]*vmap[3]*bmag[6]*f[27]+0.7071067811865475*vmap[1]*vmap[2]*bmag[6]*f[26]+0.7071067811865475*vmap[1]*vmap[3]*bmag[5]*f[25]+0.7071067811865475*vmap[1]*vmap[3]*bmag[4]*f[24]+0.7071067811865475*bmag[0]*vmap[1]*vmap[3]*f[23]+0.7071067811865475*vmap[0]*vmap[3]*bmag[7]*f[22]+0.7071067811865475*vmap[0]*bmag[3]*vmap[3]*f[21]+0.7071067811865475*vmap[0]*bmag[2]*vmap[3]*f[20]+0.7071067811865475*vmap[1]*vmap[2]*bmag[7]*f[19]+0.7071067811865475*vmap[1]*vmap[2]*bmag[3]*f[18]+0.7071067811865475*vmap[1]*bmag[2]*vmap[2]*f[17]+0.7071067811865475*vmap[0]*vmap[2]*bmag[6]*f[16]+0.7071067811865475*bmag[1]*vmap[1]*vmap[3]*f[15]+0.7071067811865475*vmap[0]*vmap[3]*bmag[5]*f[14]+0.7071067811865475*vmap[0]*vmap[3]*bmag[4]*f[13]+0.7071067811865475*bmag[0]*vmap[0]*vmap[3]*f[12]+0.7071067811865475*vmap[1]*vmap[2]*bmag[5]*f[11]+0.7071067811865475*vmap[1]*vmap[2]*bmag[4]*f[10]+0.7071067811865475*bmag[0]*vmap[1]*vmap[2]*f[9]+0.7071067811865475*vmap[0]*vmap[2]*bmag[7]*f[8]+0.7071067811865475*vmap[0]*vmap[2]*bmag[3]*f[7]+0.7071067811865475*vmap[0]*bmag[2]*vmap[2]*f[6]+0.7071067811865475*vmap[0]*bmag[1]*vmap[3]*f[5]+0.7071067811865475*vmap[0]*vmap[2]*f[3]*bmag[5]+0.7071067811865475*bmag[1]*vmap[1]*vmap[2]*f[4]+0.7071067811865475*vmap[0]*f[2]*vmap[2]*bmag[4]+0.7071067811865475*bmag[0]*vmap[0]*f[1]*vmap[2]+0.7071067811865475*f[0]*vmap[0]*bmag[1]*vmap[2])*volFact)/m_; 
@@ -123,16 +123,16 @@ GKYL_CU_DH void gyrokinetic_M3_perp_3x2v_ser_p1(const double *dxv, const double 
 } 
 GKYL_CU_DH void gyrokinetic_three_moments_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
-  const double volFact = 1.570796326794897*dxv[3]*dxv[4]/m_; 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
   double tmp[8]; 
-  tmp[0] = 1.414213562373095*vmap[3]*f[5]+1.414213562373095*f[0]*vmap[2]; 
-  tmp[1] = 1.414213562373095*vmap[3]*f[12]+1.414213562373095*f[1]*vmap[2]; 
-  tmp[2] = 1.414213562373095*vmap[3]*f[13]+1.414213562373095*f[2]*vmap[2]; 
-  tmp[3] = 1.414213562373095*vmap[3]*f[14]+1.414213562373095*vmap[2]*f[3]; 
-  tmp[4] = 1.414213562373095*vmap[3]*f[20]+1.414213562373095*vmap[2]*f[6]; 
-  tmp[5] = 1.414213562373095*vmap[3]*f[21]+1.414213562373095*vmap[2]*f[7]; 
-  tmp[6] = 1.414213562373095*vmap[3]*f[22]+1.414213562373095*vmap[2]*f[8]; 
-  tmp[7] = 1.414213562373095*vmap[3]*f[27]+1.414213562373095*vmap[2]*f[16]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[14]+1.4142135623730951*vmap[2]*f[3]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[20]+1.4142135623730951*vmap[2]*f[6]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[21]+1.4142135623730951*vmap[2]*f[7]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[22]+1.4142135623730951*vmap[2]*f[8]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[27]+1.4142135623730951*vmap[2]*f[16]; 
   const double vmap0R2 = pow(vmap[0],2);
   const double vmap1R2 = pow(vmap[1],2);
 
@@ -144,14 +144,14 @@ GKYL_CU_DH void gyrokinetic_three_moments_3x2v_ser_p1(const double *dxv, const d
   out[5] += 2.0*f[7]*volFact; 
   out[6] += 2.0*f[8]*volFact; 
   out[7] += 2.0*f[16]*volFact; 
-  out[8] += (1.414213562373095*vmap[1]*f[4]+1.414213562373095*f[0]*vmap[0])*volFact; 
-  out[9] += (1.414213562373095*vmap[1]*f[9]+1.414213562373095*vmap[0]*f[1])*volFact; 
-  out[10] += (1.414213562373095*vmap[1]*f[10]+1.414213562373095*vmap[0]*f[2])*volFact; 
-  out[11] += (1.414213562373095*vmap[1]*f[11]+1.414213562373095*vmap[0]*f[3])*volFact; 
-  out[12] += (1.414213562373095*vmap[1]*f[17]+1.414213562373095*vmap[0]*f[6])*volFact; 
-  out[13] += (1.414213562373095*vmap[1]*f[18]+1.414213562373095*vmap[0]*f[7])*volFact; 
-  out[14] += (1.414213562373095*vmap[1]*f[19]+1.414213562373095*vmap[0]*f[8])*volFact; 
-  out[15] += (1.414213562373095*vmap[1]*f[26]+1.414213562373095*vmap[0]*f[16])*volFact; 
+  out[8] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[9] += (1.4142135623730951*vmap[1]*f[9]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[10] += (1.4142135623730951*vmap[1]*f[10]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[11] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[3])*volFact; 
+  out[12] += (1.4142135623730951*vmap[1]*f[17]+1.4142135623730951*vmap[0]*f[6])*volFact; 
+  out[13] += (1.4142135623730951*vmap[1]*f[18]+1.4142135623730951*vmap[0]*f[7])*volFact; 
+  out[14] += (1.4142135623730951*vmap[1]*f[19]+1.4142135623730951*vmap[0]*f[8])*volFact; 
+  out[15] += (1.4142135623730951*vmap[1]*f[26]+1.4142135623730951*vmap[0]*f[16])*volFact; 
   out[16] += ((0.7071067811865475*bmag[7]*tmp[7]+0.7071067811865475*bmag[6]*tmp[6]+0.7071067811865475*bmag[5]*tmp[5]+0.7071067811865475*bmag[4]*tmp[4]+0.7071067811865475*bmag[3]*tmp[3]+0.7071067811865475*bmag[2]*tmp[2]+0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_+(0.8944271909999159*vmap1R2*f[32]+2.0*vmap[0]*vmap[1]*f[4]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
   out[17] += ((0.7071067811865475*bmag[6]*tmp[7]+0.7071067811865475*tmp[6]*bmag[7]+0.7071067811865475*bmag[3]*tmp[5]+0.7071067811865475*tmp[3]*bmag[5]+0.7071067811865475*bmag[2]*tmp[4]+0.7071067811865475*tmp[2]*bmag[4]+0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_+(0.8944271909999161*vmap1R2*f[33]+2.0*vmap[0]*vmap[1]*f[9]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
   out[18] += ((0.7071067811865475*bmag[5]*tmp[7]+0.7071067811865475*tmp[5]*bmag[7]+0.7071067811865475*bmag[3]*tmp[6]+0.7071067811865475*tmp[3]*bmag[6]+0.7071067811865475*bmag[1]*tmp[4]+0.7071067811865475*tmp[1]*bmag[4]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2])*volFact)/m_+(0.8944271909999161*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[10]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
@@ -162,35 +162,84 @@ GKYL_CU_DH void gyrokinetic_three_moments_3x2v_ser_p1(const double *dxv, const d
   out[23] += ((0.7071067811865475*bmag[0]*tmp[7]+0.7071067811865475*tmp[0]*bmag[7]+0.7071067811865475*bmag[1]*tmp[6]+0.7071067811865475*tmp[1]*bmag[6]+0.7071067811865475*bmag[2]*tmp[5]+0.7071067811865475*tmp[2]*bmag[5]+0.7071067811865475*bmag[3]*tmp[4]+0.7071067811865475*tmp[3]*bmag[4])*volFact)/m_+(0.8944271909999161*vmap1R2*f[43]+2.0*vmap[0]*vmap[1]*f[26]+vmap1R2*f[16]+vmap0R2*f[16])*volFact; 
 } 
 
+GKYL_CU_DH void gyrokinetic_four_moments_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
+{ 
+  const double volFact = 1.5707963267948966*dxv[3]*dxv[4]/m_; 
+  double tmp[8]; 
+  tmp[0] = 1.4142135623730951*vmap[3]*f[5]+1.4142135623730951*f[0]*vmap[2]; 
+  tmp[1] = 1.4142135623730951*vmap[3]*f[12]+1.4142135623730951*f[1]*vmap[2]; 
+  tmp[2] = 1.4142135623730951*vmap[3]*f[13]+1.4142135623730951*f[2]*vmap[2]; 
+  tmp[3] = 1.4142135623730951*vmap[3]*f[14]+1.4142135623730951*vmap[2]*f[3]; 
+  tmp[4] = 1.4142135623730951*vmap[3]*f[20]+1.4142135623730951*vmap[2]*f[6]; 
+  tmp[5] = 1.4142135623730951*vmap[3]*f[21]+1.4142135623730951*vmap[2]*f[7]; 
+  tmp[6] = 1.4142135623730951*vmap[3]*f[22]+1.4142135623730951*vmap[2]*f[8]; 
+  tmp[7] = 1.4142135623730951*vmap[3]*f[27]+1.4142135623730951*vmap[2]*f[16]; 
+  const double vmap0R2 = pow(vmap[0],2);
+  const double vmap1R2 = pow(vmap[1],2);
+
+  out[0] += 2.0*f[0]*volFact; 
+  out[1] += 2.0*f[1]*volFact; 
+  out[2] += 2.0*f[2]*volFact; 
+  out[3] += 2.0*f[3]*volFact; 
+  out[4] += 2.0*f[6]*volFact; 
+  out[5] += 2.0*f[7]*volFact; 
+  out[6] += 2.0*f[8]*volFact; 
+  out[7] += 2.0*f[16]*volFact; 
+  out[8] += (1.4142135623730951*vmap[1]*f[4]+1.4142135623730951*f[0]*vmap[0])*volFact; 
+  out[9] += (1.4142135623730951*vmap[1]*f[9]+1.4142135623730951*vmap[0]*f[1])*volFact; 
+  out[10] += (1.4142135623730951*vmap[1]*f[10]+1.4142135623730951*vmap[0]*f[2])*volFact; 
+  out[11] += (1.4142135623730951*vmap[1]*f[11]+1.4142135623730951*vmap[0]*f[3])*volFact; 
+  out[12] += (1.4142135623730951*vmap[1]*f[17]+1.4142135623730951*vmap[0]*f[6])*volFact; 
+  out[13] += (1.4142135623730951*vmap[1]*f[18]+1.4142135623730951*vmap[0]*f[7])*volFact; 
+  out[14] += (1.4142135623730951*vmap[1]*f[19]+1.4142135623730951*vmap[0]*f[8])*volFact; 
+  out[15] += (1.4142135623730951*vmap[1]*f[26]+1.4142135623730951*vmap[0]*f[16])*volFact; 
+  out[16] += (0.8944271909999159*vmap1R2*f[32]+2.0*vmap[0]*vmap[1]*f[4]+f[0]*vmap1R2+f[0]*vmap0R2)*volFact; 
+  out[17] += (0.8944271909999161*vmap1R2*f[33]+2.0*vmap[0]*vmap[1]*f[9]+f[1]*vmap1R2+vmap0R2*f[1])*volFact; 
+  out[18] += (0.8944271909999161*vmap1R2*f[34]+2.0*vmap[0]*vmap[1]*f[10]+vmap1R2*f[2]+vmap0R2*f[2])*volFact; 
+  out[19] += (0.8944271909999161*vmap1R2*f[35]+2.0*vmap[0]*vmap[1]*f[11]+vmap1R2*f[3]+vmap0R2*f[3])*volFact; 
+  out[20] += (0.8944271909999159*vmap1R2*f[37]+2.0*vmap[0]*vmap[1]*f[17]+vmap1R2*f[6]+vmap0R2*f[6])*volFact; 
+  out[21] += (0.8944271909999159*vmap1R2*f[38]+2.0*vmap[0]*vmap[1]*f[18]+vmap1R2*f[7]+vmap0R2*f[7])*volFact; 
+  out[22] += (0.8944271909999159*vmap1R2*f[39]+2.0*vmap[0]*vmap[1]*f[19]+vmap1R2*f[8]+vmap0R2*f[8])*volFact; 
+  out[23] += (0.8944271909999161*vmap1R2*f[43]+2.0*vmap[0]*vmap[1]*f[26]+vmap1R2*f[16]+vmap0R2*f[16])*volFact; 
+  out[24] += ((0.7071067811865475*bmag[7]*tmp[7]+0.7071067811865475*bmag[6]*tmp[6]+0.7071067811865475*bmag[5]*tmp[5]+0.7071067811865475*bmag[4]*tmp[4]+0.7071067811865475*bmag[3]*tmp[3]+0.7071067811865475*bmag[2]*tmp[2]+0.7071067811865475*bmag[1]*tmp[1]+0.7071067811865475*bmag[0]*tmp[0])*volFact)/m_; 
+  out[25] += ((0.7071067811865475*bmag[6]*tmp[7]+0.7071067811865475*tmp[6]*bmag[7]+0.7071067811865475*bmag[3]*tmp[5]+0.7071067811865475*tmp[3]*bmag[5]+0.7071067811865475*bmag[2]*tmp[4]+0.7071067811865475*tmp[2]*bmag[4]+0.7071067811865475*bmag[0]*tmp[1]+0.7071067811865475*tmp[0]*bmag[1])*volFact)/m_; 
+  out[26] += ((0.7071067811865475*bmag[5]*tmp[7]+0.7071067811865475*tmp[5]*bmag[7]+0.7071067811865475*bmag[3]*tmp[6]+0.7071067811865475*tmp[3]*bmag[6]+0.7071067811865475*bmag[1]*tmp[4]+0.7071067811865475*tmp[1]*bmag[4]+0.7071067811865475*bmag[0]*tmp[2]+0.7071067811865475*tmp[0]*bmag[2])*volFact)/m_; 
+  out[27] += ((0.7071067811865475*bmag[4]*tmp[7]+0.7071067811865475*tmp[4]*bmag[7]+0.7071067811865475*bmag[2]*tmp[6]+0.7071067811865475*tmp[2]*bmag[6]+0.7071067811865475*bmag[1]*tmp[5]+0.7071067811865475*tmp[1]*bmag[5]+0.7071067811865475*bmag[0]*tmp[3]+0.7071067811865475*tmp[0]*bmag[3])*volFact)/m_; 
+  out[28] += ((0.7071067811865475*bmag[3]*tmp[7]+0.7071067811865475*tmp[3]*bmag[7]+0.7071067811865475*bmag[5]*tmp[6]+0.7071067811865475*tmp[5]*bmag[6]+0.7071067811865475*bmag[0]*tmp[4]+0.7071067811865475*tmp[0]*bmag[4]+0.7071067811865475*bmag[1]*tmp[2]+0.7071067811865475*tmp[1]*bmag[2])*volFact)/m_; 
+  out[29] += ((0.7071067811865475*bmag[2]*tmp[7]+0.7071067811865475*tmp[2]*bmag[7]+0.7071067811865475*bmag[4]*tmp[6]+0.7071067811865475*tmp[4]*bmag[6]+0.7071067811865475*bmag[0]*tmp[5]+0.7071067811865475*tmp[0]*bmag[5]+0.7071067811865475*bmag[1]*tmp[3]+0.7071067811865475*tmp[1]*bmag[3])*volFact)/m_; 
+  out[30] += ((0.7071067811865475*bmag[1]*tmp[7]+0.7071067811865475*tmp[1]*bmag[7]+0.7071067811865475*bmag[0]*tmp[6]+0.7071067811865475*tmp[0]*bmag[6]+0.7071067811865475*bmag[4]*tmp[5]+0.7071067811865475*tmp[4]*bmag[5]+0.7071067811865475*bmag[2]*tmp[3]+0.7071067811865475*tmp[2]*bmag[3])*volFact)/m_; 
+  out[31] += ((0.7071067811865475*bmag[0]*tmp[7]+0.7071067811865475*tmp[0]*bmag[7]+0.7071067811865475*bmag[1]*tmp[6]+0.7071067811865475*tmp[1]*bmag[6]+0.7071067811865475*bmag[2]*tmp[5]+0.7071067811865475*tmp[2]*bmag[5]+0.7071067811865475*bmag[3]*tmp[4]+0.7071067811865475*tmp[3]*bmag[4])*volFact)/m_; 
+} 
+
 GKYL_CU_DH void gyrokinetic_M0_step1_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = dxv[3]/2; 
-  out[0] += 1.414213562373095*f[0]*volFact; 
-  out[1] += 1.414213562373095*f[1]*volFact; 
-  out[2] += 1.414213562373095*f[2]*volFact; 
-  out[3] += 1.414213562373095*f[3]*volFact; 
-  out[4] += 1.414213562373095*f[5]*volFact; 
-  out[5] += 1.414213562373095*f[6]*volFact; 
-  out[6] += 1.414213562373095*f[7]*volFact; 
-  out[7] += 1.414213562373095*f[8]*volFact; 
-  out[8] += 1.414213562373095*f[12]*volFact; 
-  out[9] += 1.414213562373095*f[13]*volFact; 
-  out[10] += 1.414213562373095*f[14]*volFact; 
-  out[11] += 1.414213562373095*f[16]*volFact; 
-  out[12] += 1.414213562373095*f[20]*volFact; 
-  out[13] += 1.414213562373095*f[21]*volFact; 
-  out[14] += 1.414213562373095*f[22]*volFact; 
-  out[15] += 1.414213562373095*f[27]*volFact; 
+  out[0] += 1.4142135623730951*f[0]*volFact; 
+  out[1] += 1.4142135623730951*f[1]*volFact; 
+  out[2] += 1.4142135623730951*f[2]*volFact; 
+  out[3] += 1.4142135623730951*f[3]*volFact; 
+  out[4] += 1.4142135623730951*f[5]*volFact; 
+  out[5] += 1.4142135623730951*f[6]*volFact; 
+  out[6] += 1.4142135623730951*f[7]*volFact; 
+  out[7] += 1.4142135623730951*f[8]*volFact; 
+  out[8] += 1.4142135623730951*f[12]*volFact; 
+  out[9] += 1.4142135623730951*f[13]*volFact; 
+  out[10] += 1.4142135623730951*f[14]*volFact; 
+  out[11] += 1.4142135623730951*f[16]*volFact; 
+  out[12] += 1.4142135623730951*f[20]*volFact; 
+  out[13] += 1.4142135623730951*f[21]*volFact; 
+  out[14] += 1.4142135623730951*f[22]*volFact; 
+  out[15] += 1.4142135623730951*f[27]*volFact; 
 } 
 GKYL_CU_DH void gyrokinetic_M0_step2_3x2v_ser_p1(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) 
 { 
   const double volFact = 2.0*M_PI/m_*dxv[4]/2; 
-  out[0] += 2.828427124746191*f[0]*volFact; 
-  out[1] += 2.828427124746191*f[1]*volFact; 
-  out[2] += 2.828427124746191*f[2]*volFact; 
-  out[3] += 2.828427124746191*f[3]*volFact; 
-  out[4] += 2.828427124746191*f[5]*volFact; 
-  out[5] += 2.828427124746191*f[6]*volFact; 
-  out[6] += 2.828427124746191*f[7]*volFact; 
-  out[7] += 2.828427124746191*f[11]*volFact; 
+  out[0] += 2.8284271247461907*f[0]*volFact; 
+  out[1] += 2.8284271247461907*f[1]*volFact; 
+  out[2] += 2.8284271247461907*f[2]*volFact; 
+  out[3] += 2.8284271247461907*f[3]*volFact; 
+  out[4] += 2.8284271247461907*f[5]*volFact; 
+  out[5] += 2.8284271247461907*f[6]*volFact; 
+  out[6] += 2.8284271247461907*f[7]*volFact; 
+  out[7] += 2.8284271247461907*f[11]*volFact; 
 } 

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -578,8 +578,8 @@ main(int argc, char **argv)
       .upper = { .type = GKYL_SPECIES_GK_SHEATH, },
     },
     
-    .num_diag_moments = 5,
-    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
+    .num_diag_moments = 1,
+    .diag_moments = { "FourMoments" },
   };
 
   // Field.

--- a/zero/gkyl_gyrokinetic_maxwellian_moments_priv.h
+++ b/zero/gkyl_gyrokinetic_maxwellian_moments_priv.h
@@ -12,7 +12,7 @@ struct gkyl_gyrokinetic_maxwellian_moments
   struct gkyl_basis conf_basis; // Configuration-space basis
   struct gkyl_basis phase_basis; // Phase-space basis
   int num_conf_basis; // Number of configuration-space basis functions
-  int vdim; // Number of velocity dimensions
+  int vdim_phys; // Number of physical velocity dimensions captured.
   const struct gk_geometry *gk_geom; // Geometry struct
   bool divide_jacobgeo; // Boolean for if we are dividing out the configuration-space Jacobian from density
   double mass; // Species mass

--- a/zero/gkyl_mom_gyrokinetic_priv.h
+++ b/zero/gkyl_mom_gyrokinetic_priv.h
@@ -920,6 +920,125 @@ kernel_gyrokinetic_three_moments_3x2v_ser_p1(const struct gkyl_mom_type *momt, c
 
 GKYL_CU_DH
 static void
+kernel_gyrokinetic_four_moments_1x1v_ser_p1(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_1x1v_ser_p1(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_1x1v_ser_p2(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_1x1v_ser_p2(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_1x2v_ser_p1(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_1x2v_ser_p1(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_1x2v_ser_p2(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_1x2v_ser_p2(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_2x2v_ser_p1(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_2x2v_ser_p1(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_2x2v_ser_p2(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_2x2v_ser_p2(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);  
+}
+
+GKYL_CU_DH
+static void
+kernel_gyrokinetic_four_moments_3x2v_ser_p1(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
+  const int *idx, const double *f, double* out, void *param)
+{
+  struct mom_type_gyrokinetic *mom_gk = container_of(momt, struct mom_type_gyrokinetic, momt);
+
+  int idx_vel[2];
+  for (int d=momt->cdim; d<momt->pdim; d++) idx_vel[d-momt->cdim] = idx[d];
+
+  long cidx = gkyl_range_idx(&mom_gk->conf_range, idx);
+  long vidx = gkyl_range_idx(&mom_gk->vel_map->local_vel, idx_vel);
+  return gyrokinetic_four_moments_3x2v_ser_p1(dx,
+    (const double*) gkyl_array_cfetch(mom_gk->vel_map->vmap, vidx), mom_gk->mass,
+    (const double*) gkyl_array_cfetch(mom_gk->gk_geom->bmag, cidx), f, out);
+}
+
+GKYL_CU_DH
+static void
 kernel_gyrokinetic_int_mom_1x1v_ser_p1(const struct gkyl_mom_type *momt, const double *xc, const double *dx,
   const int *idx, const double *f, double* out, void *param)
 {
@@ -1132,8 +1251,7 @@ static const gkyl_gyrokinetic_mom_kern_list ser_m3_perp_kernels[] = {
   { NULL, kernel_gyrokinetic_M3_perp_3x2v_ser_p1, NULL }, // 3
 };
 
-// Zeroth (density), First (parallel momentum), 
-// and Second (total energy) computed together
+// Density), parallel momentum and kinetic energy computed together.
 GKYL_CU_D
 static const gkyl_gyrokinetic_mom_kern_list ser_three_moments_kernels[] = {
   // 1x kernels
@@ -1143,6 +1261,18 @@ static const gkyl_gyrokinetic_mom_kern_list ser_three_moments_kernels[] = {
   { NULL, kernel_gyrokinetic_three_moments_2x2v_ser_p1, kernel_gyrokinetic_three_moments_2x2v_ser_p2 }, // 2
   // 3x kernels
   { NULL, kernel_gyrokinetic_three_moments_3x2v_ser_p1, NULL }, // 3
+};
+
+// Density), parallel momentum, and parallel and perpendicular kinetic energy computed together.
+GKYL_CU_D
+static const gkyl_gyrokinetic_mom_kern_list ser_four_moments_kernels[] = {
+  // 1x kernels
+  { NULL, kernel_gyrokinetic_four_moments_1x1v_ser_p1, kernel_gyrokinetic_four_moments_1x1v_ser_p2 }, // 0
+  { NULL, kernel_gyrokinetic_four_moments_1x2v_ser_p1, kernel_gyrokinetic_four_moments_1x2v_ser_p2 }, // 1
+  // 2x kernels
+  { NULL, kernel_gyrokinetic_four_moments_2x2v_ser_p1, kernel_gyrokinetic_four_moments_2x2v_ser_p2 }, // 2
+  // 3x kernels
+  { NULL, kernel_gyrokinetic_four_moments_3x2v_ser_p1, NULL }, // 3
 };
 
 // Integrated moment kernel list

--- a/zero/gyrokinetic_maxwellian_moments.c
+++ b/zero/gyrokinetic_maxwellian_moments.c
@@ -15,17 +15,14 @@ gkyl_gyrokinetic_maxwellian_moments_inew(const struct gkyl_gyrokinetic_maxwellia
 {
   gkyl_gyrokinetic_maxwellian_moments *up = gkyl_malloc(sizeof(*up));
 
+  int vdim = up->phase_basis.ndim - up->conf_basis.ndim;
+
   up->conf_basis = *inp->conf_basis;
   up->phase_basis = *inp->phase_basis;
   up->num_conf_basis = inp->conf_basis->num_basis;
   // Determine factor to divide out of temperature computation
-  // If 1x1v, up->vdim = 1, otherwise up->vdim = 3
-  if (up->phase_basis.ndim - up->conf_basis.ndim == 1) {
-    up->vdim = up->phase_basis.ndim - up->conf_basis.ndim;
-  }
-  else {
-    up->vdim = 3;
-  }
+  // If 1x1v, up->vdim_phys = 1, otherwise up->vdim_phys = 3.
+  up->vdim_phys = 2*vdim-1;
   up->gk_geom = gkyl_gk_geometry_acquire(inp->gk_geom);
   up->divide_jacobgeo = inp->divide_jacobgeo;
 
@@ -41,7 +38,7 @@ gkyl_gyrokinetic_maxwellian_moments_inew(const struct gkyl_gyrokinetic_maxwellia
     up->temperature = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);
     // Bin op memory for needed weak divisions
     up->mem = gkyl_dg_bin_op_mem_cu_dev_new(conf_range_ncells, up->num_conf_basis);
-    if (up->vdim == 3) {
+    if (vdim == 2) {
       // Additional moments if computing Bi-Maxwellian moments (Tpar, Tperp)
       up->p_par = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);
       up->t_par = gkyl_array_cu_dev_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);    
@@ -58,7 +55,7 @@ gkyl_gyrokinetic_maxwellian_moments_inew(const struct gkyl_gyrokinetic_maxwellia
     up->temperature = gkyl_array_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);
     // Bin op memory for needed weak divisions
     up->mem = gkyl_dg_bin_op_mem_new(conf_range_ncells, up->num_conf_basis);
-    if (up->vdim == 3) {
+    if (vdim == 2) {
       // Additional moments if computing Bi-Maxwellian moments (Tpar, Tperp)
       up->p_par = gkyl_array_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);
       up->t_par = gkyl_array_new(GKYL_DOUBLE, up->num_conf_basis, conf_range_ext_ncells);
@@ -75,7 +72,7 @@ gkyl_gyrokinetic_maxwellian_moments_inew(const struct gkyl_gyrokinetic_maxwellia
   up->M2_calc = gkyl_dg_updater_moment_gyrokinetic_new(inp->phase_grid, inp->conf_basis,
     inp->phase_basis, inp->conf_range, inp->mass, inp->vel_map, inp->gk_geom, "M2", 0, inp->use_gpu);   
 
-  if (up->vdim == 3) {
+  if (vdim == 2) {
     // Additional moment calculators for Bi-Maxwellian moments (M2par, M2perp) 
     up->M2_par_calc = gkyl_dg_updater_moment_gyrokinetic_new(inp->phase_grid, inp->conf_basis,
       inp->phase_basis, inp->conf_range, inp->mass, inp->vel_map, inp->gk_geom, "M2par", 0, inp->use_gpu);   
@@ -109,9 +106,6 @@ gkyl_gyrokinetic_maxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian_m
   const struct gkyl_range *phase_range, const struct gkyl_range *conf_range, 
   const struct gkyl_array *fin, struct gkyl_array *moms_out)
 {
-  int vdim = up->vdim;
-  int num_conf_basis = up->num_conf_basis;
-
   // compute J*M0 and J*M1 where J is the configurations-space Jacobian
   gkyl_dg_updater_moment_gyrokinetic_advance(up->M0_calc, phase_range, conf_range, 
     fin, up->M0);
@@ -126,15 +120,15 @@ gkyl_gyrokinetic_maxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian_m
   gkyl_dg_mul_op_range(up->conf_basis, 
     0, up->u_par_dot_M1, 0, up->u_par, 0, up->M1, conf_range); 
 
-  // Compute J*M2 = vdim*J*P/m + J*M1*upar.
+  // Compute J*M2 = vdim_phys*J*n*T/m + J*M1*upar.
   gkyl_dg_updater_moment_gyrokinetic_advance(up->M2_calc, phase_range, conf_range, 
     fin, up->pressure);
   // Subtract off J*M1*upar from total J*M2
   gkyl_array_accumulate_range(up->pressure, -1.0, 
     up->u_par_dot_M1, conf_range); 
 
-  // Rescale J*pressure by 1.0/vdim and divide out J*M0 to get T/m, T/m = J*P/(m J*M0). 
-  gkyl_array_scale(up->pressure, 1.0/vdim);
+  // Rescale J*n*T by 1.0/vdim_phys and divide out J*M0 to get T/m, T/m = J*P/(m J*M0). 
+  gkyl_array_scale(up->pressure, 1.0/up->vdim_phys);
   gkyl_dg_div_op_range(up->mem, up->conf_basis, 
     0, up->temperature, 0, up->pressure, 0, up->M0, conf_range);
 
@@ -147,6 +141,7 @@ gkyl_gyrokinetic_maxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian_m
     gkyl_array_set_range(moms_out, 1.0, up->M0, conf_range);
   }
   // Save the other outputs to moms_out (n, V_drift, T/m):
+  int num_conf_basis = up->num_conf_basis;
   gkyl_array_set_offset_range(moms_out, 1.0, up->u_par, 1*num_conf_basis, conf_range);
   gkyl_array_set_offset_range(moms_out, 1.0, up->temperature, 2*num_conf_basis, conf_range);
 }
@@ -156,9 +151,6 @@ gkyl_gyrokinetic_bimaxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian
   const struct gkyl_range *phase_range, const struct gkyl_range *conf_range, 
   const struct gkyl_array *fin, struct gkyl_array *moms_out)
 {
-  int vdim = up->vdim;
-  int num_conf_basis = up->num_conf_basis;
-
   // compute J*M0 and J*M1 where J is the configurations-space Jacobian
   gkyl_dg_updater_moment_gyrokinetic_advance(up->M0_calc, phase_range, conf_range, 
     fin, up->M0);
@@ -173,19 +165,20 @@ gkyl_gyrokinetic_bimaxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian
   gkyl_dg_mul_op_range(up->conf_basis, 
     0, up->u_par_dot_M1, 0, up->u_par, 0, up->M1, conf_range); 
 
-  // Compute J*M2_par = J*P_par/m + J*M1*upar.
+  // Compute J*M2_par = J*n*T_par/m + J*M1*upar.
   gkyl_dg_updater_moment_gyrokinetic_advance(up->M2_par_calc, phase_range, conf_range, 
     fin, up->p_par);
   // Subtract off J*M1*upar from total J*M2_par
   gkyl_array_accumulate_range(up->p_par, -1.0, 
     up->u_par_dot_M1, conf_range); 
 
-  // Compute J*M2_perp = 2*J*P_perp/m.
+  // Compute J*M2_perp = 2*J*n*T_perp/m.
   gkyl_dg_updater_moment_gyrokinetic_advance(up->M2_perp_calc, phase_range, conf_range, 
     fin, up->p_perp);
 
-  // Rescale J*p_perp by 1.0/2.0 and divide out J*M0 to get T_par/m, T_perp/m from P_par/m, P_perp/m. 
-  gkyl_array_scale(up->p_perp, 1.0/2.0);
+  // Rescale J*n*T_perp by 1/2 and divide out J*M0 to get T_par/m, T_perp/m
+  // from n*T_par/m, n*T_perp/m.
+  gkyl_array_scale(up->p_perp, 0.5);
   gkyl_dg_div_op_range(up->mem, up->conf_basis, 
     0, up->t_par, 0, up->p_par, 0, up->M0, conf_range);
   gkyl_dg_div_op_range(up->mem, up->conf_basis, 
@@ -200,6 +193,7 @@ gkyl_gyrokinetic_bimaxwellian_moments_advance(struct gkyl_gyrokinetic_maxwellian
     gkyl_array_set_range(moms_out, 1.0, up->M0, conf_range);
   }
   // Save the other outputs to moms_out (n, u_par, T_par/m, T_perp/m):
+  int num_conf_basis = up->num_conf_basis;
   gkyl_array_set_offset_range(moms_out, 1.0, up->u_par, 1*num_conf_basis, conf_range);
   gkyl_array_set_offset_range(moms_out, 1.0, up->t_par, 2*num_conf_basis, conf_range);
   gkyl_array_set_offset_range(moms_out, 1.0, up->t_perp, 3*num_conf_basis, conf_range);
@@ -220,7 +214,7 @@ gkyl_gyrokinetic_maxwellian_moments_release(gkyl_gyrokinetic_maxwellian_moments 
   gkyl_dg_updater_moment_gyrokinetic_release(up->M0_calc);
   gkyl_dg_updater_moment_gyrokinetic_release(up->M1_calc);
   gkyl_dg_updater_moment_gyrokinetic_release(up->M2_calc);
-  if (up->vdim == 3) {
+  if (up->vdim_phys == 3) {
     gkyl_array_release(up->p_par);
     gkyl_array_release(up->t_par);
     gkyl_array_release(up->p_perp);

--- a/zero/mom_gyrokinetic.c
+++ b/zero/mom_gyrokinetic.c
@@ -49,7 +49,8 @@ gkyl_mom_gyrokinetic_new(const struct gkyl_basis* cbasis, const struct gkyl_basi
 
   // choose kernel tables based on basis-function type
   const gkyl_gyrokinetic_mom_kern_list *m0_kernels, *m1_kernels, *m2_kernels, 
-    *m2_par_kernels, *m2_perp_kernels, *m3_par_kernels, *m3_perp_kernels, *three_moments_kernels;
+    *m2_par_kernels, *m2_perp_kernels, *m3_par_kernels, *m3_perp_kernels,
+    *three_moments_kernels, *four_moments_kernels;;
 
   switch (cbasis->b_type) {
     case GKYL_BASIS_MODAL_SERENDIPITY:
@@ -61,6 +62,7 @@ gkyl_mom_gyrokinetic_new(const struct gkyl_basis* cbasis, const struct gkyl_basi
       m3_par_kernels = ser_m3_par_kernels;
       m3_perp_kernels = ser_m3_perp_kernels;
       three_moments_kernels = ser_three_moments_kernels;
+      four_moments_kernels = ser_four_moments_kernels;
       break;
 
     default:
@@ -117,12 +119,21 @@ gkyl_mom_gyrokinetic_new(const struct gkyl_basis* cbasis, const struct gkyl_basi
     mom_gk->momt.kernel = m3_perp_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order];
     mom_gk->momt.num_mom = 1;
   }
-  else if (strcmp(mom, "ThreeMoments") == 0) { // Zeroth (density), First (parallel momentum),
-    assert(cv_index[cdim].vdim[vdim] != -1);   // and Second (total energy) computed together
+  else if (strcmp(mom, "ThreeMoments") == 0) { 
+    // Density), parallel momentum, and total energy computed together.
+    assert(cv_index[cdim].vdim[vdim] != -1);   
     assert(NULL != three_moments_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order]);
     
     mom_gk->momt.kernel = three_moments_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order];
     mom_gk->momt.num_mom = 3;
+  }
+  else if (strcmp(mom, "FourMoments") == 0) { // Density, parallel momentum, parallel and perpendicular
+                                              // kinetic energy computed together.
+    assert(cv_index[cdim].vdim[vdim] != -1);
+    assert(NULL != four_moments_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order]);
+    
+    mom_gk->momt.kernel = four_moments_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order];
+    mom_gk->momt.num_mom = vdim > 1? 4 : 3;
   }
   else {
     // string not recognized

--- a/zero/proj_bimaxwellian_on_basis.c
+++ b/zero/proj_bimaxwellian_on_basis.c
@@ -286,14 +286,13 @@ gkyl_proj_bimaxwellian_on_basis_gyrokinetic_lab_mom(const gkyl_proj_bimaxwellian
       }
       upar[n] = upar[n]/den;
       vtparsq[n] = (m2par_n - den*upar[n]*upar[n])/den;
-      vtperpsq[n] = m2perp_n/den;
+      vtperpsq[n] = 0.5*m2perp_n/den;
 
-      // compute the amplitude of the exponential.
+      // Compute the amplitude of the exponential.
       if ((den > 0.) && (vtparsq[n]>0.) && (vtperpsq[n]>0.))
         exp_amp[n] = jac*den/(sqrt(pow(2.0*GKYL_PI,3)*vtparsq[n])*vtperpsq[n]);
       else
         exp_amp[n] = 0.;
-
     }
 
     // inner loop over velocity space


### PR DESCRIPTION
New feature:
- A FourMoments option for GK which calculates M0, M1, M2par and M2perp together.

Two fixes:
1. Previously we were making the positivity shift diagnostic moments the same as those the user requested. But when the user requests Maxwellian or BiMaxwellian moments one gets a division error at t=0 when computing upar of the positivity shift, because its density is zero. We fix this by simply making the diagnostic for pos shift always be FourMoments.
2. Fix a missing factor of 0.5 in the proj_bimaxwellian_on_basis_lab_mom. It had snuck in when we changed the definition of M2perp.

This goes with PR 44 in gkylcas: https://github.com/ammarhakim/gkylcas/pull/44