### PR TITLE
Change makefile to avoid long link line error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,9 +369,15 @@ OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
 ZERO_SH_LIB := $(BUILD_DIR)/$(ZERO).so
+# MF 2024/09/29: below we dump the link command into a file, and run the file,
+# because that command is too long for make to execute it directly. When make
+# version 4.0+ becomes the norm, we'll be able to use the file function
+# instead.
 $(ZERO_SH_LIB): $(OBJS)
 	$(MKDIR_P) $(dir $@)
-	${CC} ${SHFLAGS} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@
+	@echo ${CC} ${SHFLAGS} ${LDFLAGS} $(OBJS) ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command.sh
+	chmod +x ./link_command.sh
+	./link_command.sh
 
 # Due to an issue with shared-lib linking on the Mac, we need to build
 # a separate shared lib to install. This one has the install path
@@ -381,7 +387,9 @@ $(ZERO_SH_LIB): $(OBJS)
 ZERO_SH_INSTALL_LIB := $(BUILD_DIR)/$(ZERO)-install.so
 $(ZERO_SH_INSTALL_LIB): $(OBJS)
 	$(MKDIR_P) $(dir $@)
-	${CC} ${SHFLAGS_INSTALL} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@
+	@echo ${CC} ${SHFLAGS_INSTALL} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command-install.sh
+	chmod +x ./link_command-install.sh
+	./link_command-install.sh
 
 ## All libraries build targets completed at this point
 

--- a/Makefile
+++ b/Makefile
@@ -369,16 +369,35 @@ OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
 ZERO_SH_LIB := $(BUILD_DIR)/$(ZERO).so
-# MF 2024/09/29: below we dump the link command into a file, and run the file,
-# because that command is too long for make to execute it directly. When make
-# version 4.0+ becomes the norm, we'll be able to use the file function
-# instead.
-$(ZERO_SH_LIB): $(OBJS)
+# MF 2024/09/29: below we dump the list of object files into a file, then
+# incorporate the file in the link command. This is because that command
+# is too long for make to execute it directly. We use a convoluted way of
+# writing to file with the NL definition below to avoid running into long
+# line limits. When make version 4.0+ becomes the norm, we'll be able to
+# use the file function instead.
+
+# Just a single newline!  Note 2 blank lines are needed.
+define NL
+
+
+endef
+
+OPT_FROM_FILE :=
+ifdef USING_NVCC
+	# Note there should be a blank space following --options-file.
+        OPT_FROM_FILE += --options-file 
+else
+	# There should be no blank space follow @.
+        OPT_FROM_FILE += @
+endif
+
+$(ZERO_SH_LIB).in: $(OBJS)
+	$(foreach f,$(OBJS),echo $(f) >> $@$(NL))
+
+$(ZERO_SH_LIB): $(ZERO_SH_LIB).in $(OBJS)
 	$(MKDIR_P) $(dir $@)
-	@echo ${CC} ${SHFLAGS} ${LDFLAGS} $(OBJS) ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command.sh
-	chmod +x ./link_command.sh
-	./link_command.sh
-	rm ./link_command.sh
+	${CC} ${SHFLAGS} ${LDFLAGS} ${OPT_FROM_FILE}$@.in ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@
+	rm $@.in
 
 # Due to an issue with shared-lib linking on the Mac, we need to build
 # a separate shared lib to install. This one has the install path
@@ -386,12 +405,13 @@ $(ZERO_SH_LIB): $(OBJS)
 # can link to the library properly. Perhaps there is a another way to
 # do this, don't know. -- AH, Feb 4th 2023.
 ZERO_SH_INSTALL_LIB := $(BUILD_DIR)/$(ZERO)-install.so
-$(ZERO_SH_INSTALL_LIB): $(OBJS)
+$(ZERO_SH_INSTALL_LIB).in: $(OBJS)
+	$(foreach f,$(OBJS),echo $(f) >> $@$(NL))
+
+$(ZERO_SH_INSTALL_LIB): $(ZERO_SH_INSTALL_LIB).in $(OBJS)
 	$(MKDIR_P) $(dir $@)
-	@echo ${CC} ${SHFLAGS_INSTALL} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command-install.sh
-	chmod +x ./link_command-install.sh
-	./link_command-install.sh
-	rm ./link_command-install.sh
+	${CC} ${SHFLAGS_INSTALL} ${LDFLAGS} ${OPT_FROM_FILE}$@.in ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@
+	rm $@.in
 
 ## All libraries build targets completed at this point
 

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ endif
 
 # Build directory
 ifdef USING_NVCC
-	BUILD_DIR ?= cubld
+	BUILD_DIR ?= cuda-build
 else	
-	BUILD_DIR ?= bld
+	BUILD_DIR ?= build
 endif
 
 # On OSX we should use Accelerate framework
@@ -378,6 +378,7 @@ $(ZERO_SH_LIB): $(OBJS)
 	@echo ${CC} ${SHFLAGS} ${LDFLAGS} $(OBJS) ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command.sh
 	chmod +x ./link_command.sh
 	./link_command.sh
+	rm ./link_command.sh
 
 # Due to an issue with shared-lib linking on the Mac, we need to build
 # a separate shared lib to install. This one has the install path
@@ -390,6 +391,7 @@ $(ZERO_SH_INSTALL_LIB): $(OBJS)
 	@echo ${CC} ${SHFLAGS_INSTALL} ${LDFLAGS} ${OBJS} ${EXEC_LIB_DIRS} ${EXEC_EXT_LIBS} -o $@ > ./link_command-install.sh
 	chmod +x ./link_command-install.sh
 	./link_command-install.sh
+	rm ./link_command-install.sh
 
 ## All libraries build targets completed at this point
 


### PR DESCRIPTION
As the makefile is currently written we can encounter an error about long link lines, see issue #398 

In the past we avoided this problem by reducing the number of characters in the folder names build/ and cuda-build/ by renaming them bld/ and cubld/.

Here we offer another solution, where we dump the object files in the the long link line into a temporary file, then invoke that file in the link command.

I tested this on my Mac (make 3.81), on stellar-amd and on perlmutter-gpu (make 4.2.1). They all produced working executables, for regression tests and input files outside of gkylzero/. I also ran them with MPI and with NCCL.