### PR TITLE
Comments in gkyl_deflated_fem_poisson Headers

### DIFF
--- a/zero/gkyl_deflated_fem_poisson.h
+++ b/zero/gkyl_deflated_fem_poisson.h
@@ -13,12 +13,48 @@
 // Object type
 typedef struct gkyl_deflated_fem_poisson gkyl_deflated_fem_poisson;
 
+/**
+ * Create new updater to solve a poisson equation
+ *   - nabla . (epsilon * nabla phi) = rho
+ *   on lines or planes using FEM to ensure phi is continuous.
+ * The inputs are a DG field rho and epsilon and the output is
+ * a DG field phi.
+ *
+ * rho and epsilon are evaluated at surfaces that are constant
+ * in the last coordinate and then the FEM poisson solver
+ * is called to solve the poisson equation at each surface.
+ * The surfaces are lines (1d) if the initial fields are 2d
+ * and planes (2d) if the initial fields are 3d).
+ * Finally, the surfaces are assembled and converted into
+ * a solution with the initial dimenionality.
+ * Free using gkyl_deflated_fem_poisson_release method.
+ *
+ *
+ * @param grid Grid object
+ * @param basis_on_dev Basis functions of the DG field stored on the gpu.
+ * @param basis Basis functions of the DG field.
+ * @param local range on which the poisson problem should be solver
+ * @param global_sub_range local range as a sub-range of the global range
+ * @param bcs Boundary conditions.
+ * @param epsilon Permittivity tensor. Defined over the extended range.
+ * @param use_gpu boolean indicating whether to use the GPU.
+ * @return New updater pointer.
+ */
 struct gkyl_deflated_fem_poisson* gkyl_deflated_fem_poisson_new(struct gkyl_rect_grid grid, 
-  struct gkyl_basis *basis_on_dev, struct gkyl_basis basis, struct gkyl_range local, struct gkyl_range local_ext, 
-  struct gkyl_array *epsilon, struct gkyl_poisson_bc poisson_bc, bool use_gpu);
+  struct gkyl_basis *basis_on_dev, struct gkyl_basis basis, struct gkyl_range local, struct gkyl_range global_sub_range, struct gkyl_array *epsilon, struct gkyl_poisson_bc poisson_bc, bool use_gpu);
 
-
+/**
+ * Solve the poisson equation for the given charge density
+ *
+ * @param up deflated FEM poisson updater to run.
+ * @param field DG field to set as RHS source (charge density rho).
+ * @param phi DG field solution to poison problem (phi).
+ */
 void gkyl_deflated_fem_poisson_advance(struct gkyl_deflated_fem_poisson* up, struct gkyl_array *field, struct gkyl_array* phi);
 
-
+/**
+ * Delete updater.
+ *
+ * @param up Updater to delete.
+ */
 void gkyl_deflated_fem_poisson_release(struct gkyl_deflated_fem_poisson* up);

--- a/zero/gkyl_deflated_fem_poisson_priv.h
+++ b/zero/gkyl_deflated_fem_poisson_priv.h
@@ -5,6 +5,10 @@
 #include <gkyl_basis.h>
 #include <gkyl_fem_poisson_bctype.h>
 
+// Struct containing all fields and solver
+// needed to solve the poisson equation on a
+// surface which is constant in the last coordinate
+// of the configuration space grid
 struct deflated_fem_data {
   struct gkyl_array *deflated_field;
   struct gkyl_array *deflated_phi;
@@ -15,26 +19,37 @@ struct deflated_fem_data {
 
 // Updater type
 struct gkyl_deflated_fem_poisson {
-  struct gkyl_rect_grid grid;
-  struct gkyl_rect_grid deflated_grid;
-  struct gkyl_basis basis;
-  struct gkyl_basis *basis_on_dev;
-  struct gkyl_basis deflated_basis;
-  struct gkyl_basis *deflated_basis_on_dev;
-  struct gkyl_range local;
-  struct gkyl_range deflated_local;
-  struct gkyl_range global_sub_range;
-  struct gkyl_range deflated_local_ext;
-  struct gkyl_range nrange;
-  struct gkyl_range deflated_nrange;
-  struct gkyl_poisson_bc poisson_bc;
-  struct deflated_fem_data *d_fem_data;
-  struct gkyl_array *nodal_fld;
-  int num_solves_z;
-  int cdim;
-  struct gkyl_nodal_ops *n2m;
-  struct gkyl_nodal_ops *n2m_deflated;
-  struct gkyl_deflate_zsurf *deflator_lo;
-  struct gkyl_deflate_zsurf *deflator_up;
-  bool use_gpu;
+  struct gkyl_rect_grid grid; // Conf space grid
+  struct gkyl_rect_grid deflated_grid; // Conf space grid with last
+                                       // dimension removed
+  struct gkyl_basis basis; // Basis object
+  struct gkyl_basis *basis_on_dev; // Basis object on GPU
+  struct gkyl_basis deflated_basis; // Basis object with one
+                                    // less dimension than basis
+  struct gkyl_basis *deflated_basis_on_dev; // deflated basis on GPU
+  struct gkyl_range local; // Local range where poisson problem
+                           // should be solved
+  struct gkyl_range deflated_local; // Local range with last dim removed
+  struct gkyl_range global_sub_range; // Local range as a
+                                      // sub range of the global range
+  struct gkyl_range deflated_local_ext; // extended deflated local range
+  struct gkyl_range nrange; // nodal range corresponding to
+                            // local range
+  struct gkyl_range deflated_nrange; // nodal range corresponding to
+                                     // deflated local range
+  struct gkyl_poisson_bc poisson_bc; // Boundary conditions
+  struct deflated_fem_data *d_fem_data; // Array of deflated_dem_data
+                                        // to be used for individual surface solves
+  struct gkyl_array *nodal_fld; // Nodal field which holds solution
+  int num_solves_z; // Number of surfaces to solve on
+  int cdim; // Dimension of configureation space
+  struct gkyl_nodal_ops *n2m; // Nodal to modal operator to be
+                              // used to construct the final DG solution
+  struct gkyl_nodal_ops *n2m_deflated; // Nodal to modal operator to
+                                       // be used at each surface
+  struct gkyl_deflate_zsurf *deflator_lo; // Deflation operator used to
+                                          // evaluate fields at a lower surface
+  struct gkyl_deflate_zsurf *deflator_up; // Deflation operator used to
+                                          // evaluate fields at an upper surface
+  bool use_gpu; // Whether to use the GPU
 };


### PR DESCRIPTION
Address issue #488 by adding comments to the deflated_fem_poisson header files. This is a small enhancement that does not change any code, only comments and the name of one variable in the header declaration of gkyl_deflated_fem_poisson_new.