### PR TITLE
Bug fix in maxwellian_moments updator

### DIFF
--- a/zero/gyrokinetic_maxwellian_moments.c
+++ b/zero/gyrokinetic_maxwellian_moments.c
@@ -15,11 +15,11 @@ gkyl_gyrokinetic_maxwellian_moments_inew(const struct gkyl_gyrokinetic_maxwellia
 {
   gkyl_gyrokinetic_maxwellian_moments *up = gkyl_malloc(sizeof(*up));
 
-  int vdim = up->phase_basis.ndim - up->conf_basis.ndim;
-
   up->conf_basis = *inp->conf_basis;
   up->phase_basis = *inp->phase_basis;
   up->num_conf_basis = inp->conf_basis->num_basis;
+  int vdim = up->phase_basis.ndim - up->conf_basis.ndim;
+
   // Determine factor to divide out of temperature computation
   // If 1x1v, up->vdim_phys = 1, otherwise up->vdim_phys = 3.
   up->vdim_phys = 2*vdim-1;


### PR DESCRIPTION
Fix an issue with maxwellian moments with vdim. It didn't know what the basis was initially. Seems like commit [https://github.com/ammarhakim/gkylzero/commit/0c09950b2bcc9be5f7acb7bdadb7b7cd292998ed](url) wasn't tested before it was pushed.

Sometimes 1 line of code takes hours to debug