### PR TITLE
Gk g0 app xptfinder bugfix

### DIFF
--- a/regression/rt_gk_asdex_3x2v_p1.c
+++ b/regression/rt_gk_asdex_3x2v_p1.c
@@ -244,7 +244,7 @@ create_ctx(void)
   double r0 = 0.5;   
   double Lx = 0.02;
   double Ly = 50 * rho_s * q0/r0 ; 
-  double Lz = 3.14*2;
+  double Lz = (M_PI-1e-14)*2.0 ; // Domain size (configuration space: z-direction).
 
   // Source parameters.
   double x_source = 0.16167;

--- a/regression/rt_gk_solovev_out_3x2v_p1.c
+++ b/regression/rt_gk_solovev_out_3x2v_p1.c
@@ -228,7 +228,7 @@ create_ctx(void)
   double r0 = 0.40705706492831;
   double Lx = 0.02;
   double Ly = 50 * rho_s * q0/r0 ; // should be 0.107890816895
-  double Lz = 3.14*2;
+  double Lz = (M_PI-1e-14)*2.0 ; // Domain size (configuration space: z-direction).
 
   // Source parameters.
   double x_source = -0.07;

--- a/regression/rt_gk_step_1x2v_p1_cons.c
+++ b/regression/rt_gk_step_1x2v_p1_cons.c
@@ -170,7 +170,7 @@ create_ctx(void)
   int Nz = 16; // Cell count (configuration space: z-direction).
   int Nvpar = 16; // Cell count (velocity space: parallel velocity direction).
   int Nmu = 16; // Cell count (velocity space: magnetic moment direction).
-  double Lz = 3.14*2.0 ; // Domain size (configuration space: z-direction).
+  double Lz = (M_PI-1e-14)*2.0 ; // Domain size (configuration space: z-direction).
   double vpar_max_elc = 4.0 * vte; // Domain boundary (electron velocity space: parallel velocity direction).
   double mu_max_elc = (3.0 / 2.0) * 0.5 * mass_elc * pow(4.0 * vte,2) / (2.0 * B0); // Domain boundary (electron velocity space: magnetic moment direction).
   double vpar_max_ion = 4.0 * vti; // Domain boundary (ion velocity space: parallel velocity direction).

--- a/regression/rt_gk_step_3x2v_p1_cons.c
+++ b/regression/rt_gk_step_3x2v_p1_cons.c
@@ -174,7 +174,7 @@ create_ctx(void)
   int Nz = 4; // Cell count (configuration space: z-direction).
   int Nvpar = 16; // Cell count (velocity space: parallel velocity direction).
   int Nmu = 16; // Cell count (velocity space: magnetic moment direction).
-  double Lz = 3.14*2.0 ; // Domain size (configuration space: z-direction).
+  double Lz = (M_PI-1e-14)*2.0 ; // Domain size (configuration space: z-direction).
   double vpar_max_elc = 4.0 * vte; // Domain boundary (electron velocity space: parallel velocity direction).
   double mu_max_elc = (3.0 / 2.0) * 0.5 * mass_elc * pow(4.0 * vte,2) / (2.0 * B0); // Domain boundary (electron velocity space: magnetic moment direction).
   double vpar_max_ion = 4.0 * vti; // Domain boundary (ion velocity space: parallel velocity direction).

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -654,7 +654,6 @@ main(int argc, char **argv)
     // psiRZ and related inputs
     .filepath = "./data/eqdsk/step.geqdsk",   // equilibrium to use
     .rz_poly_order = 2,                       // polynomial order for psi(R,Z) used for field line tracing
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR, // Basis to use for psi(R,Z)
     .flux_poly_order = 1,                     // polynomial order for fpol(psi)
     .reflect = true,                          // Reflect lower half of psi(R,Z) for up-down symmetry
   };

--- a/regression/rt_multib_step_2x2v_p1.c
+++ b/regression/rt_multib_step_2x2v_p1.c
@@ -77,7 +77,6 @@ create_block_geom(void)
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/step.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
       .reflect = true,
     };

--- a/regression/rt_multib_step_sol_2x2v_p1.c
+++ b/regression/rt_multib_step_sol_2x2v_p1.c
@@ -34,7 +34,6 @@ create_block_geom(void)
     // psiRZ and related inputs
     .filepath = "./data/eqdsk/step.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect = true,
   };
@@ -206,7 +205,7 @@ create_ctx(void)
   double lower_x = 0.934;
   double upper_x = 1.4688;
   double Lx = upper_x - lower_x;
-  double Lz = 3.14*2;
+  double Lz = (M_PI-1e-14)*2.0 ; // Domain size (configuration space: z-direction).
 
   double vpar_max_elc = 4.0*vtElc;
   double mu_max_elc = 18*me*vtElc*vtElc/(2.0*B0);

--- a/unit/ctest_asdex.c
+++ b/unit/ctest_asdex.c
@@ -90,12 +90,11 @@ test_fixed_z()
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/asdex.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
     };
 
-  double clower[] = { 0.16, -0.01, -3.14 };
-  double cupper[] = {0.17501, 0.01, 3.14 };
+  double clower[] = { 0.16, -0.01, -M_PI+1e-14 };
+  double cupper[] = {0.17501, 0.01, M_PI-1e-14 };
 
   int ccells[] = { 1, 1, 32 };
 
@@ -160,13 +159,12 @@ test_shaped_plate()
   struct gkyl_efit_inp efit_inp = {
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/asdex.geqdsk",
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .rz_poly_order = 2,
       .flux_poly_order = 1,
     };
 
-  double clower[] = { 0.16, -0.01, -3.14 };
-  double cupper[] = {0.17501, 0.01, 3.14 };
+  double clower[] = { 0.16, -0.01, -M_PI+1e-14 };
+  double cupper[] = {0.17501, 0.01, M_PI-1e-14 };
 
   int ccells[] = { 1, 1, 32 };
 

--- a/unit/ctest_cerfon.c
+++ b/unit/ctest_cerfon.c
@@ -23,7 +23,6 @@
       .filepath = "./data/eqdsk/cerfon.geqdsk",
       .rz_poly_order = 2,
       .flux_poly_order = 1,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .reflect = true,
     };
 

--- a/unit/ctest_efit.c
+++ b/unit/ctest_efit.c
@@ -20,7 +20,6 @@ void test_solovev(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/solovev.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };
@@ -39,7 +38,6 @@ void test_step(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/step.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };
@@ -58,7 +56,6 @@ void test_asdex(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/asdex.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
   };
   struct gkyl_efit* efit = gkyl_efit_new(&inp);
@@ -77,7 +74,6 @@ void test_cerfon(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/cerfon.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };
@@ -96,7 +92,6 @@ void test_elliptical(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/elliptical.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };
@@ -115,7 +110,6 @@ void test_wham(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/wham.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     //.reflect =  true,
   };
@@ -135,7 +129,6 @@ void test_tcv(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/tcv.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
   };
   struct gkyl_efit* efit = gkyl_efit_new(&inp);
@@ -153,7 +146,6 @@ void test_mast(){
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/mast.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };

--- a/unit/ctest_elliptical_surfaces.c
+++ b/unit/ctest_elliptical_surfaces.c
@@ -47,7 +47,6 @@ test_elliptical()
       .filepath = "./data/eqdsk/elliptical.geqdsk",
       .rz_poly_order = 2,
       .flux_poly_order = 1,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .reflect = true,
     };
 

--- a/unit/ctest_gk_geometry_mirror.c
+++ b/unit/ctest_gk_geometry_mirror.c
@@ -77,7 +77,6 @@ test_lores()
     .filepath = "./data/eqdsk/wham.geqdsk",
     .rz_poly_order = 2,
     .flux_poly_order = 1,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .reflect = true,
   };
 

--- a/unit/ctest_step_compare.c
+++ b/unit/ctest_step_compare.c
@@ -169,7 +169,6 @@ struct gkyl_efit_inp inp_inner= {
     // psiRZ and related inputs
     .filepath = "./data/eqdsk/step.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect = true,
   };
@@ -178,7 +177,6 @@ struct gkyl_efit_inp inp = {
     // psiRZ and related inputs
     .filepath = "./data/eqdsk/step.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect = true,
   };
@@ -187,7 +185,6 @@ struct gkyl_efit_inp inp_outer = {
     // psiRZ and related inputs
     .filepath = "./data/eqdsk/step.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect = true,
   };

--- a/unit/ctest_step_outboard.c
+++ b/unit/ctest_step_outboard.c
@@ -147,13 +147,10 @@ test_fixed_z()
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/step.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
       .reflect = true,
     };
 
-  //double clower[] = { 0.934, -0.01, -3.14 };
-  //double cupper[] = {1.0, 0.01, 3.14 };
 
   double psisep = 1.5098198350000001;
   double clower[] = { 0.934, -0.01, -M_PI+1e-14 };
@@ -248,12 +245,11 @@ test_horizontal_plate()
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/step.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
     };
 
-  double clower[] = { 0.934, -0.01, -3.14 };
-  double cupper[] = {1.3, 0.01, 3.14 };
+  double clower[] = { 0.934, -0.01, -M_PI+1e-14 };
+  double cupper[] = {1.3, 0.01, M_PI-1e-14 };
 
   int ccells[] = { 2, 1, 32 };
 
@@ -321,12 +317,11 @@ test_vertical_plate()
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/step.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
     };
 
-  double clower[] = { 0.934, -0.01, -3.14 };
-  double cupper[] = {1.4688, 0.01, 3.14 };
+  double clower[] = { 0.934, -0.01, -M_PI+1e-14 };
+  double cupper[] = {1.4688, 0.01, M_PI-1e-14 };
 
   int ccells[] = { 2, 1, 32 };
 
@@ -392,12 +387,9 @@ test_shaped_plate()
       // psiRZ and related inputs
       .filepath = "./data/eqdsk/step.geqdsk",
       .rz_poly_order = 2,
-      .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
       .flux_poly_order = 1,
     };
 
-  //double clower[] = { 0.934, -0.01, -3.14 };
-  //double cupper[] = {1.4688, 0.01, 3.14 };
 
   double psisep = 1.5098198350000001;
   double clower[] = { 0.934, -0.01, -M_PI+1e-14 };

--- a/unit/ctest_time_roots.c
+++ b/unit/ctest_time_roots.c
@@ -189,7 +189,6 @@ compare_quad_and_cub(void)
   struct gkyl_efit_inp inp  = {
     .filepath = "./data/eqdsk/wham.geqdsk",
     .rz_poly_order = 2,
-    .rz_basis_type = GKYL_BASIS_MODAL_TENSOR,
     .flux_poly_order = 1,
     .reflect =  true,
   };

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -247,13 +247,13 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
       if(psi_curr < up->fluxgrid.lower[0] || psi_curr > up->fluxgrid.upper[0]){
         psi_curr = up->sibry;
       }
-      int fidx = up->fluxlocal.lower[0] + (int) floor((psi_curr - up->fluxgrid.lower[0])/up->fluxgrid.dx[0]);
-      fidx = GKYL_MIN2(fidx, up->fluxlocal.upper[0]);
-      fidx = GKYL_MAX2(fidx, up->fluxlocal.lower[0]);
-      long flux_loc = gkyl_range_idx(&up->fluxlocal, &fidx);
+      fidx[0] = up->fluxlocal.lower[0] + (int) floor((psi_curr - up->fluxgrid.lower[0])/up->fluxgrid.dx[0]);
+      fidx[0] = GKYL_MIN2(fidx[0], up->fluxlocal.upper[0]);
+      fidx[0] = GKYL_MAX2(fidx[0], up->fluxlocal.lower[0]);
+      long flux_loc = gkyl_range_idx(&up->fluxlocal, fidx);
       const double *coeffs = gkyl_array_cfetch(up->fpolflux, flux_loc);
       double fxc;
-      gkyl_rect_grid_cell_center(&up->fluxgrid, &fidx, &fxc);
+      gkyl_rect_grid_cell_center(&up->fluxgrid, fidx, &fxc);
       double fx = (psi_curr - fxc)/(up->fluxgrid.dx[0]*0.5);
       double fpol = up->fluxbasis.eval_expand(&fx, coeffs);
       double bphi = fpol/R;

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -222,15 +222,13 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
       // Calculate Bpol.
       double xn[2] = {R, Z};
       double psi_curr, br, bz;
-      double *bpol_n ;
+      double *bpol_n;
       if (R == 0.0) {
         double fout[4];
         up->evf->eval_cubic_wgrad2(0.0, xn, fout, up->evf->ctx);
         psi_curr = fout[0];
         br = fout[3]*scale_factorZ*scale_factorR;
         bz = fout[1]*scale_factorR*scale_factorR;
-        bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
-        bpol_n[0] = sqrt(br*br + bz*bz);
       }
       else {
         double fout[3];
@@ -238,9 +236,9 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
         psi_curr = fout[0];
         br = 1.0/R*fout[2]*scale_factorZ;
         bz = -1.0/R*fout[1]*scale_factorR;
-        bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
-        bpol_n[0] = sqrt(br*br + bz*bz);
       }
+      bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
+      bpol_n[0] = sqrt(br*br + bz*bz);
 
       // Calculate Bphi.
       if (psi_curr < up->fluxgrid.lower[0] || psi_curr > up->fluxgrid.upper[0]){

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -25,17 +25,7 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
 
   gkyl_cart_modal_tensor(&up->rzbasis_cubic, 2, 3);
   gkyl_cart_modal_serendip(&up->fluxbasis, 1, inp->flux_poly_order);
-  switch (inp->rz_basis_type){
-    case GKYL_BASIS_MODAL_SERENDIPITY:
-      gkyl_cart_modal_serendip(&up->rzbasis, 2, inp->rz_poly_order);
-      break;
-    case GKYL_BASIS_MODAL_TENSOR:
-      gkyl_cart_modal_tensor(&up->rzbasis, 2, inp->rz_poly_order);
-      break;
-    default:
-      assert(false);
-      break;
-  }
+  gkyl_cart_modal_tensor(&up->rzbasis, 2, inp->rz_poly_order);
 
   FILE *ptr = fopen(up->filepath,"r");
   size_t status;
@@ -292,16 +282,14 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
   double Rxpt[num_max_xpts];
   double Zxpt[num_max_xpts];
 
-  if (inp->rz_basis_type == GKYL_BASIS_MODAL_TENSOR) {
-    up->num_xpts = find_xpts(up, Rxpt, Zxpt);
-    up->Rxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-    up->Zxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-    for (int i = 0; i < up->num_xpts; i++) {
-      up->Rxpt[i] = Rxpt[i];
-      up->Zxpt[i] = Zxpt[i];
-      // AS 9/24/24 This commented print statement is useful for checking the X-point Locations
-      //  printf("Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt[i], i, up->Zxpt[i], up->psisep);
-    }
+  up->num_xpts = find_xpts(up, Rxpt, Zxpt);
+  up->Rxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
+  up->Zxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
+  for (int i = 0; i < up->num_xpts; i++) {
+    up->Rxpt[i] = Rxpt[i];
+    up->Zxpt[i] = Zxpt[i];
+    // AS 9/24/24 This commented print statement is useful for checking the X-point Locations
+    //  printf("Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt[i], i, up->Zxpt[i], up->psisep);
   }
 
   up->num_xpts_cubic = find_xpts_cubic(up, Rxpt, Zxpt);
@@ -319,10 +307,8 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
 }
 
 void gkyl_efit_release(gkyl_efit* up){
-  if (up->rzbasis.b_type == GKYL_BASIS_MODAL_TENSOR) {
-    gkyl_free(up->Rxpt);
-    gkyl_free(up->Zxpt);
-  }
+  gkyl_free(up->Rxpt);
+  gkyl_free(up->Zxpt);
   gkyl_free(up->Rxpt_cubic);
   gkyl_free(up->Zxpt_cubic);
   gkyl_array_release(up->psizr);

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -305,8 +305,8 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
   }
 
   up->num_xpts_cubic = find_xpts_cubic(up, Rxpt, Zxpt);
-  up->Rxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts);
-  up->Zxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts);
+  up->Rxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
+  up->Zxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
   for (int i = 0; i < up->num_xpts_cubic; i++) {
     up->Rxpt_cubic[i] = Rxpt[i];
     up->Zxpt_cubic[i] = Zxpt[i];

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -222,7 +222,6 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
       // Calculate Bpol.
       double xn[2] = {R, Z};
       double psi_curr, br, bz;
-      double *bpol_n;
       if (R == 0.0) {
         double fout[4];
         up->evf->eval_cubic_wgrad2(0.0, xn, fout, up->evf->ctx);
@@ -237,7 +236,7 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
         br = 1.0/R*fout[2]*scale_factorZ;
         bz = -1.0/R*fout[1]*scale_factorR;
       }
-      bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
+      double *bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
       bpol_n[0] = sqrt(br*br + bz*bz);
 
       // Calculate Bphi.

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -288,18 +288,30 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
   
   fclose(ptr);
 
+  int num_max_xpts = 10;
+  double Rxpt[num_max_xpts];
+  double Zxpt[num_max_xpts];
+
   if (inp->rz_basis_type == GKYL_BASIS_MODAL_TENSOR) {
-    find_xpts(up);
-    printf("num_xpts = %d\n", up->num_xpts);
+    up->num_xpts = find_xpts(up, Rxpt, Zxpt);
+    up->Rxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
+    up->Zxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
     for (int i = 0; i < up->num_xpts; i++) {
-      printf("Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt[i], i, up->Zxpt[i], up->psisep);
+      up->Rxpt[i] = Rxpt[i];
+      up->Zxpt[i] = Zxpt[i];
+      // AS 9/24/24 This commented print statement is useful for checking the X-point Locations
+      //  printf("Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt[i], i, up->Zxpt[i], up->psisep);
     }
   }
 
-  find_xpts_cubic(up);
-  printf("cubic: num_xpts = %d\n", up->num_xpts_cubic);
+  up->num_xpts_cubic = find_xpts_cubic(up, Rxpt, Zxpt);
+  up->Rxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts);
+  up->Zxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts);
   for (int i = 0; i < up->num_xpts_cubic; i++) {
-    printf("cubic: Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt_cubic[i], i, up->Zxpt_cubic[i], up->psisep_cubic);
+    up->Rxpt_cubic[i] = Rxpt[i];
+    up->Zxpt_cubic[i] = Zxpt[i];
+    // AS 9/24/24 This commented print statement is useful for checking the X-point Locations
+    //  printf("cubic: Rxpt[%d] = %1.16f, Zxpt[%d] = %1.16f | psisep = %1.16f\n", i, up->Rxpt_cubic[i], i, up->Zxpt_cubic[i], up->psisep_cubic);
   }
 
 
@@ -307,8 +319,12 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
 }
 
 void gkyl_efit_release(gkyl_efit* up){
-  gkyl_free(up->Rxpt);
-  gkyl_free(up->Zxpt);
+  if (up->rzbasis.b_type == GKYL_BASIS_MODAL_TENSOR) {
+    gkyl_free(up->Rxpt);
+    gkyl_free(up->Zxpt);
+  }
+  gkyl_free(up->Rxpt_cubic);
+  gkyl_free(up->Zxpt_cubic);
   gkyl_array_release(up->psizr);
   gkyl_array_release(up->psizr_cubic);
   gkyl_array_release(up->bmagzr);

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -230,7 +230,7 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
         psi_curr = fout[0];
         br = fout[3]*scale_factorZ*scale_factorR;
         bz = fout[1]*scale_factorR*scale_factorR;
-        double *bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
+        bpol_n = gkyl_array_fetch(bpolzr_n, gkyl_range_idx(&nrange, idx));
         bpol_n[0] = sqrt(br*br + bz*bz);
       }
       else {

--- a/zero/efit_utils.c
+++ b/zero/efit_utils.c
@@ -103,8 +103,8 @@ newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cu
 
 }
 
-void
-find_xpts(gkyl_efit* up)
+int
+find_xpts(gkyl_efit* up, double *Rxpt, double *Zxpt)
 {
     bool found_xpt = false;
     double Rsep, Zsep;
@@ -134,30 +134,28 @@ find_xpts(gkyl_efit* up)
       }
     }
 
+    int num_xpts = 0;
     if (found_xpt) {
       if (up->reflect) {
-        up->num_xpts = 2;
-        up->Rxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-        up->Zxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-        up->Rxpt[0] = Rsep;
-        up->Rxpt[1] = Rsep;
-        up->Zxpt[0] = Zsep;
-        up->Zxpt[1] = -Zsep;
+        num_xpts = 2;
+        Rxpt[0] = Rsep;
+        Rxpt[1] = Rsep;
+        Zxpt[0] = Zsep;
+        Zxpt[1] = -Zsep;
         up->psisep = psisep;
       }
       else {
-        up->num_xpts = 1;
-        up->Rxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-        up->Zxpt = gkyl_malloc(sizeof(double)*up->num_xpts);
-        up->Rxpt[0] = Rsep;
-        up->Zxpt[0] = Zsep;
+        num_xpts = 1;
+        Rxpt[0] = Rsep;
+        Zxpt[0] = Zsep;
         up->psisep = psisep;
       }
     }
+  return num_xpts;
 }
 
-void
-find_xpts_cubic(gkyl_efit* up)
+int
+find_xpts_cubic(gkyl_efit* up, double *Rxpt, double *Zxpt)
 {
     bool found_xpt = false;
     double Rsep, Zsep;
@@ -187,25 +185,23 @@ find_xpts_cubic(gkyl_efit* up)
       }
     }
 
+    int num_xpts = 0;
     if (found_xpt) {
       if (up->reflect) {
-        up->num_xpts_cubic = 2;
-        up->Rxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
-        up->Zxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
-        up->Rxpt_cubic[0] = Rsep;
-        up->Rxpt_cubic[1] = Rsep;
-        up->Zxpt_cubic[0] = Zsep;
-        up->Zxpt_cubic[1] = -Zsep;
+        num_xpts = 2;
+        Rxpt[0] = Rsep;
+        Rxpt[1] = Rsep;
+        Zxpt[0] = Zsep;
+        Zxpt[1] = -Zsep;
         up->psisep_cubic = psisep;
       }
       else {
-        up->num_xpts_cubic = 1;
-        up->Rxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
-        up->Zxpt_cubic = gkyl_malloc(sizeof(double)*up->num_xpts_cubic);
-        up->Rxpt_cubic[0] = Rsep;
-        up->Zxpt_cubic[0] = Zsep;
+        num_xpts = 1;
+        Rxpt[0] = Rsep;
+        Zxpt[0] = Zsep;
         up->psisep_cubic = psisep;
       }
     }
+  return num_xpts;
 }
 

--- a/zero/gkyl_efit.h
+++ b/zero/gkyl_efit.h
@@ -13,7 +13,6 @@ struct gkyl_efit_inp {
   // Inputs to get psiRZ and related inputs from efit
   char filepath[1024]; // filepath path to eqdsk file
   int rz_poly_order; // poly order for DG rep of psi, psi/R, and psi/R^2
-  enum gkyl_basis_type rz_basis_type; // rz_basis_type RZ basis to use for DG rep of psi, psi/R, and psi/R^2
   int flux_poly_order; // poly order to use for DG rep of F(psi)
   bool reflect; // whether to reflect across R axis to preserve symmetry
   bool use_gpu; // whether to use the GPU

--- a/zero/gkyl_efit_priv.h
+++ b/zero/gkyl_efit_priv.h
@@ -4,9 +4,9 @@
 bool 
 newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cubics);
 
-void
-find_xpts(gkyl_efit* up);
+int 
+find_xpts(gkyl_efit* up, double *Rxpt, double *Zxpt);
 
-void
-find_xpts_cubic(gkyl_efit* up);
+int 
+find_xpts_cubic(gkyl_efit* up, double *Rxpt, double *Zxpt);
 

--- a/zero/gkyl_mirror_geo_priv.h
+++ b/zero/gkyl_mirror_geo_priv.h
@@ -72,58 +72,6 @@ calc_RdR_p1(const double *psi, double psi0, double Z, double xc[2], double dx[2]
   return sol;
 }
 
-// Compute roots R(psi,Z) and dR/dZ(psi,Z) in a p=2 DG cell
-static inline struct RdRdZ_sol
-calc_RdR_p2(const double *psi, double psi0, double Z, double xc[2], double dx[2])
-{
-  struct RdRdZ_sol sol = { .nsol = 0 };
-  double y = (Z-xc[1])/(dx[1]*0.5);
-
-  double aq = 2.904737509655563*psi[6]*y+1.677050983124842*psi[4]; 
-  double bq = 2.904737509655563*psi[7]*SQ(y)+1.5*psi[3]*y-0.9682458365518543*psi[7]+0.8660254037844386*psi[1]; 
-  double cq = 1.677050983124842*psi[5]*SQ(y)-0.9682458365518543*psi[6]*y+0.8660254037844386*psi[2]*y-1.0*psi0-0.5590169943749475*psi[5]-0.5590169943749475*psi[4]+0.5*psi[0]; 
-  double delta2 = bq*bq - 4*aq*cq;
-
-  if (delta2 > 0) {
-    double r1, r2;
-    double delta = sqrt(delta2);
-    // compute both roots
-    if (bq>=0) {
-      r1 = (-bq-delta)/(2*aq);
-      r2 = 2*cq/(-bq-delta);
-    }
-    else {
-      r1 = 2*cq/(-bq+delta);
-      r2 = (-bq+delta)/(2*aq);
-    }
-
-    int sidx = 0;
-    if ((-1<=r1) && (r1 < 1)) {
-      sol.nsol += 1;
-      sol.R[sidx] = r1*dx[0]*0.5 + xc[0];
-
-      double x = r1;
-      double C = 5.809475019311126*psi[7]*x*y+3.354101966249685*psi[5]*y+2.904737509655563*psi[6]*SQ(x)+1.5*psi[3]*x-0.9682458365518543*psi[6]+0.8660254037844386*psi[2]; 
-      double A = 2.904737509655563*psi[7]*SQ(y)+5.809475019311126*psi[6]*x*y+1.5*psi[3]*y+3.354101966249685*psi[4]*x-0.9682458365518543*psi[7]+0.8660254037844386*psi[1];
-      sol.dRdZ[sidx] = -C/A*dx[0]/dx[1];
-      
-      sidx += 1;
-    }
-    if ((-1<=r2) && (r2 < 1)) {
-      sol.nsol += 1;
-      sol.R[sidx] = r2*dx[0]*0.5 + xc[0];
-
-      double x = r2;
-      double C = 5.809475019311126*psi[7]*x*y+3.354101966249685*psi[5]*y+2.904737509655563*psi[6]*SQ(x)+1.5*psi[3]*x-0.9682458365518543*psi[6]+0.8660254037844386*psi[2]; 
-      double A = 2.904737509655563*psi[7]*SQ(y)+5.809475019311126*psi[6]*x*y+1.5*psi[3]*y+3.354101966249685*psi[4]*x-0.9682458365518543*psi[7]+0.8660254037844386*psi[1];
-      sol.dRdZ[sidx] = -C/A*dx[0]/dx[1];
-      
-      sidx += 1;
-    }
-  }
-  return sol;
-}
-
 // Compute roots R(psi,Z) and dR/dZ(psi,Z) in a p=2 DG cell with tensor basis
 static inline struct RdRdZ_sol
 calc_RdR_p2_tensor(const double *psi, double psi0, double Z, double xc[2], double dx[2])
@@ -415,19 +363,6 @@ calc_grad_psi_p1(const double *psih, const double eta[2], const double dx[2])
   double y = eta[1];
   double dpsidx = 1.5*psih[3]*y+0.8660254037844386*psih[1];
   double dpsidy = 1.5*psih[3]*x+0.8660254037844386*psih[2];
-  dpsidx = dpsidx*2.0/dx[0];
-  dpsidy = dpsidy*2.0/dx[1];
-  return sqrt(dpsidx*dpsidx + dpsidy*dpsidy);
-}
-
-// In cylindrical coords, grad psi = dpsi/dR Rhat + dpsi/dZ zhat
-static double
-calc_grad_psi_p2(const double *psih, const double eta[2], const double dx[2])
-{
-  double x = eta[0];
-  double y = eta[1];
-  double dpsidx = 2.904737509655563*psih[7]*(y*y-0.3333333333333333)+5.809475019311126*psih[6]*x*y+1.5*psih[3]*y+3.354101966249684*psih[4]*x+0.8660254037844386*psih[1];
-  double dpsidy =	5.809475019311126*psih[7]*x*y+3.354101966249684*psih[5]*y+2.904737509655563*psih[6]*(x*x-0.3333333333333333)+1.5*psih[3]*x+0.8660254037844386*psih[2];
   dpsidx = dpsidx*2.0/dx[0];
   dpsidy = dpsidy*2.0/dx[1];
   return sqrt(dpsidx*dpsidx + dpsidy*dpsidy);

--- a/zero/gkyl_tok_geo_priv.h
+++ b/zero/gkyl_tok_geo_priv.h
@@ -83,58 +83,6 @@ calc_RdR_p1(const double *psi, double psi0, double Z, double xc[2], double dx[2]
   return sol;
 }
 
-// Compute roots R(psi,Z) and dR/dZ(psi,Z) in a p=2 DG cell
-static inline struct RdRdZ_sol
-calc_RdR_p2(const double *psi, double psi0, double Z, double xc[2], double dx[2])
-{
-  struct RdRdZ_sol sol = { .nsol = 0 };
-  double y = (Z-xc[1])/(dx[1]*0.5);
-
-  double aq = 2.904737509655563*psi[6]*y+1.677050983124842*psi[4]; 
-  double bq = 2.904737509655563*psi[7]*SQ(y)+1.5*psi[3]*y-0.9682458365518543*psi[7]+0.8660254037844386*psi[1]; 
-  double cq = 1.677050983124842*psi[5]*SQ(y)-0.9682458365518543*psi[6]*y+0.8660254037844386*psi[2]*y-1.0*psi0-0.5590169943749475*psi[5]-0.5590169943749475*psi[4]+0.5*psi[0]; 
-  double delta2 = bq*bq - 4*aq*cq;
-
-  if (delta2 > 0) {
-    double r1, r2;
-    double delta = sqrt(delta2);
-    // compute both roots
-    if (bq>=0) {
-      r1 = (-bq-delta)/(2*aq);
-      r2 = 2*cq/(-bq-delta);
-    }
-    else {
-      r1 = 2*cq/(-bq+delta);
-      r2 = (-bq+delta)/(2*aq);
-    }
-
-    int sidx = 0;
-    if ((-1<=r1) && (r1 < 1)) {
-      sol.nsol += 1;
-      sol.R[sidx] = r1*dx[0]*0.5 + xc[0];
-
-      double x = r1;
-      double C = 5.809475019311126*psi[7]*x*y+3.354101966249685*psi[5]*y+2.904737509655563*psi[6]*SQ(x)+1.5*psi[3]*x-0.9682458365518543*psi[6]+0.8660254037844386*psi[2]; 
-      double A = 2.904737509655563*psi[7]*SQ(y)+5.809475019311126*psi[6]*x*y+1.5*psi[3]*y+3.354101966249685*psi[4]*x-0.9682458365518543*psi[7]+0.8660254037844386*psi[1];
-      sol.dRdZ[sidx] = -C/A*dx[0]/dx[1];
-      
-      sidx += 1;
-    }
-    if ((-1<=r2) && (r2 < 1)) {
-      sol.nsol += 1;
-      sol.R[sidx] = r2*dx[0]*0.5 + xc[0];
-
-      double x = r2;
-      double C = 5.809475019311126*psi[7]*x*y+3.354101966249685*psi[5]*y+2.904737509655563*psi[6]*SQ(x)+1.5*psi[3]*x-0.9682458365518543*psi[6]+0.8660254037844386*psi[2]; 
-      double A = 2.904737509655563*psi[7]*SQ(y)+5.809475019311126*psi[6]*x*y+1.5*psi[3]*y+3.354101966249685*psi[4]*x-0.9682458365518543*psi[7]+0.8660254037844386*psi[1];
-      sol.dRdZ[sidx] = -C/A*dx[0]/dx[1];
-      
-      sidx += 1;
-    }
-  }
-  return sol;
-}
-
 // Compute roots R(psi,Z) and dR/dZ(psi,Z) in a p=2 DG cell with tensor basis
 static inline struct RdRdZ_sol
 calc_RdR_p2_tensor(const double *psi, double psi0, double Z, double xc[2], double dx[2])
@@ -433,19 +381,6 @@ calc_grad_psi_p1(const double *psih, const double eta[2], const double dx[2])
   double y = eta[1];
   double dpsidx = 1.5*psih[3]*y+0.8660254037844386*psih[1];
   double dpsidy = 1.5*psih[3]*x+0.8660254037844386*psih[2];
-  dpsidx = dpsidx*2.0/dx[0];
-  dpsidy = dpsidy*2.0/dx[1];
-  return sqrt(dpsidx*dpsidx + dpsidy*dpsidy);
-}
-
-// In cylindrical coords, grad psi = dpsi/dR Rhat + dpsi/dZ zhat
-static double
-calc_grad_psi_p2(const double *psih, const double eta[2], const double dx[2])
-{
-  double x = eta[0];
-  double y = eta[1];
-  double dpsidx = 2.904737509655563*psih[7]*(y*y-0.3333333333333333)+5.809475019311126*psih[6]*x*y+1.5*psih[3]*y+3.354101966249684*psih[4]*x+0.8660254037844386*psih[1];
-  double dpsidy =	5.809475019311126*psih[7]*x*y+3.354101966249684*psih[5]*y+2.904737509655563*psih[6]*(x*x-0.3333333333333333)+1.5*psih[3]*x+0.8660254037844386*psih[2];
   dpsidx = dpsidx*2.0/dx[0];
   dpsidy = dpsidy*2.0/dx[1];
   return sqrt(dpsidx*dpsidx + dpsidy*dpsidy);

--- a/zero/mirror_geo.c
+++ b/zero/mirror_geo.c
@@ -127,14 +127,8 @@ gkyl_mirror_geo_new(const struct gkyl_efit_inp *inp, const struct gkyl_mirror_ge
     geo->calc_grad_psi = calc_grad_psi_p1;
   }
   else if (geo->efit->rzbasis.poly_order == 2){
-    if(inp->rz_basis_type == GKYL_BASIS_MODAL_SERENDIPITY) {
-      geo->calc_roots = calc_RdR_p2;
-      geo->calc_grad_psi = calc_grad_psi_p2;
-    }
-    else if(inp->rz_basis_type == GKYL_BASIS_MODAL_TENSOR) {
-      geo->calc_roots = calc_RdR_p2_tensor_nrc;
-      geo->calc_grad_psi = calc_grad_psi_p2_tensor;
-    }
+    geo->calc_roots = calc_RdR_p2_tensor_nrc;
+    geo->calc_grad_psi = calc_grad_psi_p2_tensor;
   }
 
   geo->stat = (struct gkyl_mirror_geo_stat) { };

--- a/zero/tok_geo.c
+++ b/zero/tok_geo.c
@@ -340,14 +340,8 @@ gkyl_tok_geo_new(const struct gkyl_efit_inp *inp, const struct gkyl_tok_geo_grid
     geo->calc_grad_psi = calc_grad_psi_p1;
   }
   else if (geo->efit->rzbasis.poly_order == 2){
-    if(inp->rz_basis_type == GKYL_BASIS_MODAL_SERENDIPITY) {
-      geo->calc_roots = calc_RdR_p2;
-      geo->calc_grad_psi = calc_grad_psi_p2;
-    }
-    else if(inp->rz_basis_type == GKYL_BASIS_MODAL_TENSOR) {
-      geo->calc_roots = calc_RdR_p2_tensor_nrc;
-      geo->calc_grad_psi = calc_grad_psi_p2_tensor;
-    }
+    geo->calc_roots = calc_RdR_p2_tensor_nrc;
+    geo->calc_grad_psi = calc_grad_psi_p2_tensor;
   }
 
   geo->stat = (struct gkyl_tok_geo_stat) { };


### PR DESCRIPTION
Fixes issue #480: Serendipity basis is no longer used at all for Psi(R,Z) when using efit for geometry. Along with this we also fix a memory leak in efit.c. Also clean up some unit and regression tests, removing the rz_basis_type option for all of them.

(MF) Also fit some bugs:
1. The case in which psi increases with x was not handled properly in efit.c, leading to a nonsensical flux grid.
2. Redefined variables and variables with mixed scope were giving seg faults on Macs (but not Linux) even though the test was valgrind clean.