### PR TITLE
Fix an error in the eval_cubic_wgrad2 function

### DIFF
--- a/zero/dg_basis_ops.c
+++ b/zero/dg_basis_ops.c
@@ -622,6 +622,7 @@ eval_cubic_wgrad2(double t, const double *xn, double *fout, void *ctx)
 
   fout[0] = ectx->basis.eval_expand(eta, fdg);
   if (ectx->ndim > 1) {
+    fout[1] = eval_laplacian_expand_2d_tensor_p3(0, eta, fdg);
     fout[2] = eval_laplacian_expand_2d_tensor_p3(1, eta, fdg);
     fout[3] = eval_mixedpartial_expand_2d_tensor_p3(eta, fdg);
   }

--- a/zero/efit.c
+++ b/zero/efit.c
@@ -227,7 +227,7 @@ gkyl_efit* gkyl_efit_new(const struct gkyl_efit_inp *inp)
         up->evf->eval_cubic_wgrad2(0.0, xn, fout, up->evf->ctx);
         psi_curr = fout[0];
         br = fout[3]*scale_factorZ*scale_factorR;
-        bz = fout[1]*scale_factorR*scale_factorR;
+        bz = -fout[1]*scale_factorR*scale_factorR;
       }
       else {
         double fout[3];

--- a/zero/gkyl_dg_basis_ops.h
+++ b/zero/gkyl_dg_basis_ops.h
@@ -37,8 +37,14 @@ typedef double (*eval_mixedpartial_expand)(const double *z, const double *f);
 struct gkyl_basis_ops_evalf {
   void *ctx; // function context
   evalf_t eval_cubic; // function pointer to evaluate the cubic
-  evalf_t eval_cubic_wgrad; // function pointer to evaluate the cubic & its gradient
+  evalf_t eval_cubic_wgrad; // function pointer to evaluate the cubic & its gradient with signature
+                            // void (*evalf_t)(double t, const double *xn, double *fout, void *ctx);
+                            // On return, fout[0], fout[1], and fout[2] are the value, gradient in direction 0,
+                            // and gradient in direction 1 of the cubic evaluated at grid coordinates xn.
   evalf_t eval_cubic_wgrad2; // function pointer to evaluate the cubic & its 2nd derivatives
+                             // On return, fout[0], fout[1], fout[2], and fout[3] are the value, second derivative
+                             // in direction 0, second derivative in direction 1, and mixed partial derivative
+                             // of the cubic evaluated at grid coordinates xn.
   eval_laplacian_expand eval_cubic_laplacian; // function pointer to evaluate the laplacian
   eval_mixedpartial_expand eval_cubic_mixedpartial; // function pointer to evaluate the mixed partial
   struct gkyl_ref_count ref_count;   

--- a/zero/mirror_geo.c
+++ b/zero/mirror_geo.c
@@ -78,6 +78,7 @@ struct gkyl_mirror_geo*
 gkyl_mirror_geo_new(const struct gkyl_efit_inp *inp, const struct gkyl_mirror_geo_grid_inp *ginp)
 {
   struct gkyl_mirror_geo *geo = gkyl_malloc(sizeof(*geo));
+  *geo = (struct gkyl_mirror_geo) {};
 
   geo->efit = gkyl_efit_new(inp);
 

--- a/zero/tok_geo.c
+++ b/zero/tok_geo.c
@@ -291,6 +291,7 @@ struct gkyl_tok_geo*
 gkyl_tok_geo_new(const struct gkyl_efit_inp *inp, const struct gkyl_tok_geo_grid_inp *ginp)
 {
   struct gkyl_tok_geo *geo = gkyl_malloc(sizeof(*geo));
+  *geo = (struct gkyl_tok_geo) {};
 
   geo->efit = gkyl_efit_new(inp);
 


### PR DESCRIPTION
This is a bug fix that affects mirror geometry on the magnetic axis. Before commit 4ce1631, there was a memory error that obscured this issue. When @manauref was trying to run mirror calculations post this commit, he noticed the error. We have tracked it back to this mistake which fixes the issue.


Error in the eval_cubic_wgrad2 function in dg_basis_ops: Accidentally returned only one of the second derivatives and the mixed partial rather than both second derivatives and the mixed partial. (This is for the 2x case). This was breaking on axis calculation of bmag for the mirror.

This wgrad2 function is supposed to return f, d^2f/dx^2, d^2f/dy^2, and d^2f/dxdy which it now does.