### PR TITLE
GK app I/O reorg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ NVCC_FLAGS =
 CUDA_LIBS =
 ifeq ($(CC), nvcc)
        USING_NVCC = yes
-       CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC
+       CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
        NVCC_FLAGS = -x cu -dc -arch=sm_${CUDA_ARCH} --compiler-options="-fPIC"
        LDFLAGS += -arch=sm_${CUDA_ARCH}
        ifdef CUDAMATH_LIBDIR

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 
 # Type make help to see help for this Makefile
 
+# Obtain the git commit ID.
+GIT_COMMIT_HASH := "$(shell git describe --dirty=+ --always --tags)"
+
 ARCH_FLAGS ?= -march=native
 CUDA_ARCH ?= 70
 # Warning flags: -Wall -Wno-unused-variable -Wno-unused-function -Wno-missing-braces
-CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP 
+CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
 LDFLAGS = 
 PREFIX ?= ${HOME}/gkylsoft
 INSTALL_PREFIX ?= ${PREFIX}

--- a/Makefile.sample
+++ b/Makefile.sample
@@ -3,10 +3,13 @@
 # Sample Makefile to use installed gkylzero library: copy and modify
 # for your needs
 
+# Obtain the git commit ID.
+GIT_COMMIT_HASH := "$(shell git describe --dirty=+ --always --tags)"
+
 ARCH_FLAGS ?= -march=native
 CUDA_ARCH ?= 70
 # Warning flags: -Wall -Wno-unused-variable -Wno-unused-function -Wno-missing-braces
-CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP
+CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
 LDFLAGS = 
 PREFIX ?= ${HOME}/gkylsoft
 
@@ -30,7 +33,7 @@ endif
 # Include config.mak file (if it exists)
 -include G0_SHARE_INSTALL_PREFIX_TAG/config.mak
 
-CFLAGS = -O3 -g -ffast-math -I.
+CFLAGS = -O3 -g -ffast-math -I. -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
 
 G0_INC_DIR = ${PREFIX}/gkylzero/include
 G0_LIB_DIR = ${PREFIX}/gkylzero/lib
@@ -41,7 +44,7 @@ NVCC_FLAGS =
 CUDA_LIBS =
 ifeq ($(CC), nvcc)
        USING_NVCC = yes
-       CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC
+       CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
        NVCC_FLAGS = -x cu -dc -arch=sm_${CUDA_ARCH} --compiler-options="-fPIC"
        LDFLAGS += -arch=sm_${CUDA_ARCH}
        ifdef CUDAMATH_LIBDIR

--- a/apps/gk_neut_species_source.c
+++ b/apps/gk_neut_species_source.c
@@ -16,7 +16,6 @@ gk_neut_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_spe
       src->source_host = mkarr(false, app->neut_basis.num_basis, s->local_ext.volume);
     }
 
-    src->write_source = s->info.source.write_source; // optional flag to write out source
     src->evolve = s->info.source.evolve; // Whether the source is time dependent.
 
     src->num_sources = s->info.source.num_sources;

--- a/apps/gk_neut_species_source.c
+++ b/apps/gk_neut_species_source.c
@@ -5,54 +5,60 @@ void
 gk_neut_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_species *s, 
   struct gk_source *src)
 {
-  int vdim = app->vdim+1;
-  // we need to ensure source has same shape as distribution function
-  src->source = mkarr(app->use_gpu, app->neut_basis.num_basis, s->local_ext.volume);
-  src->source_id = s->source_id;
-  src->source_host = src->source;
-  if (app->use_gpu) {
-    src->source_host = mkarr(false, app->neut_basis.num_basis, s->local_ext.volume);
-  }
+  src->source_id = s->info.source.source_id;
 
-  src->write_source = s->info.source.write_source; // optional flag to write out source
+  if (src->source_id) {
+    int vdim = app->vdim+1;
+    // we need to ensure source has same shape as distribution function
+    src->source = mkarr(app->use_gpu, app->neut_basis.num_basis, s->local_ext.volume);
+    src->source_host = src->source;
+    if (app->use_gpu) {
+      src->source_host = mkarr(false, app->neut_basis.num_basis, s->local_ext.volume);
+    }
 
-  src->num_sources = s->info.source.num_sources;
-  for (int k=0; k<s->info.source.num_sources; k++) {
-    gk_neut_species_projection_init(app, s, s->info.source.projection[k], &src->proj_source[k]);
-  }
+    src->write_source = s->info.source.write_source; // optional flag to write out source
+    src->evolve = s->info.source.evolve; // Whether the source is time dependent.
 
-  // Allocate data and updaters for diagnostic moments.
-  src->num_diag_moments = s->info.num_diag_moments;
-  s->src.moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_moments]));
-  for (int m=0; m<src->num_diag_moments; ++m) {
-    gk_neut_species_moment_init(app, s, &s->src.moms[m], s->info.diag_moments[m]);
-  }
+    src->num_sources = s->info.source.num_sources;
+    for (int k=0; k<s->info.source.num_sources; k++) {
+      gk_neut_species_projection_init(app, s, s->info.source.projection[k], &src->proj_source[k]);
+    }
 
-  // Allocate data and updaters for integrated moments.
-  gk_neut_species_moment_init(app, s, &s->src.integ_moms, "Integrated");
-  if (app->use_gpu) {
-    s->src.red_integ_diag = gkyl_cu_malloc(sizeof(double[vdim+2]));
-    s->src.red_integ_diag_global = gkyl_cu_malloc(sizeof(double[vdim+2]));
-  } 
-  else {
-    s->src.red_integ_diag = gkyl_malloc(sizeof(double[vdim+2]));
-    s->src.red_integ_diag_global = gkyl_malloc(sizeof(double[vdim+2]));
+    // Allocate data and updaters for diagnostic moments.
+    src->num_diag_moments = s->info.num_diag_moments;
+    s->src.moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_moments]));
+    for (int m=0; m<src->num_diag_moments; ++m) {
+      gk_neut_species_moment_init(app, s, &s->src.moms[m], s->info.diag_moments[m]);
+    }
+
+    // Allocate data and updaters for integrated moments.
+    gk_neut_species_moment_init(app, s, &s->src.integ_moms, "Integrated");
+    if (app->use_gpu) {
+      s->src.red_integ_diag = gkyl_cu_malloc(sizeof(double[vdim+2]));
+      s->src.red_integ_diag_global = gkyl_cu_malloc(sizeof(double[vdim+2]));
+    } 
+    else {
+      s->src.red_integ_diag = gkyl_malloc(sizeof(double[vdim+2]));
+      s->src.red_integ_diag_global = gkyl_malloc(sizeof(double[vdim+2]));
+    }
+    // allocate dynamic-vector to store all-reduced integrated moments 
+    s->src.integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, vdim+2);
+    s->src.is_first_integ_write_call = true;
   }
-  // allocate dynamic-vector to store all-reduced integrated moments 
-  s->src.integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, vdim+2);
-  s->src.is_first_integ_write_call = true;
 }
 
 void
 gk_neut_species_source_calc(gkyl_gyrokinetic_app *app, const struct gk_neut_species *s, 
   struct gk_source *src, double tm)
 {
-  struct gkyl_array *source_tmp = mkarr(app->use_gpu, app->neut_basis.num_basis, s->local_ext.volume);
-  for (int k=0; k<s->info.source.num_sources; k++) {
-    gk_neut_species_projection_calc(app, s, &src->proj_source[k], source_tmp, tm);
-    gkyl_array_accumulate(src->source, 1., source_tmp);
+  if (src->source_id) {
+    struct gkyl_array *source_tmp = mkarr(app->use_gpu, app->neut_basis.num_basis, s->local_ext.volume);
+    for (int k=0; k<s->info.source.num_sources; k++) {
+      gk_neut_species_projection_calc(app, s, &src->proj_source[k], source_tmp, tm);
+      gkyl_array_accumulate(src->source, 1., source_tmp);
+    }
+    gkyl_array_release(source_tmp);
   }
-  gkyl_array_release(source_tmp);
 }
 
 // Compute rhs of the source
@@ -60,33 +66,37 @@ void
 gk_neut_species_source_rhs(gkyl_gyrokinetic_app *app, const struct gk_neut_species *species,
   struct gk_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs)
 {
-  gkyl_array_accumulate(rhs, 1.0, src->source);
+  if (src->source_id) {
+    gkyl_array_accumulate(rhs, 1.0, src->source);
+  }
 }
 
 void
 gk_neut_species_source_release(const struct gkyl_gyrokinetic_app *app, const struct gk_source *src)
 {
-  gkyl_array_release(src->source);
-  if (app->use_gpu) {
-    gkyl_array_release(src->source_host);
-  }
-  for (int k=0; k<src->num_sources; k++) {
-    gk_neut_species_projection_release(app, &src->proj_source[k]);
-  }
+  if (src->source_id) {
+    gkyl_array_release(src->source);
+    if (app->use_gpu) {
+      gkyl_array_release(src->source_host);
+    }
+    for (int k=0; k<src->num_sources; k++) {
+      gk_neut_species_projection_release(app, &src->proj_source[k]);
+    }
 
-  // Release moment data.
-  for (int i=0; i<src->num_diag_moments; ++i) {
-    gk_neut_species_moment_release(app, &src->moms[i]);
+    // Release moment data.
+    for (int i=0; i<src->num_diag_moments; ++i) {
+      gk_neut_species_moment_release(app, &src->moms[i]);
+    }
+    gkyl_free(src->moms);
+    gk_neut_species_moment_release(app, &src->integ_moms); 
+    if (app->use_gpu) {
+      gkyl_cu_free(src->red_integ_diag);
+      gkyl_cu_free(src->red_integ_diag_global);
+    }
+    else {
+      gkyl_free(src->red_integ_diag);
+      gkyl_free(src->red_integ_diag_global);
+    }  
+    gkyl_dynvec_release(src->integ_diag);
   }
-  gkyl_free(src->moms);
-  gk_neut_species_moment_release(app, &src->integ_moms); 
-  if (app->use_gpu) {
-    gkyl_cu_free(src->red_integ_diag);
-    gkyl_cu_free(src->red_integ_diag_global);
-  }
-  else {
-    gkyl_free(src->red_integ_diag);
-    gkyl_free(src->red_integ_diag_global);
-  }  
-  gkyl_dynvec_release(src->integ_diag);
 }

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -222,10 +222,10 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   // Determine collision type and initialize it.
   gks->lbo = (struct gk_lbo_collisions) { };
   gks->bgk = (struct gk_bgk_collisions) { };
-  if (gks->lbo.collision_id == GKYL_LBO_COLLISIONS) {
+  if (gks->info.collisions.collision_id == GKYL_LBO_COLLISIONS) {
     gk_species_lbo_init(app, gks, &gks->lbo);
   }
-  if (gks->bgk.collision_id == GKYL_BGK_COLLISIONS) {
+  if (gks->info.collisions.collision_id == GKYL_BGK_COLLISIONS) {
     gk_species_bgk_init(app, gks, &gks->bgk);
   }
 

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -218,38 +218,32 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
 
   // set species source id
   gks->src = (struct gk_source) { };
-  gks->source_id = gks->info.source.source_id;
   
   // Determine collision type and initialize it.
-  gks->collision_id = gks->info.collisions.collision_id;
   gks->lbo = (struct gk_lbo_collisions) { };
   gks->bgk = (struct gk_bgk_collisions) { };
-  if (gks->collision_id == GKYL_LBO_COLLISIONS) {
+  if (gks->lbo.collision_id == GKYL_LBO_COLLISIONS) {
     gk_species_lbo_init(app, gks, &gks->lbo);
   }
-  else if (gks->collision_id == GKYL_BGK_COLLISIONS) {
+  if (gks->bgk.collision_id == GKYL_BGK_COLLISIONS) {
     gk_species_bgk_init(app, gks, &gks->bgk);
   }
 
-  gks->has_reactions = false;
-  gks->has_neutral_reactions = false;
   gks->react = (struct gk_react) { };
   gks->react_neut = (struct gk_react) { };
   if (gks->info.react.num_react) {
-    gks->has_reactions = true;
     gk_species_react_init(app, gks, gks->info.react, &gks->react, true);
   }
   if (gks->info.react_neut.num_react) {
-    gks->has_neutral_reactions = true;
     gk_species_react_init(app, gks, gks->info.react_neut, &gks->react_neut, false);
   }
 
   // determine radiation type to use in gyrokinetic update
   gks->rad = (struct gk_rad_drag) { };
-  gks->radiation_id = gks->info.radiation.radiation_id;
 
   // initialize boundary fluxes for diagnostics and, if present,
   // ambipolar potential solve
+  gks->bflux = (struct gk_boundary_fluxes) { };
   gk_species_bflux_init(app, gks, &gks->bflux); 
 
   // vtsq_min
@@ -407,8 +401,7 @@ gk_species_apply_ic(gkyl_gyrokinetic_app *app, struct gk_species *gks, double t0
   gk_species_projection_calc(app, gks, &gks->proj_init, gks->f, t0);
 
   // We are pre-computing source for now as it is time-independent.
-  if (gks->source_id)
-    gk_species_source_calc(app, gks, &gks->src, t0);
+  gk_species_source_calc(app, gks, &gks->src, t0);
 }
 
 void
@@ -478,21 +471,21 @@ gk_species_rhs(gkyl_gyrokinetic_app *app, struct gk_species *species,
   gkyl_dg_updater_gyrokinetic_advance(species->slvr, &species->local, 
     fin, species->cflrate, rhs);
 
-  if (species->collision_id == GKYL_LBO_COLLISIONS)
+  if (species->lbo.collision_id == GKYL_LBO_COLLISIONS)
     gk_species_lbo_rhs(app, species, &species->lbo, fin, rhs);
-  else if (species->collision_id == GKYL_BGK_COLLISIONS)
+  if (species->bgk.collision_id == GKYL_BGK_COLLISIONS)
     gk_species_bgk_rhs(app, species, &species->bgk, fin, rhs);
   
   if (species->has_diffusion)
     gkyl_dg_updater_diffusion_gyrokinetic_advance(species->diff_slvr, &species->local, 
       species->diffD, app->gk_geom->jacobgeo_inv, fin, species->cflrate, rhs);
 
-  if (species->radiation_id == GKYL_GK_RADIATION)
+  if (species->rad.radiation_id == GKYL_GK_RADIATION)
     gk_species_radiation_rhs(app, species, &species->rad, fin, rhs);
 
-  if (species->has_reactions)
+  if (species->react.num_react)
     gk_species_react_rhs(app, species, &species->react, fin, rhs);
-  if (species->has_neutral_reactions)
+  if (species->react_neut.num_react)
     gk_species_react_rhs(app, species, &species->react_neut, fin, rhs);
   
   app->stat.nspecies_omega_cfl +=1;
@@ -574,7 +567,7 @@ void
 gk_species_coll_tm(gkyl_gyrokinetic_app *app)
 {
   for (int i=0; i<app->num_species; ++i) {
-    if (app->species[i].collision_id == GKYL_LBO_COLLISIONS) {
+    if (app->species[i].lbo.collision_id == GKYL_LBO_COLLISIONS) {
       struct gkyl_dg_updater_lbo_gyrokinetic_tm tm =
         gkyl_dg_updater_lbo_gyrokinetic_get_tm(app->species[i].lbo.coll_slvr);
       app->stat.species_lbo_coll_diff_tm[i] = tm.diff_tm;
@@ -637,21 +630,19 @@ gk_species_release(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
   gk_species_moment_release(app, &s->integ_moms); 
   gkyl_dynvec_release(s->integ_diag);
 
-  if (s->source_id) {
-    gk_species_source_release(app, &s->src);
-  }
+  gk_species_source_release(app, &s->src);
 
-  if (s->collision_id == GKYL_LBO_COLLISIONS)
+  if (s->lbo.collision_id == GKYL_LBO_COLLISIONS)
     gk_species_lbo_release(app, &s->lbo);
-  else if (s->collision_id == GKYL_BGK_COLLISIONS)
+  if (s->bgk.collision_id == GKYL_BGK_COLLISIONS)
     gk_species_bgk_release(app, &s->bgk);
 
-  if (s->has_reactions)
+  if (s->react.num_react)
     gk_species_react_release(app, &s->react);
-  if (s->has_neutral_reactions)
+  if (s->react_neut.num_react)
     gk_species_react_release(app, &s->react_neut);  
 
-  if (s->radiation_id == GKYL_GK_RADIATION) 
+  if (s->rad.radiation_id == GKYL_GK_RADIATION) 
     gk_species_radiation_release(app, &s->rad);
 
   gk_species_bflux_release(app, &s->bflux);

--- a/apps/gk_species_bgk.c
+++ b/apps/gk_species_bgk.c
@@ -5,6 +5,9 @@
 void 
 gk_species_bgk_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, struct gk_bgk_collisions *bgk)
 {
+  bgk->collision_id = s->info.collisions.collision_id;
+  bgk->write_diagnostics = s->info.collisions.write_diagnostics;
+
   int cdim = app->cdim, vdim = app->vdim;
   // allocate nu and initialize it
   bgk->nu_sum = mkarr(app->use_gpu, app->confBasis.num_basis, app->local_ext.volume);

--- a/apps/gk_species_lbo.c
+++ b/apps/gk_species_lbo.c
@@ -5,6 +5,9 @@
 void 
 gk_species_lbo_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, struct gk_lbo_collisions *lbo)
 {
+  lbo->collision_id = s->info.collisions.collision_id;
+  lbo->write_diagnostics = s->info.collisions.write_diagnostics;
+
   int cdim = app->cdim, vdim = app->vdim;
 
   // Allocate nu and initialize it.

--- a/apps/gk_species_radiation.c
+++ b/apps/gk_species_radiation.c
@@ -200,6 +200,16 @@ gk_species_radiation_moms(gkyl_gyrokinetic_app *app, const struct gk_species *sp
   gkyl_array_set_offset(rad->vtsq, 1.0, rad->prim_moms, 1*app->confBasis.num_basis);
 }
 
+void
+gk_species_radiation_integrated_moms(gkyl_gyrokinetic_app *app, struct gk_species *species,
+  struct gk_rad_drag *rad, const struct gkyl_array *fin[], const struct gkyl_array *fin_neut[])
+{
+  gkyl_array_clear(rad->integrated_moms_rhs, 0.0);
+  gkyl_dg_updater_rad_gyrokinetic_advance(rad->drag_slvr, &species->local,
+    species->f, species->cflrate, rad->integrated_moms_rhs);
+  gk_species_moment_calc(&rad->integ_moms, species->local, app->local, rad->integrated_moms_rhs);
+}
+
 // computes emissivity
 void
 gk_species_radiation_emissivity(gkyl_gyrokinetic_app *app, struct gk_species *species,
@@ -241,17 +251,6 @@ gk_species_radiation_emissivity(gkyl_gyrokinetic_app *app, struct gk_species *sp
     rad->emissivity[i] = gkyl_array_scale(rad->emissivity[i], -species->info.mass/2.0);
   }  
 }
-
-void
-gk_species_radiation_integrated_moms(gkyl_gyrokinetic_app *app, struct gk_species *species,
-				struct gk_rad_drag *rad, const struct gkyl_array *fin[], const struct gkyl_array *fin_neut[])
-{
-  gkyl_array_clear(rad->integrated_moms_rhs, 0.0);
-  gkyl_dg_updater_rad_gyrokinetic_advance(rad->drag_slvr, &species->local,
-    species->f, species->cflrate, rad->integrated_moms_rhs);
-  gk_species_moment_calc(&rad->integ_moms, species->local, app->local, rad->integrated_moms_rhs);
-}
-
 
 // updates the collision terms in the rhs
 void

--- a/apps/gk_species_radiation.c
+++ b/apps/gk_species_radiation.c
@@ -4,6 +4,8 @@
 void 
 gk_species_radiation_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, struct gk_rad_drag *rad)
 {
+  rad->radiation_id = s->info.radiation.radiation_id;
+
   int cdim = app->cdim, vdim = app->vdim;
   int pdim = cdim+vdim;
   // Cutoff below which radiation is set to 0. Set to 1eV. Keep the radiation from driving Te negative.

--- a/apps/gk_species_react.c
+++ b/apps/gk_species_react.c
@@ -409,7 +409,7 @@ gk_species_react_release(const struct gkyl_gyrokinetic_app *app, const struct gk
     gkyl_array_release(react->prim_vars_proj_inp[i]); 
     gkyl_array_release(react->prim_vars_se_proj_inp[i]); 
 
-    if(app->use_gpu)
+    if (app->use_gpu)
       gkyl_array_release(react->coeff_react_host[i]);
 
     if (react->react_id[i] == GKYL_REACT_IZ) 

--- a/apps/gk_species_source.c
+++ b/apps/gk_species_source.c
@@ -16,7 +16,6 @@ gk_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
       src->source_host = mkarr(false, app->basis.num_basis, s->local_ext.volume);
     }
 
-    src->write_source = s->info.source.write_source; // optional flag to write out source
     src->evolve = s->info.source.evolve; // Whether the source is time dependent.
 
     src->num_sources = s->info.source.num_sources;

--- a/apps/gk_species_source.c
+++ b/apps/gk_species_source.c
@@ -5,54 +5,60 @@ void
 gk_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s, 
   struct gk_source *src)
 {
-  int vdim = app->vdim;
-  // we need to ensure source has same shape as distribution function
-  src->source = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
-  src->source_id = s->source_id;
-  src->source_host = src->source;
-  if (app->use_gpu) {
-    src->source_host = mkarr(false, app->basis.num_basis, s->local_ext.volume);
-  }
+  src->source_id = s->info.source.source_id;
 
-  src->write_source = s->info.source.write_source; // optional flag to write out source
+  if (src->source_id) {
+    int vdim = app->vdim;
+    // we need to ensure source has same shape as distribution function
+    src->source = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
+    src->source_host = src->source;
+    if (app->use_gpu) {
+      src->source_host = mkarr(false, app->basis.num_basis, s->local_ext.volume);
+    }
 
-  src->num_sources = s->info.source.num_sources;
-  for (int k=0; k<s->info.source.num_sources; k++) {
-    gk_species_projection_init(app, s, s->info.source.projection[k], &src->proj_source[k]);
-  }
+    src->write_source = s->info.source.write_source; // optional flag to write out source
+    src->evolve = s->info.source.evolve; // Whether the source is time dependent.
 
-  // Allocate data and updaters for diagnostic moments.
-  src->num_diag_moments = s->info.num_diag_moments;
-  s->src.moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_moments]));
-  for (int m=0; m<src->num_diag_moments; ++m) {
-    gk_species_moment_init(app, s, &s->src.moms[m], s->info.diag_moments[m]);
-  }
+    src->num_sources = s->info.source.num_sources;
+    for (int k=0; k<s->info.source.num_sources; k++) {
+      gk_species_projection_init(app, s, s->info.source.projection[k], &src->proj_source[k]);
+    }
 
-  // Allocate data and updaters for integrated moments.
-  gk_species_moment_init(app, s, &s->src.integ_moms, "Integrated");
-  if (app->use_gpu) {
-    s->src.red_integ_diag = gkyl_cu_malloc(sizeof(double[vdim+2]));
-    s->src.red_integ_diag_global = gkyl_cu_malloc(sizeof(double[vdim+2]));
-  } 
-  else {
-    s->src.red_integ_diag = gkyl_malloc(sizeof(double[vdim+2]));
-    s->src.red_integ_diag_global = gkyl_malloc(sizeof(double[vdim+2]));
+    // Allocate data and updaters for diagnostic moments.
+    src->num_diag_moments = s->info.num_diag_moments;
+    s->src.moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_moments]));
+    for (int m=0; m<src->num_diag_moments; ++m) {
+      gk_species_moment_init(app, s, &s->src.moms[m], s->info.diag_moments[m]);
+    }
+
+    // Allocate data and updaters for integrated moments.
+    gk_species_moment_init(app, s, &s->src.integ_moms, "Integrated");
+    if (app->use_gpu) {
+      s->src.red_integ_diag = gkyl_cu_malloc(sizeof(double[vdim+2]));
+      s->src.red_integ_diag_global = gkyl_cu_malloc(sizeof(double[vdim+2]));
+    } 
+    else {
+      s->src.red_integ_diag = gkyl_malloc(sizeof(double[vdim+2]));
+      s->src.red_integ_diag_global = gkyl_malloc(sizeof(double[vdim+2]));
+    }
+    // allocate dynamic-vector to store all-reduced integrated moments 
+    s->src.integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, vdim+2);
+    s->src.is_first_integ_write_call = true;
   }
-  // allocate dynamic-vector to store all-reduced integrated moments 
-  s->src.integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, vdim+2);
-  s->src.is_first_integ_write_call = true;
 }
 
 void
 gk_species_source_calc(gkyl_gyrokinetic_app *app, const struct gk_species *s, 
   struct gk_source *src, double tm)
 {
-  struct gkyl_array *source_tmp = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
-  for (int k=0; k<s->info.source.num_sources; k++) {
-    gk_species_projection_calc(app, s, &src->proj_source[k], source_tmp, tm);
-    gkyl_array_accumulate(src->source, 1., source_tmp);
+  if (src->source_id) {
+    struct gkyl_array *source_tmp = mkarr(app->use_gpu, app->basis.num_basis, s->local_ext.volume);
+    for (int k=0; k<s->info.source.num_sources; k++) {
+      gk_species_projection_calc(app, s, &src->proj_source[k], source_tmp, tm);
+      gkyl_array_accumulate(src->source, 1., source_tmp);
+    }
+    gkyl_array_release(source_tmp);
   }
-  gkyl_array_release(source_tmp);
 }
 
 // Compute rhs of the source.
@@ -60,33 +66,37 @@ void
 gk_species_source_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *s,
   struct gk_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs)
 {
-  gkyl_array_accumulate(rhs, 1.0, src->source);
+  if (src->source_id) {
+    gkyl_array_accumulate(rhs, 1.0, src->source);
+  }
 }
 
 void
 gk_species_source_release(const struct gkyl_gyrokinetic_app *app, const struct gk_source *src)
 {
-  gkyl_array_release(src->source);
-  if (app->use_gpu) {
-    gkyl_array_release(src->source_host);
-  }
-  for (int k=0; k<src->num_sources; k++) {
-    gk_species_projection_release(app, &src->proj_source[k]);
-  }
+  if (src->source_id) {
+    gkyl_array_release(src->source);
+    if (app->use_gpu) {
+      gkyl_array_release(src->source_host);
+    }
+    for (int k=0; k<src->num_sources; k++) {
+      gk_species_projection_release(app, &src->proj_source[k]);
+    }
 
-  // Release moment data.
-  for (int i=0; i<src->num_diag_moments; ++i) {
-    gk_species_moment_release(app, &src->moms[i]);
+    // Release moment data.
+    for (int i=0; i<src->num_diag_moments; ++i) {
+      gk_species_moment_release(app, &src->moms[i]);
+    }
+    gkyl_free(src->moms);
+    gk_species_moment_release(app, &src->integ_moms); 
+    if (app->use_gpu) {
+      gkyl_cu_free(src->red_integ_diag);
+      gkyl_cu_free(src->red_integ_diag_global);
+    }
+    else {
+      gkyl_free(src->red_integ_diag);
+      gkyl_free(src->red_integ_diag_global);
+    }  
+    gkyl_dynvec_release(src->integ_diag);
   }
-  gkyl_free(src->moms);
-  gk_species_moment_release(app, &src->integ_moms); 
-  if (app->use_gpu) {
-    gkyl_cu_free(src->red_integ_diag);
-    gkyl_cu_free(src->red_integ_diag_global);
-  }
-  else {
-    gkyl_free(src->red_integ_diag);
-    gkyl_free(src->red_integ_diag_global);
-  }  
-  gkyl_dynvec_release(src->integ_diag);
 }

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -44,6 +44,8 @@ struct gkyl_gyrokinetic_projection {
 // Parameters for species collisions
 struct gkyl_gyrokinetic_collisions {
   enum gkyl_collision_id collision_id; // type of collisions (see gkyl_eqn_type.h)
+  enum gkyl_radiation_id radiation_id; // type of radiation
+  bool write_diagnostics; // Whether to write diagnostics out.
 
   void *ctx; // context for collision function
   // function for computing self-collision frequency
@@ -79,8 +81,9 @@ struct gkyl_gyrokinetic_diffusion {
 // Parameters for species source
 struct gkyl_gyrokinetic_source {
   enum gkyl_source_id source_id; // type of source
-  bool write_source; // optional parameter to write out source
   int num_sources;
+  bool write_source; // optional parameter to write out source distribution
+  bool evolve; // Whether the source is time dependent.
 
   // sources using projection routine
   struct gkyl_gyrokinetic_projection projection[GKYL_MAX_SOURCES];
@@ -393,6 +396,407 @@ void gkyl_gyrokinetic_app_apply_ic_neut_species(gkyl_gyrokinetic_app* app, int s
 void gkyl_gyrokinetic_app_apply_ic_cross_species(gkyl_gyrokinetic_app* app, int sidx, double t0);
 
 /**
+ * Write geometry file.
+ *
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_write_geometry(gkyl_gyrokinetic_app *app);
+
+/**
+ * Write field data to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_field(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
+ * Calculate integrated field energy
+ *
+ * @param tm Time at which integrated diagnostic are to be computed
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_calc_field_energy(gkyl_gyrokinetic_app* app, double tm);
+
+/**
+ * Write field energy to file. Field energy data is appended to the
+ * same file.
+ * 
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_write_field_energy(gkyl_gyrokinetic_app* app);
+
+/**
+ * Write species data to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write neutral species data to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for neutral species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments for a plasma species.
+ *
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_species_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm);
+
+/**
+ * Calculate integrated diagnostic moments for a neutral species.
+ *
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_neut_species_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm);
+
+/**
+ * Write integrated diagnostic moments for charged species to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ */
+void gkyl_gyrokinetic_app_write_species_integrated_mom(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write integrated diagnostic moments for neutral species to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ */
+void gkyl_gyrokinetic_app_write_neut_species_integrated_mom(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_source(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write neutral species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species_source(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_source_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for neutral species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species_source_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments for a plasma species source.
+ *
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_species_source_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm);
+
+/**
+ * Calculate integrated diagnostic moments for a neutral species source.
+ *
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_neut_species_source_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm);
+
+/**
+ * Write integrated diagnostic moments for charged species source to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ */
+void gkyl_gyrokinetic_app_write_species_source_integrated_mom(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write integrated diagnostic moments for neutral species source to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ */
+void gkyl_gyrokinetic_app_write_neut_species_source_integrated_mom(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write LBO collisional moments for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_lbo_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write integrated correct Maxwellian status of the species BGK distribution function
+ * to file. Correct Maxwellian status is appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ */
+void gkyl_gyrokinetic_app_write_species_bgk_max_corr_status(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write radiation drag coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_rad_drag(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write radiation emissivity of each species that species sidx collides with
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_rad_emissivity(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments of the radiation model.
+ *
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_species_rad_integrated_mom(gkyl_gyrokinetic_app *app, int sidx, double tm);
+
+/**
+ * Write integrated moments of radiation rhs for radiating species 
+ * 
+ * @param app App object.
+ * @param sidx Index of species from which to write radiation.
+ */
+void gkyl_gyrokinetic_app_write_species_rad_integrated_mom(gkyl_gyrokinetic_app *app, int sidx);
+
+/**
+ * Write iz react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_iz_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write iz react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_iz_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write recomb react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_recomb_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write recomb react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_recomb_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write cx react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_cx_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write the phase-space diagnostics for a charged species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_phase(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the phase-space diagnostics for a neutral species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species_phase(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the conf-space diagnostics for a charged species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_species_conf(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the conf-space diagnostics for a neutral species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_neut_species_conf(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for all species (including sources) to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app *app, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments for all species (including sources).
+ *
+ * @param app App object.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_app_calc_integrated_mom(gkyl_gyrokinetic_app* app, double tm);
+
+/**
+ * Write integrated diagnostic moments for all species (including sources)
+ * to file. Integrated moments are appended to the same file.
+ * 
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_write_integrated_mom(gkyl_gyrokinetic_app *app);
+
+/**
+ * Write phase space diagnostics to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_phase(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
+ * Write configuration space diagnostics to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_conf(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
+ * Write both conf and phase-space diagnostics to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
+ * Write stats to file. Data is written in json format.
+ *
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_stat_write(gkyl_gyrokinetic_app* app);
+
+/**
+ * Read geometry file.
+ *
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_read_geometry(gkyl_gyrokinetic_app *app);
+
+/**
  * Initialize field from file
  *
  * @param app App object
@@ -460,288 +864,6 @@ gkyl_gyrokinetic_app_from_frame_species(gkyl_gyrokinetic_app *app, int sidx, int
  */
 struct gkyl_app_restart_status
 gkyl_gyrokinetic_app_from_frame_neut_species(gkyl_gyrokinetic_app *app, int sidx, int frame);
-
-
-/**
- * Calculate diagnostic moments.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_calc_mom(gkyl_gyrokinetic_app *app);
-
-/**
- * Calculate integrated diagnostic moments for plasma species (including sources).
- *
- * @param tm Time at which integrated diagnostics are to be computed
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_calc_integrated_mom(gkyl_gyrokinetic_app* app, double tm);
-
-/**
- * Calculate integrated diagnostic moments for neutral species (including sources).
- *
- * @param tm Time at which integrated diagnostics are to be computed
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_calc_integrated_neut_mom(gkyl_gyrokinetic_app* app, double tm);
-
-/**
- * Calculate integrated field energy
- *
- * @param tm Time at which integrated diagnostic are to be computed
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_calc_field_energy(gkyl_gyrokinetic_app* app, double tm);
-
-/**
- * Write configuration space diagnostics to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_conf(gkyl_gyrokinetic_app* app, double tm, int frame);
-
-/**
- * Write phase space diagnostics to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_phase(gkyl_gyrokinetic_app* app, double tm, int frame);
-
-/**
- * Write field and species data to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write(gkyl_gyrokinetic_app* app, double tm, int frame);
-
-/**
- * Write field data to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_field(gkyl_gyrokinetic_app* app, double tm, int frame);
-
-/**
- * Write species data to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
-
-
-/**
- * Write neutral species data to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
-
-/**
- * Write source species data to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_source_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
-
-/**
- * Write source neutral species data to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_source_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame);
-
-/**
- * Write collisional moments for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_coll_mom(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
-
-/**
- * Write radiation drag coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_rad_drag(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
-
-/**
- * Write radiation emissivity of each species that species sidx collides with
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_rad_emissivity(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
-
-/**
- * Calculate integrated diagnostic moments of the radiation model.
- *
- * @param tm Time at which integrated diagnostics are to be computed
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_calc_rad_integrated_mom(gkyl_gyrokinetic_app *app, double tm);
-
-/**
- * Write integrated moments of radiation rhs for radiating species 
- * 
- * @param app App object.
- * @param sidx Index of species from which to write radiation.
- * @param tm Time-stamp
- */
-void gkyl_gyrokinetic_app_write_rad_integrated_mom(gkyl_gyrokinetic_app *app);
-
-/**
- * Write iz react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_iz_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write recomb react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_recomb_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write iz react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_iz_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write recomb react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_recomb_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write cx react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_cx_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write diagnostic moments for species to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app *app, double tm, int frame);
-
-/**
- * Write diagnostic moments for species source to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_app_write_source_mom(gkyl_gyrokinetic_app *app, double tm, int frame);
-
-/**
- * Write integrated diagnostic moments for species to file. Integrated
- * moments are appended to the same file.
- * 
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_write_integrated_mom(gkyl_gyrokinetic_app *app);
-
-/**
- * Write integrated diagnostic moments for sources to file. Integrated
- * moments are appended to the same file.
- * 
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_write_integrated_source_mom(gkyl_gyrokinetic_app *app);
-
-/**
- * Write field energy to file. Field energy data is appended to the
- * same file.
- * 
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_write_field_energy(gkyl_gyrokinetic_app* app);
-
-/**
- * Write integrated correct Maxwellian status of the species distribution function to file. Correct
- * Maxwellian status is appended to the same file.
- * 
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_write_max_corr_status(gkyl_gyrokinetic_app *app);
-
-/**
- * Write geometry file.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_write_geometry(gkyl_gyrokinetic_app *app);
-
-/**
- * Read geometry file.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_read_geometry(gkyl_gyrokinetic_app *app);
-
-/**
- * Write stats to file. Data is written in json format.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_app_stat_write(gkyl_gyrokinetic_app* app);
 
 /**
  * Write output to console: this is mainly for diagnostic messages the

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -583,14 +583,21 @@ void gkyl_gyrokinetic_app_write_rad_drag(gkyl_gyrokinetic_app *app, int sidx, do
 void gkyl_gyrokinetic_app_write_rad_emissivity(gkyl_gyrokinetic_app *app, int sidx, double tm, int frame);
 
 /**
+ * Calculate integrated diagnostic moments of the radiation model.
+ *
+ * @param tm Time at which integrated diagnostics are to be computed
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_app_calc_rad_integrated_mom(gkyl_gyrokinetic_app *app, double tm);
+
+/**
  * Write integrated moments of radiation rhs for radiating species 
  * 
  * @param app App object.
  * @param sidx Index of species from which to write radiation.
  * @param tm Time-stamp
  */
-void gkyl_gyrokinetic_app_write_rad_integrated_moms(gkyl_gyrokinetic_app *app, int sidx, double tm);
-
+void gkyl_gyrokinetic_app_write_rad_integrated_mom(gkyl_gyrokinetic_app *app);
 
 /**
  * Write iz react rate coefficients for species to file.

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -82,7 +82,6 @@ struct gkyl_gyrokinetic_diffusion {
 struct gkyl_gyrokinetic_source {
   enum gkyl_source_id source_id; // type of source
   int num_sources;
-  bool write_source; // optional parameter to write out source distribution
   bool evolve; // Whether the source is time dependent.
 
   // sources using projection routine

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -494,6 +494,24 @@ void gkyl_gyrokinetic_app_calc_integrated_neut_mom(gkyl_gyrokinetic_app* app, do
 void gkyl_gyrokinetic_app_calc_field_energy(gkyl_gyrokinetic_app* app, double tm);
 
 /**
+ * Write configuration space diagnostics to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_conf(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
+ * Write phase space diagnostics to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_app_write_phase(gkyl_gyrokinetic_app* app, double tm, int frame);
+
+/**
  * Write field and species data to file.
  * 
  * @param app App object.

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -300,27 +300,12 @@ void gkyl_gyrokinetic_multib_app_cout(const gkyl_gyrokinetic_multib_app* app, FI
 void gkyl_gyrokinetic_multib_app_write_topo(const gkyl_gyrokinetic_multib_app* app);
 
 /**
- * Calculate diagnostic moments.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_multib_app_calc_mom(gkyl_gyrokinetic_multib_app *app);
-
-/**
  * Calculate integrated diagnostic moments for plasma species (including sources).
  *
  * @param tm Time at which integrated diagnostics are to be computed
  * @param app App object.
  */
 void gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app* app, double tm);
-
-/**
- * Calculate integrated diagnostic moments for neutral species (including sources).
- *
- * @param tm Time at which integrated diagnostics are to be computed
- * @param app App object.
- */
-void gkyl_gyrokinetic_multib_app_calc_integrated_neut_mom(gkyl_gyrokinetic_multib_app* app, double tm);
 
 /**
  * Calculate integrated field energy

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -174,6 +174,7 @@ struct gk_species_moment {
 };
 
 struct gk_rad_drag {  
+  enum gkyl_radiation_id radiation_id; // type of radiation
   int num_cross_collisions; // number of species we cross-collide with
   struct gk_species *collide_with[GKYL_MAX_SPECIES]; // pointers to cross-species we collide with
   struct gk_neut_species *collide_with_neut[GKYL_MAX_SPECIES]; // pointers to neutral cross-species we collide with
@@ -228,6 +229,8 @@ struct gk_rad_drag {
 struct gk_species;
 
 struct gk_lbo_collisions {  
+  enum gkyl_collision_id collision_id; // type of collisions
+  bool write_diagnostics; // Whether to write diagnostics out.
   struct gkyl_array *boundary_corrections; // LBO boundary corrections
   struct gkyl_mom_calc_bcorr *bcorr_calc; // LBO boundary corrections calculator
   struct gkyl_array *nu_sum, *prim_moms, *nu_prim_moms; // LBO primitive moments
@@ -270,6 +273,8 @@ struct gk_lbo_collisions {
 };
 
 struct gk_bgk_collisions {  
+  enum gkyl_collision_id collision_id; // type of collisions
+  bool write_diagnostics; // Whether to write diagnostics out.
   struct gkyl_array *nu_sum; // BGK collision frequency 
   struct gkyl_array *nu_sum_host; // BGK collision frequency host-side for I/O
   struct gkyl_array *self_nu; // BGK self-collision frequency
@@ -430,6 +435,7 @@ struct gk_proj {
 struct gk_source {
   enum gkyl_source_id source_id; // type of source
   bool write_source; // optional parameter to write out source distribution
+  bool evolve; // Whether the source is time dependent.
   struct gkyl_array *source; // applied source
   struct gkyl_array *source_host; // host copy for use in IO and projecting
   struct gk_proj proj_source[GKYL_MAX_SOURCES]; // projector for source
@@ -524,7 +530,6 @@ struct gk_species {
 
   struct gk_proj proj_init; // projector for initial conditions
 
-  enum gkyl_source_id source_id; // type of source
   struct gk_source src; // applied source
 
   // boundary fluxes
@@ -532,19 +537,15 @@ struct gk_species {
 
   // collisions
   struct {
-    enum gkyl_collision_id collision_id; // type of collisions
     union {
       struct gk_lbo_collisions lbo; // LBO collisions object
       struct gk_bgk_collisions bgk; // BGK collisions object
     };      
   };
 
-  bool has_reactions; 
-  bool has_neutral_reactions; 
   struct gk_react react; // reaction object for reactions with other plasma species
   struct gk_react react_neut; // reaction object for reactions with neutral species
 
-  enum gkyl_radiation_id radiation_id; // type of radiation
   struct gk_rad_drag rad; // radiation object
 
   // Gyrokinetic diffusion.
@@ -629,10 +630,8 @@ struct gk_neut_species {
 
   struct gk_proj proj_init; // projector for initial conditions
 
-  enum gkyl_source_id source_id; // type of source
   struct gk_source src; // applied source
 
-  bool has_neutral_reactions;
   struct gk_react react_neut; // reaction object
 
   // vtsq_min

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -434,7 +434,6 @@ struct gk_proj {
 
 struct gk_source {
   enum gkyl_source_id source_id; // type of source
-  bool write_source; // optional parameter to write out source distribution
   bool evolve; // Whether the source is time dependent.
   struct gkyl_array *source; // applied source
   struct gkyl_array *source_host; // host copy for use in IO and projecting

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -403,7 +403,7 @@ gkyl_gyrokinetic_app_new(struct gkyl_gk *gk)
       gk_species_react_cross_init(app, &app->species[i], &gk_s->react_neut);
     }
     // initial radiation (e.g., line radiation from cross-collisions of electrons with ions)
-    if (gk_s->rad.radiation_id == GKYL_GK_RADIATION) {
+    if (gk_s->info.radiation.radiation_id == GKYL_GK_RADIATION) {
       gk_species_radiation_init(app, &app->species[i], &gk_s->rad);
     }
   }
@@ -1972,31 +1972,33 @@ forward_euler(gkyl_gyrokinetic_app* app, double tcurr, double dt,
   // Compute necessary moments for cross-species collisions.
   // Needs to be done after self-collisions moments, so separate loop over species.
   for (int i=0; i<app->num_species; ++i) {
-    if (app->species[i].lbo.collision_id == GKYL_LBO_COLLISIONS) { 
-      if (app->species[i].lbo.num_cross_collisions) {
+    struct gk_species *gk_s = &app->species[i];
+
+    if (gk_s->lbo.collision_id == GKYL_LBO_COLLISIONS) { 
+      if (gk_s->lbo.num_cross_collisions) {
         gk_species_lbo_cross_moms(app, &app->species[i], 
-          &app->species[i].lbo, fin[i]);        
+          &gk_s->lbo, fin[i]);        
       }
     }
-    if (app->species[i].bgk.collision_id == GKYL_BGK_COLLISIONS) {
-      if (app->species[i].bgk.num_cross_collisions) {
+    if (gk_s->bgk.collision_id == GKYL_BGK_COLLISIONS) {
+      if (gk_s->bgk.num_cross_collisions) {
         gk_species_bgk_cross_moms(app, &app->species[i], 
-          &app->species[i].bgk, fin[i]);        
+          &gk_s->bgk, fin[i]);        
       }
     }
     // Compute reaction rates (e.g., ionization, recombination, or charge exchange).
-    if (app->species[i].react.num_react) {
+    if (gk_s->react.num_react) {
       gk_species_react_cross_moms(app, &app->species[i], 
-        &app->species[i].react, fin[i], fin, fin_neut);
+        &gk_s->react, fin[i], fin, fin_neut);
     }
-    if (app->species[i].react_neut.num_react) {
+    if (gk_s->react_neut.num_react) {
       gk_species_react_cross_moms(app, &app->species[i], 
-        &app->species[i].react_neut, fin[i], fin, fin_neut);
+        &gk_s->react_neut, fin[i], fin, fin_neut);
     }
     // Compute necessary drag coefficients for radiation operator.
-    if (app->species[i].rad.radiation_id == GKYL_GK_RADIATION) {
+    if (gk_s->rad.radiation_id == GKYL_GK_RADIATION) {
       gk_species_radiation_moms(app, &app->species[i], 
-        &app->species[i].rad, fin, fin_neut);
+        &gk_s->rad, fin, fin_neut);
     }
   }
 

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -79,6 +79,9 @@ gyrokinetic_array_meta_new(struct gyrokinetic_output_meta meta)
   mpack_write_cstr(&writer, "basisType");
   mpack_write_cstr(&writer, meta.basis_type);
 
+  mpack_write_cstr(&writer, "Git_commit_hash");
+  mpack_write_cstr(&writer, GIT_COMMIT_ID);
+
   mpack_complete_map(&writer);
 
   int status = mpack_writer_destroy(&writer);

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -591,26 +591,11 @@ gkyl_gyrokinetic_multib_app_write_topo(const gkyl_gyrokinetic_multib_app* app)
   }
 }
 
-void gkyl_gyrokinetic_multib_app_calc_mom(gkyl_gyrokinetic_multib_app *app)
-{
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_calc_mom(app->singleb_apps[i]);
-  }
-}
-
 void gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app* app, double tm)
 {
   for (int i=0; i<app->num_local_blocks; ++i) {
     gkyl_gyrokinetic_app_calc_integrated_mom(app->singleb_apps[i], tm);
   }
-  // TO DO: REDUCE ACROSS BLOCKS
-}
-
-void gkyl_gyrokinetic_multib_app_calc_integrated_neut_mom(gkyl_gyrokinetic_multib_app* app, double tm)
-{
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_calc_integrated_neut_mom(app->singleb_apps[i], tm);
-  }  
   // TO DO: REDUCE ACROSS BLOCKS
 }
 

--- a/regression/rt_gk_ar_react_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_ar_react_nonuniformv_1x2v_p1.c
@@ -349,10 +349,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
     
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
     
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_asdex_3x2v_p1.c
+++ b/regression/rt_gk_asdex_3x2v_p1.c
@@ -387,7 +387,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -440,7 +439,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_asdex_3x2v_p1.c
+++ b/regression/rt_gk_asdex_3x2v_p1.c
@@ -325,11 +325,10 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
+    gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
+
+    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
   }
 }

--- a/regression/rt_gk_bgk_3x2v_p1.c
+++ b/regression/rt_gk_bgk_3x2v_p1.c
@@ -440,7 +440,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -501,7 +500,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_bgk_3x2v_p1.c
+++ b/regression/rt_gk_bgk_3x2v_p1.c
@@ -374,10 +374,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_bgk_cross_relax_1x2v_p1.c
+++ b/regression/rt_gk_bgk_cross_relax_1x2v_p1.c
@@ -287,10 +287,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_bgk_periodic_sod_shock_1x2v_p1.c
+++ b/regression/rt_gk_bgk_periodic_sod_shock_1x2v_p1.c
@@ -181,10 +181,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_bgk_relax_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_1x2v_p1.c
@@ -218,10 +218,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_bgk_relax_bimaxwellian_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_bimaxwellian_1x2v_p1.c
@@ -64,6 +64,9 @@ struct sheath_ctx
 
   double t_end; // Final simulation time.
   int num_frames; // Number of output frames.
+  int int_diag_calc_num; // Number of integrated diagnostics computations (=INT_MAX for every step).
+  double dt_failure_tol; // Minimum allowable fraction of initial time-step.
+  int num_failures_max; // Maximum allowable number of consecutive small time-steps.
 };
 
 struct sheath_ctx
@@ -130,6 +133,9 @@ create_ctx(void)
 
   double t_end = 1.0/nu_elc; // Final simulation time.
   int num_frames = 1; // Number of output frames.
+  int int_diag_calc_num = num_frames*100;
+  double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
+  int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
   
   struct sheath_ctx ctx = {
     .pi = pi,
@@ -171,6 +177,9 @@ create_ctx(void)
     .Lmu_ion = Lmu_ion,
     .t_end = t_end,
     .num_frames = num_frames,
+    .int_diag_calc_num = int_diag_calc_num,
+    .dt_failure_tol = dt_failure_tol,
+    .num_failures_max = num_failures_max,
   };
 
   return ctx;
@@ -287,12 +296,26 @@ bmag_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *ctx)
 }
 
 void
-write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr)
+calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr, bool force_calc)
 {
-  if (gkyl_tm_trigger_check_and_bump(iot, t_curr)) {
-    gkyl_gyrokinetic_app_write(app, t_curr, iot->curr - 1);
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, iot->curr - 1);
+  if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
+    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+  }
+}
+
+void
+write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr, bool force_write)
+{
+  bool trig_now = gkyl_tm_trigger_check_and_bump(iot, t_curr);
+  if (trig_now || force_write) {
+    int frame = (!trig_now) && force_write? iot->curr : iot->curr-1;
+
+    gkyl_gyrokinetic_app_write(app, t_curr, frame);
+
+    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
+
+    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_app_write_integrated_mom(app);
   }
 }
 
@@ -436,30 +459,50 @@ main(int argc, char **argv)
   gkyl_gyrokinetic_app *app = gkyl_gyrokinetic_app_new(&app_inp);
 
   // Initial and final simulation times.
+  int frame_curr = 0;
   double t_curr = 0.0, t_end = ctx.t_end;
-
-  // Create trigger for IO.
-  int num_frames = ctx.num_frames;
-  struct gkyl_tm_trigger io_trig = { .dt = t_end / num_frames };
-
   // Initialize simulation.
-  gkyl_gyrokinetic_app_apply_ic(app, t_curr);
-  write_data(&io_trig, app, t_curr);
+  if (app_args.is_restart) {
+    struct gkyl_app_restart_status status = gkyl_gyrokinetic_app_read_from_frame(app, app_args.restart_frame);
 
-  gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-  gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    if (status.io_status != GKYL_ARRAY_RIO_SUCCESS) {
+      gkyl_gyrokinetic_app_cout(app, stderr, "*** Failed to read restart file! (%s)\n",
+        gkyl_array_rio_status_msg(status.io_status));
+      goto freeresources;
+    }
+
+    frame_curr = status.frame;
+    t_curr = status.stime;
+
+    gkyl_gyrokinetic_app_cout(app, stdout, "Restarting from frame %d", frame_curr);
+    gkyl_gyrokinetic_app_cout(app, stdout, " at time = %g\n", t_curr);
+  }
+  else {
+    gkyl_gyrokinetic_app_apply_ic(app, t_curr);
+  }
+
+  // Create triggers for IO.
+  int num_frames = ctx.num_frames, num_int_diag_calc = ctx.int_diag_calc_num;
+  struct gkyl_tm_trigger trig_write = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_calc_intdiag = { .dt = t_end/GKYL_MAX2(num_frames, num_int_diag_calc),
+    .tcurr = t_curr, .curr = frame_curr };
+
+  // Write out ICs (if restart, it overwrites the restart frame).
+  calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, false);
+  write_data(&trig_write, app, t_curr, false);
 
   // Compute initial guess of maximum stable time-step.
   double dt = t_end - t_curr;
+
+  // Initialize small time-step check.
+  double dt_init = -1.0, dt_failure_tol = ctx.dt_failure_tol;
+  int num_failures = 0, num_failures_max = ctx.num_failures_max;
 
   long step = 1;
   while ((t_curr < t_end) && (step <= app_args.num_steps)) {
     gkyl_gyrokinetic_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, t_curr);
     struct gkyl_update_status status = gkyl_gyrokinetic_update(app, dt);
     gkyl_gyrokinetic_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
-
-    gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
 
     if (!status.success) {
       gkyl_gyrokinetic_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
@@ -469,15 +512,33 @@ main(int argc, char **argv)
     t_curr += status.dt_actual;
     dt = status.dt_suggested;
 
-    write_data(&io_trig, app, t_curr);
+    calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, t_curr > t_end);
+    write_data(&trig_write, app, t_curr, t_curr > t_end);
+
+    if (dt_init < 0.0) {
+      dt_init = status.dt_actual;
+    }
+    else if (status.dt_actual < dt_failure_tol * dt_init) {
+      num_failures += 1;
+
+      gkyl_gyrokinetic_app_cout(app, stdout, "WARNING: Time-step dt = %g", status.dt_actual);
+      gkyl_gyrokinetic_app_cout(app, stdout, " is below %g*dt_init ...", dt_failure_tol);
+      gkyl_gyrokinetic_app_cout(app, stdout, " num_failures = %d\n", num_failures);
+      if (num_failures >= num_failures_max) {
+        gkyl_gyrokinetic_app_cout(app, stdout, "ERROR: Time-step was below %g*dt_init ", dt_failure_tol);
+        gkyl_gyrokinetic_app_cout(app, stdout, "%d consecutive times. Aborting simulation ....\n", num_failures_max);
+        calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, true);
+        write_data(&trig_write, app, t_curr, true);
+        break;
+      }
+    }
+    else {
+      num_failures = 0;
+    }
 
     step += 1;
   }
 
-  gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-  gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
-  
-  write_data(&io_trig, app, t_curr);
   gkyl_gyrokinetic_app_stat_write(app);
   
   struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_app_stat(app);
@@ -500,6 +561,7 @@ main(int argc, char **argv)
   gkyl_gyrokinetic_app_cout(app, stdout, "Number of write calls %ld,\n", stat.nio);
   gkyl_gyrokinetic_app_cout(app, stdout, "IO time took %g secs \n", stat.io_tm);
 
+  freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
   gkyl_gyrokinetic_comms_release(comm);

--- a/regression/rt_gk_bgk_relax_bimaxwellian_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_bgk_relax_bimaxwellian_nonuniformv_1x2v_p1.c
@@ -62,8 +62,12 @@ struct sheath_ctx
   double Lmu_elc; // Domain size (electron velocity space: magnetic moment direction).
   double Lvpar_ion; // Domain size (ion velocity space: parallel velocity direction).
   double Lmu_ion; // Domain size (ion velocity space: magnetic moment direction).
+
   double t_end; // Final simulation time.
   int num_frames; // Number of output frames.
+  int int_diag_calc_num; // Number of integrated diagnostics computations (=INT_MAX for every step).
+  double dt_failure_tol; // Minimum allowable fraction of initial time-step.
+  int num_failures_max; // Maximum allowable number of consecutive small time-steps.
 };
 
 struct sheath_ctx
@@ -131,6 +135,9 @@ create_ctx(void)
 
   double t_end = 1.0/nu_elc; // Final simulation time.
   int num_frames = 1; // Number of output frames.
+  int int_diag_calc_num = num_frames*100;
+  double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
+  int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
   
   struct sheath_ctx ctx = {
     .pi = pi,
@@ -172,6 +179,9 @@ create_ctx(void)
     .Lmu_ion = Lmu_ion,
     .t_end = t_end,
     .num_frames = num_frames,
+    .int_diag_calc_num = int_diag_calc_num,
+    .dt_failure_tol = dt_failure_tol,
+    .num_failures_max = num_failures_max,
   };
 
   return ctx;
@@ -306,12 +316,26 @@ bmag_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *ctx)
 }
 
 void
-write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr)
+calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr, bool force_calc)
 {
-  if (gkyl_tm_trigger_check_and_bump(iot, t_curr)) {
-    gkyl_gyrokinetic_app_write(app, t_curr, iot->curr - 1);
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, iot->curr - 1);
+  if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
+    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+  }
+}
+
+void
+write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr, bool force_write)
+{
+  bool trig_now = gkyl_tm_trigger_check_and_bump(iot, t_curr);
+  if (trig_now || force_write) {
+    int frame = (!trig_now) && force_write? iot->curr : iot->curr-1;
+
+    gkyl_gyrokinetic_app_write(app, t_curr, frame);
+
+    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
+
+    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_app_write_integrated_mom(app);
   }
 }
 
@@ -462,30 +486,50 @@ main(int argc, char **argv)
   gkyl_gyrokinetic_app *app = gkyl_gyrokinetic_app_new(&app_inp);
 
   // Initial and final simulation times.
+  int frame_curr = 0;
   double t_curr = 0.0, t_end = ctx.t_end;
-
-  // Create trigger for IO.
-  int num_frames = ctx.num_frames;
-  struct gkyl_tm_trigger io_trig = { .dt = t_end / num_frames };
-
   // Initialize simulation.
-  gkyl_gyrokinetic_app_apply_ic(app, t_curr);
-  write_data(&io_trig, app, t_curr);
+  if (app_args.is_restart) {
+    struct gkyl_app_restart_status status = gkyl_gyrokinetic_app_read_from_frame(app, app_args.restart_frame);
 
-  gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-  gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    if (status.io_status != GKYL_ARRAY_RIO_SUCCESS) {
+      gkyl_gyrokinetic_app_cout(app, stderr, "*** Failed to read restart file! (%s)\n",
+        gkyl_array_rio_status_msg(status.io_status));
+      goto freeresources;
+    }
+
+    frame_curr = status.frame;
+    t_curr = status.stime;
+
+    gkyl_gyrokinetic_app_cout(app, stdout, "Restarting from frame %d", frame_curr);
+    gkyl_gyrokinetic_app_cout(app, stdout, " at time = %g\n", t_curr);
+  }
+  else {
+    gkyl_gyrokinetic_app_apply_ic(app, t_curr);
+  }
+
+  // Create triggers for IO.
+  int num_frames = ctx.num_frames, num_int_diag_calc = ctx.int_diag_calc_num;
+  struct gkyl_tm_trigger trig_write = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_calc_intdiag = { .dt = t_end/GKYL_MAX2(num_frames, num_int_diag_calc),
+    .tcurr = t_curr, .curr = frame_curr };
+
+  // Write out ICs (if restart, it overwrites the restart frame).
+  calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, false);
+  write_data(&trig_write, app, t_curr, false);
 
   // Compute initial guess of maximum stable time-step.
   double dt = t_end - t_curr;
+
+  // Initialize small time-step check.
+  double dt_init = -1.0, dt_failure_tol = ctx.dt_failure_tol;
+  int num_failures = 0, num_failures_max = ctx.num_failures_max;
 
   long step = 1;
   while ((t_curr < t_end) && (step <= app_args.num_steps)) {
     gkyl_gyrokinetic_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, t_curr);
     struct gkyl_update_status status = gkyl_gyrokinetic_update(app, dt);
     gkyl_gyrokinetic_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
-
-    gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-    gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
 
     if (!status.success) {
       gkyl_gyrokinetic_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
@@ -495,15 +539,33 @@ main(int argc, char **argv)
     t_curr += status.dt_actual;
     dt = status.dt_suggested;
 
-    write_data(&io_trig, app, t_curr);
+    calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, t_curr > t_end);
+    write_data(&trig_write, app, t_curr, t_curr > t_end);
+
+    if (dt_init < 0.0) {
+      dt_init = status.dt_actual;
+    }
+    else if (status.dt_actual < dt_failure_tol * dt_init) {
+      num_failures += 1;
+
+      gkyl_gyrokinetic_app_cout(app, stdout, "WARNING: Time-step dt = %g", status.dt_actual);
+      gkyl_gyrokinetic_app_cout(app, stdout, " is below %g*dt_init ...", dt_failure_tol);
+      gkyl_gyrokinetic_app_cout(app, stdout, " num_failures = %d\n", num_failures);
+      if (num_failures >= num_failures_max) {
+        gkyl_gyrokinetic_app_cout(app, stdout, "ERROR: Time-step was below %g*dt_init ", dt_failure_tol);
+        gkyl_gyrokinetic_app_cout(app, stdout, "%d consecutive times. Aborting simulation ....\n", num_failures_max);
+        calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, true);
+        write_data(&trig_write, app, t_curr, true);
+        break;
+      }
+    }
+    else {
+      num_failures = 0;
+    }
 
     step += 1;
   }
 
-  gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
-  gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
-  
-  write_data(&io_trig, app, t_curr);
   gkyl_gyrokinetic_app_stat_write(app);
   
   struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_app_stat(app);
@@ -526,6 +588,7 @@ main(int argc, char **argv)
   gkyl_gyrokinetic_app_cout(app, stdout, "Number of write calls %ld,\n", stat.nio);
   gkyl_gyrokinetic_app_cout(app, stdout, "IO time took %g secs \n", stat.io_tm);
 
+  freeresources:
   // Free resources after simulation completion.
   gkyl_gyrokinetic_app_release(app);
   gkyl_gyrokinetic_comms_release(comm);

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -606,7 +606,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = false,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -679,7 +678,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = false,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -542,10 +542,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_ion_sound_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_1x2v_p1.c
@@ -116,10 +116,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_adiabatic_elc_1x2v_p1.c
@@ -206,10 +206,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_ion_sound_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_ion_sound_nonuniformv_1x2v_p1.c
@@ -121,10 +121,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lapd_cart_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cart_3x2v_p1.c
@@ -374,10 +374,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lapd_cart_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cart_3x2v_p1.c
@@ -437,7 +437,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -495,7 +494,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_lapd_cyl_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cyl_3x2v_p1.c
@@ -370,10 +370,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lapd_cyl_3x2v_p1.c
+++ b/regression/rt_gk_lapd_cyl_3x2v_p1.c
@@ -435,7 +435,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -494,7 +493,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_lbo_cross_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_cross_relax_1x2v_p1.c
@@ -287,10 +287,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lbo_relax_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_1x2v_p1.c
@@ -219,10 +219,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_1x2v_p1.c
@@ -353,10 +353,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_bimaxwellian_nonuniformv_3x2v_p1.c
@@ -365,10 +365,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lbo_relax_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_nonuniformv_1x2v_p1.c
@@ -235,10 +235,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
+++ b/regression/rt_gk_lbo_relax_varnu_1x2v_p1.c
@@ -229,10 +229,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_li_react_3x2v_p1.c
+++ b/regression/rt_gk_li_react_3x2v_p1.c
@@ -424,10 +424,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_li_react_3x2v_p1.c
+++ b/regression/rt_gk_li_react_3x2v_p1.c
@@ -486,7 +486,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -563,7 +562,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -608,7 +606,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -679,7 +676,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_li_react_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_li_react_nonuniformv_3x2v_p1.c
@@ -447,10 +447,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_li_react_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_li_react_nonuniformv_3x2v_p1.c
@@ -514,7 +514,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -591,7 +590,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -636,7 +634,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -707,7 +704,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources=1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_ltx_1x2v_p1.c
+++ b/regression/rt_gk_ltx_1x2v_p1.c
@@ -511,7 +511,6 @@ int main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -560,7 +559,6 @@ int main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_ltx_1x2v_p1.c
+++ b/regression/rt_gk_ltx_1x2v_p1.c
@@ -450,10 +450,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
@@ -460,7 +460,6 @@ int main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
@@ -402,10 +402,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_mdpx_cart_3x2v_p1.c
+++ b/regression/rt_gk_mdpx_cart_3x2v_p1.c
@@ -281,10 +281,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
@@ -713,10 +713,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_1x2v_p1.c
@@ -776,7 +776,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
@@ -864,7 +864,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
+++ b/regression/rt_gk_mirror_boltz_elc_nonuniformz_1x2v_p1.c
@@ -800,10 +800,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
@@ -693,10 +693,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
+++ b/regression/rt_gk_mirror_kinetic_elc_1x2v_p1.c
@@ -757,7 +757,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -808,7 +807,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_rad_1x2v_p1.c
+++ b/regression/rt_gk_rad_1x2v_p1.c
@@ -252,7 +252,6 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
-    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 
@@ -265,16 +264,11 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
-    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 

--- a/regression/rt_gk_rad_1x2v_p1.c
+++ b/regression/rt_gk_rad_1x2v_p1.c
@@ -252,6 +252,7 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 
@@ -273,6 +274,7 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
+    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 

--- a/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
@@ -268,7 +268,6 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
-    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 
@@ -281,16 +280,11 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
-    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 

--- a/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_rad_nonuniformv_1x2v_p1.c
@@ -268,6 +268,7 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 
@@ -289,6 +290,7 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
+    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 

--- a/regression/rt_gk_sheath_1x2v_p1.c
+++ b/regression/rt_gk_sheath_1x2v_p1.c
@@ -350,10 +350,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_1x2v_p1.c
+++ b/regression/rt_gk_sheath_1x2v_p1.c
@@ -414,7 +414,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -465,7 +464,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_1x2v_p1_cons.c
+++ b/regression/rt_gk_sheath_1x2v_p1_cons.c
@@ -439,7 +439,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -510,7 +509,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_1x2v_p1_cons.c
+++ b/regression/rt_gk_sheath_1x2v_p1_cons.c
@@ -377,10 +377,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_2x2v_p1.c
+++ b/regression/rt_gk_sheath_2x2v_p1.c
@@ -484,7 +484,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -538,7 +537,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_2x2v_p1.c
+++ b/regression/rt_gk_sheath_2x2v_p1.c
@@ -421,10 +421,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -501,7 +501,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -554,7 +553,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -72,6 +72,7 @@ struct sheath_ctx
 
   double t_end; // Final simulation time.
   int num_frames; // Number of output frames.
+  double write_phase_freq; // Frequency of writing phase-space diagnostics (as a fraction of num_frames).
   int int_diag_calc_num; // Number of integrated diagnostics computations (=INT_MAX for every step).
   double dt_failure_tol; // Minimum allowable fraction of initial time-step.
   int num_failures_max; // Maximum allowable number of consecutive small time-steps.
@@ -146,6 +147,7 @@ create_ctx(void)
 
   double t_end = 6.0e-6; // Final simulation time.
   int num_frames = 1; // Number of output frames.
+  double write_phase_freq = 0.2; // Frequency of writing phase-space diagnostics (as a fraction of num_frames).
   int int_diag_calc_num = num_frames*100;
   double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
   int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
@@ -197,6 +199,7 @@ create_ctx(void)
     .mu_max_ion = mu_max_ion,
     .t_end = t_end,
     .num_frames = num_frames,
+    .write_phase_freq = write_phase_freq,
     .int_diag_calc_num = int_diag_calc_num,
     .dt_failure_tol = dt_failure_tol,
     .num_failures_max = num_failures_max,
@@ -420,13 +423,14 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
 }
 
 void
-write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr, bool force_write)
+write_data(struct gkyl_tm_trigger* iot_conf, struct gkyl_tm_trigger* iot_phase,
+  gkyl_gyrokinetic_app* app, double t_curr, bool force_write)
 {
-  bool trig_now = gkyl_tm_trigger_check_and_bump(iot, t_curr);
+  bool trig_now = gkyl_tm_trigger_check_and_bump(iot_conf, t_curr);
   if (trig_now || force_write) {
-    int frame = (!trig_now) && force_write? iot->curr : iot->curr-1;
+    int frame = (!trig_now) && force_write? iot_conf->curr : iot_conf->curr-1;
 
-    gkyl_gyrokinetic_app_write(app, t_curr, frame);
+    gkyl_gyrokinetic_app_write_conf(app, t_curr, frame);
 
     gkyl_gyrokinetic_app_calc_mom(app);
     gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
@@ -437,6 +441,13 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
+  }
+
+  trig_now = gkyl_tm_trigger_check_and_bump(iot_phase, t_curr);
+  if (trig_now || force_write) {
+    int frame = (!trig_now) && force_write? iot_phase->curr : iot_phase->curr-1;
+
+    gkyl_gyrokinetic_app_write_phase(app, t_curr, frame);
   }
 }
 
@@ -644,13 +655,14 @@ main(int argc, char **argv)
 
   // Create triggers for IO.
   int num_frames = ctx.num_frames, num_int_diag_calc = ctx.int_diag_calc_num;
-  struct gkyl_tm_trigger trig_write = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_write_conf = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_write_phase = { .dt = t_end/(ctx.write_phase_freq*num_frames), .tcurr = t_curr, .curr = frame_curr };
   struct gkyl_tm_trigger trig_calc_intdiag = { .dt = t_end/GKYL_MAX2(num_frames, num_int_diag_calc),
     .tcurr = t_curr, .curr = frame_curr };
 
   // Write out ICs (if restart, it overwrites the restart frame).
   calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, false);
-  write_data(&trig_write, app, t_curr, false);
+  write_data(&trig_write_conf, &trig_write_phase, app, t_curr, false);
 
   // Compute initial guess of maximum stable time-step.
   double dt = t_end - t_curr;
@@ -674,7 +686,7 @@ main(int argc, char **argv)
     dt = status.dt_suggested;
 
     calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, t_curr > t_end);
-    write_data(&trig_write, app, t_curr, t_curr > t_end);
+    write_data(&trig_write_conf, &trig_write_phase, app, t_curr, t_curr > t_end);
 
     if (dt_init < 0.0) {
       dt_init = status.dt_actual;
@@ -689,7 +701,7 @@ main(int argc, char **argv)
         gkyl_gyrokinetic_app_cout(app, stdout, "ERROR: Time-step was below %g*dt_init ", dt_failure_tol);
         gkyl_gyrokinetic_app_cout(app, stdout, "%d consecutive times. Aborting simulation ....\n", num_failures_max);
         calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, true);
-        write_data(&trig_write, app, t_curr, true);
+        write_data(&trig_write_conf, &trig_write_phase, app, t_curr, true);
         break;
       }
     }

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -426,9 +426,9 @@ void
 write_data(struct gkyl_tm_trigger* iot_conf, struct gkyl_tm_trigger* iot_phase,
   gkyl_gyrokinetic_app* app, double t_curr, bool force_write)
 {
-  bool trig_now = gkyl_tm_trigger_check_and_bump(iot_conf, t_curr);
-  if (trig_now || force_write) {
-    int frame = (!trig_now) && force_write? iot_conf->curr : iot_conf->curr-1;
+  bool trig_now_conf = gkyl_tm_trigger_check_and_bump(iot_conf, t_curr);
+  if (trig_now_conf || force_write) {
+    int frame = (!trig_now_conf) && force_write? iot_conf->curr : iot_conf->curr-1;
 
     gkyl_gyrokinetic_app_write_conf(app, t_curr, frame);
 
@@ -443,9 +443,9 @@ write_data(struct gkyl_tm_trigger* iot_conf, struct gkyl_tm_trigger* iot_phase,
     gkyl_gyrokinetic_app_write_integrated_mom(app);
   }
 
-  trig_now = gkyl_tm_trigger_check_and_bump(iot_phase, t_curr);
-  if (trig_now || force_write) {
-    int frame = (!trig_now) && force_write? iot_phase->curr : iot_phase->curr-1;
+  bool trig_now_phase = gkyl_tm_trigger_check_and_bump(iot_phase, t_curr);
+  if (trig_now_phase || force_write) {
+    int frame = (!trig_now_conf) && force_write? iot_conf->curr : iot_conf->curr-1;
 
     gkyl_gyrokinetic_app_write_phase(app, t_curr, frame);
   }
@@ -631,12 +631,11 @@ main(int argc, char **argv)
   gkyl_gyrokinetic_app *app = gkyl_gyrokinetic_app_new(&app_inp);
 
   // Initial and final simulation times.
-  int frame_curr_conf = 0, frame_curr_phase = 0;;
+  int frame_curr = 0;
   double t_curr = 0.0, t_end = ctx.t_end;
   // Initialize simulation.
   if (app_args.is_restart) {
-    int distf_restart_frame = round(ctx.write_phase_freq*app_args.restart_frame);
-    struct gkyl_app_restart_status status = gkyl_gyrokinetic_app_read_from_frame(app, distf_restart_frame);
+    struct gkyl_app_restart_status status = gkyl_gyrokinetic_app_read_from_frame(app, app_args.restart_frame);
 
     if (status.io_status != GKYL_ARRAY_RIO_SUCCESS) {
       gkyl_gyrokinetic_app_cout(app, stderr, "*** Failed to read restart file! (%s)\n",
@@ -644,11 +643,10 @@ main(int argc, char **argv)
       goto freeresources;
     }
 
-    frame_curr_conf = app_args.restart_frame;
-    frame_curr_phase = status.frame;
+    frame_curr = app_args.restart_frame;
     t_curr = status.stime;
 
-    gkyl_gyrokinetic_app_cout(app, stdout, "Restarting from frame %d", frame_curr_conf);
+    gkyl_gyrokinetic_app_cout(app, stdout, "Restarting from frame %d", frame_curr);
     gkyl_gyrokinetic_app_cout(app, stdout, " at time = %g\n", t_curr);
   }
   else {
@@ -657,10 +655,10 @@ main(int argc, char **argv)
 
   // Create triggers for IO.
   int num_frames = ctx.num_frames, num_int_diag_calc = ctx.int_diag_calc_num;
-  struct gkyl_tm_trigger trig_write_conf = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr_conf };
-  struct gkyl_tm_trigger trig_write_phase = { .dt = t_end/(ctx.write_phase_freq*num_frames), .tcurr = t_curr, .curr = frame_curr_phase };
+  struct gkyl_tm_trigger trig_write_conf = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_write_phase = { .dt = t_end/(ctx.write_phase_freq*num_frames), .tcurr = t_curr, .curr = frame_curr};
   struct gkyl_tm_trigger trig_calc_intdiag = { .dt = t_end/GKYL_MAX2(num_frames, num_int_diag_calc),
-    .tcurr = t_curr, .curr = frame_curr_conf };
+    .tcurr = t_curr, .curr = frame_curr };
 
   // Write out ICs (if restart, it overwrites the restart frame).
   calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, false);

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -432,10 +432,6 @@ write_data(struct gkyl_tm_trigger* iot_conf, struct gkyl_tm_trigger* iot_phase,
 
     gkyl_gyrokinetic_app_write_conf(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_3x2v_p1_cons.c
+++ b/regression/rt_gk_sheath_3x2v_p1_cons.c
@@ -452,7 +452,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -523,7 +522,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_3x2v_p1_cons.c
+++ b/regression/rt_gk_sheath_3x2v_p1_cons.c
@@ -390,10 +390,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_bgk_1x2v_p1.c
+++ b/regression/rt_gk_sheath_bgk_1x2v_p1.c
@@ -413,7 +413,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -464,7 +463,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_bgk_1x2v_p1.c
+++ b/regression/rt_gk_sheath_bgk_1x2v_p1.c
@@ -349,10 +349,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_cx_2x2v_p1.c
+++ b/regression/rt_gk_sheath_cx_2x2v_p1.c
@@ -452,10 +452,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_cx_2x2v_p1.c
+++ b/regression/rt_gk_sheath_cx_2x2v_p1.c
@@ -515,7 +515,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -603,7 +602,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_neut_3x2v_p1.c
+++ b/regression/rt_gk_sheath_neut_3x2v_p1.c
@@ -536,7 +536,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -613,7 +612,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_neut_3x2v_p1.c
+++ b/regression/rt_gk_sheath_neut_3x2v_p1.c
@@ -459,10 +459,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
@@ -386,10 +386,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_1x2v_p1.c
@@ -456,7 +456,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -512,7 +511,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
@@ -458,10 +458,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_2x2v_p1.c
@@ -528,7 +528,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -588,7 +587,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
@@ -534,7 +534,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -594,7 +593,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
+++ b/regression/rt_gk_sheath_nonuniformv_3x2v_p1.c
@@ -464,10 +464,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_solovev_out_3x2v_p1.c
+++ b/regression/rt_gk_solovev_out_3x2v_p1.c
@@ -371,7 +371,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -424,7 +423,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_solovev_out_3x2v_p1.c
+++ b/regression/rt_gk_solovev_out_3x2v_p1.c
@@ -309,10 +309,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_step_1x2v_p1_cons.c
+++ b/regression/rt_gk_step_1x2v_p1_cons.c
@@ -449,7 +449,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -520,7 +519,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_step_1x2v_p1_cons.c
+++ b/regression/rt_gk_step_1x2v_p1_cons.c
@@ -387,10 +387,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_step_3x2v_p1_cons.c
+++ b/regression/rt_gk_step_3x2v_p1_cons.c
@@ -393,10 +393,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_step_3x2v_p1_cons.c
+++ b/regression/rt_gk_step_3x2v_p1_cons.c
@@ -455,7 +455,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
@@ -526,7 +525,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 0,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -395,7 +395,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -496,7 +495,6 @@ main(int argc, char **argv)
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -743,7 +741,7 @@ main(int argc, char **argv)
 
   long step = 1, num_steps = app_args.num_steps;
   while ((t_curr < t_end) && (step <= num_steps)) {
-    gkyl_gyrokinetic_app_cout(app, stdout, "Taking time-step at t = %g ...", t_curr);
+    gkyl_gyrokinetic_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, t_curr);
     struct gkyl_update_status status = gkyl_gyrokinetic_update(app, dt);
     gkyl_gyrokinetic_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
 

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -316,7 +316,6 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
-    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 
@@ -329,16 +328,11 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
-    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -316,6 +316,7 @@ calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* a
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_app_calc_rad_integrated_mom(app, t_curr);
   }
 }
 
@@ -337,6 +338,7 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_calc_integrated_mom(app, t_curr);
     gkyl_gyrokinetic_app_write_integrated_mom(app);
+    gkyl_gyrokinetic_app_write_rad_integrated_mom(app);
   }
 }
 

--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -729,10 +729,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -792,7 +792,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -842,7 +841,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_wham_2x2v_p1.c
+++ b/regression/rt_gk_wham_2x2v_p1.c
@@ -591,10 +591,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_wham_2x2v_p1.c
+++ b/regression/rt_gk_wham_2x2v_p1.c
@@ -660,7 +660,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -723,7 +722,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_gk_wham_3x2v_p1.c
+++ b/regression/rt_gk_wham_3x2v_p1.c
@@ -594,10 +594,6 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_app* app, double t_curr
 
     gkyl_gyrokinetic_app_write(app, t_curr, frame);
 
-    gkyl_gyrokinetic_app_calc_mom(app);
-    gkyl_gyrokinetic_app_write_mom(app, t_curr, frame);
-    gkyl_gyrokinetic_app_write_source_mom(app, t_curr, frame);
-
     gkyl_gyrokinetic_app_calc_field_energy(app, t_curr);
     gkyl_gyrokinetic_app_write_field_energy(app);
 

--- a/regression/rt_gk_wham_3x2v_p1.c
+++ b/regression/rt_gk_wham_3x2v_p1.c
@@ -663,7 +663,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -726,7 +725,6 @@ int main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_multib_step_2x2v_p1.c
+++ b/regression/rt_multib_step_2x2v_p1.c
@@ -813,7 +813,6 @@ struct gkyl_comm *comm = 0;
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -956,7 +955,6 @@ struct gkyl_comm *comm = 0;
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 

--- a/regression/rt_multib_step_sol_2x2v_p1.c
+++ b/regression/rt_multib_step_sol_2x2v_p1.c
@@ -441,7 +441,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -558,7 +557,6 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .write_source = true,
       .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 


### PR DESCRIPTION
At the moment the GK app has the following `write` functions:
```
gkyl_gyrokinetic_app_write(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_field(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_source_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_source_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_coll_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_rad_drag(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_rad_emissivity(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_rad_integrated_mom(gkyl_gyrokinetic_app *app)
gkyl_gyrokinetic_app_write_iz_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_recomb_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_iz_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_recomb_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_cx_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_source_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_integrated_mom(gkyl_gyrokinetic_app *app)
gkyl_gyrokinetic_app_write_integrated_source_mom(gkyl_gyrokinetic_app *app)
gkyl_gyrokinetic_app_write_field_energy(gkyl_gyrokinetic_app* app)
gkyl_gyrokinetic_app_write_max_corr_status(gkyl_gyrokinetic_app* app)
```
and the first of these, `gkyl_gyrokinetic_app_write`, calls all the others except for
```
gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_source_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_max_corr_status(gkyl_gyrokinetic_app* app)
```
and the integrated diagnostic ones.

There are a couple of problems or less than ideal things about this arrangement:
1. gkyl_gyrokinetic_app_write writes both conf-space and phase-space diagnostics, and we may wish to write distributions less frequently (see issue #478 ).
2. gkyl_gyrokinetic_app_write seems to write nearly everything, except for moments. Why treat moments differently?
3. In general the implementation of the above write functions seems to lack a system and has numerous inconsistencies.

In this branch we reorganized all the write functions so that we now have the following
```
// Field outputs
gkyl_gyrokinetic_app_write_field(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_calc_field_energy(gkyl_gyrokinetic_app* app, double tm)
gkyl_gyrokinetic_app_write_field_energy(gkyl_gyrokinetic_app* app)
// Species outputs
gkyl_gyrokinetic_app_write_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_species_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_calc_species_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
gkyl_gyrokinetic_app_calc_neut_species_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
gkyl_gyrokinetic_app_write_species_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
gkyl_gyrokinetic_app_write_neut_species_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
// Source ouputs
gkyl_gyrokinetic_app_write_species_source(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species_source(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_species_source_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species_source_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_calc_species_source_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
gkyl_gyrokinetic_app_calc_neut_species_source_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
gkyl_gyrokinetic_app_write_species_source_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
gkyl_gyrokinetic_app_write_neut_species_source_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
// Collision outputs
gkyl_gyrokinetic_app_write_species_lbo_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_species_bgk_coll_max_corr_status(gkyl_gyrokinetic_app* app, int sidx)
// Radiation outputs
gkyl_gyrokinetic_app_write_species_rad_drag(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_species_rad_emissivity(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_calc_species_rad_integrated_mom(gkyl_gyrokinetic_app *app, int sidx, double tm)
gkyl_gyrokinetic_app_write_species_rad_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
// Ionization outputs
gkyl_gyrokinetic_app_write_iz_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_iz_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
// Recombination outputs
gkyl_gyrokinetic_app_write_recomb_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
gkyl_gyrokinetic_app_write_recomb_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
// Charge exchange outputs
gkyl_gyrokinetic_app_write_species_cx_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)

// Functions that group several outputs for a single species
gkyl_gyrokinetic_app_write_species_phase(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species_phase(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_species_conf(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
gkyl_gyrokinetic_app_write_neut_species_conf(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)

// Functions that group several species outputs
gkyl_gyrokinetic_app_write_mom(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_calc_integrated_mom(gkyl_gyrokinetic_app* app, double tm)
gkyl_gyrokinetic_app_write_integrated_mom(gkyl_gyrokinetic_app *app)
gkyl_gyrokinetic_app_write_conf(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write_phase(gkyl_gyrokinetic_app* app, double tm, int frame)
gkyl_gyrokinetic_app_write(gkyl_gyrokinetic_app* app, double tm, int frame)
```
The above API has been implemented in a consistent manner, and provides users sufficient granularity to write out exactly what they want, or to bulk write diagnostics with the functions that group several writes. Additionally, the functions
`gkyl_gyrokinetic_app_write_conf` and `gkyl_gyrokinetic_app_write_phase` (or their species counterparts) will allow users to write conf- and phase-space diagnostics at different rates (an example is implemented in rt_gk_sheath_3x2v_p1). This design was described in DR #483 .

Additionally, in this PR we do 3 more things:
a) Modify write_geometry and read_geometry functions so we are not allocating so many arrays and so we are not doing serial I/O (I checked all the geo files for a couple of reg tests, e.g. rt_gk_step_out_2x2v_p1, in serial and parallel and made sure they were correct).
b) Add the git commit ID to the metadata in the GK app.
c) Historically we stored a number of booleans or IDs in the species, specifically collision_id, radiation_id, source_id, has_reactions, and then we checked these everywhere we may want to do something with their corresponding module. We here move these booleans/IDs into their respective modules now. The benefit of this is that it simplifies (and in some cases removes) if-statements. Note that between gyrokinetic.c and gk_species.c we have >200 if-statements. Furthermore, though some of these if-statements remain in gyrokinetic.c or gk_species.c, I believe they could be moved into their respective modules. The benefit of this is that each module could function-pointer-set during initialization so that it chooses methods that don't have if-statements at all (this last point has not been fully realized and is left for future work).