### PR TITLE
A unit test with a struct-based approach to arrays of arrays v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ UNIT_CU_OBJS =
 # There is some problem with the Vlasov and Maxwell kernels that is causing some unit builds to fail
 ifdef USING_NVCC
 #	UNIT_CU_SRCS = $(shell find unit -name *.cu)
-	UNIT_CU_SRCS = unit/ctest_cusolver.cu unit/ctest_alloc_cu.cu unit/ctest_basis_cu.cu unit/ctest_array_cu.cu unit/ctest_mom_vlasov_cu.cu unit/ctest_range_cu.cu unit/ctest_rect_grid_cu.cu unit/ctest_wave_geom_cu.cu unit/ctest_wv_euler_cu.cu unit/ctest_wv_maxwell_cu.cu unit/ctest_wv_ten_moment_cu.cu
+	UNIT_CU_SRCS = unit/ctest_cusolver.cu unit/ctest_alloc_cu.cu unit/ctest_basis_cu.cu unit/ctest_array_cu.cu unit/ctest_mom_vlasov_cu.cu unit/ctest_range_cu.cu unit/ctest_rect_grid_cu.cu unit/ctest_wave_geom_cu.cu unit/ctest_wv_euler_cu.cu unit/ctest_wv_maxwell_cu.cu unit/ctest_wv_ten_moment_cu.cu unit/ctest_struct_of_arrays_cu.cu
 ifdef USING_CUDSS
 	UNIT_CU_SRCS += unit/ctest_cudss.cu
 endif

--- a/unit/ctest_struct_of_arrays.c
+++ b/unit/ctest_struct_of_arrays.c
@@ -7,7 +7,14 @@
 #include <gkyl_elem_type_priv.h>
 #include <gkyl_range.h>
 #include <gkyl_util.h>
-#include "gkyl_struct_of_arrays.h"
+
+struct gkyl_array_container {
+  struct gkyl_array *arr;
+};
+
+struct gkyl_container_pack {
+  struct gkyl_array_container *ac;
+};
 
 void test_array_container_accumulate_ho()
 {

--- a/unit/ctest_struct_of_arrays.c
+++ b/unit/ctest_struct_of_arrays.c
@@ -1,0 +1,319 @@
+#include <acutest.h>
+#include <mpack.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_array.h>
+#include <gkyl_array_ops.h>
+#include <gkyl_elem_type_priv.h>
+#include <gkyl_range.h>
+#include <gkyl_util.h>
+#include "gkyl_struct_of_arrays.h"
+
+void test_array_container_accumulate_ho()
+{
+  int arr_ncomp = 1; // Number of components of each array.
+  int arr_size = 10; // Number of elements/cells of each array.
+  int num_containers = 2; // Number of array containers (i.e. no. of arrays).
+
+  // Allocate objects.
+  struct gkyl_array_container *acs1 = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+  struct gkyl_array_container *acs2 = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+    arrc1->arr = gkyl_array_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+    arrc2->arr = gkyl_array_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+  }
+
+  // Assign arrays.
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+    double *arr1_d = arrc1->arr->data;
+    for (unsigned i=0; i<arrc1->arr->size; ++i) {
+      arr1_d[i] = k*100.0 + i*1.0;
+    }
+
+    double *arr2_d  = arrc2->arr->data;
+    for (unsigned i=0; i<arrc2->arr->size; ++i) {
+      arr2_d[i] = k*200.0 + i*2.0;
+    }
+  }
+
+  // Accumulate arrays.
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+    gkyl_array_accumulate(arrc1->arr, 0.5, arrc2->arr);
+  }
+
+  // Check results.
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k];
+    double *arr1_d  = arrc1->arr->data;
+    for (unsigned i=0; i<arrc1->arr->size; ++i)
+      TEST_CHECK( gkyl_compare(arr1_d[i], 2.0*(k*100.0+i*1.0), 1e-14) );
+  }
+
+  // Free objects.
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];;
+    gkyl_array_release(arrc1->arr);
+    gkyl_array_release(arrc2->arr);
+  }
+  gkyl_free(acs1);
+  gkyl_free(acs2);
+}
+
+void test_container_pack_accumulate_ho()
+{
+  int arr_ncomp = 1; // Number of components of each array.
+  int arr_size = 10; // Number of elements/cells of each array.
+  int num_containers = 2; // Number of array containers (i.e. no. of arrays).
+  int num_packs = 3; // Number of container packs (e.g. number of arrays of containers)
+
+  // Allocate objects.
+  struct gkyl_container_pack *cp1 = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  struct gkyl_container_pack *cp2 = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+
+  for (int j=0; j<num_packs; j++) {
+    cp1[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+    cp2[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+      arrc1->arr = gkyl_array_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+      arrc2->arr = gkyl_array_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+    }
+  }
+
+  // Assign arrays.
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+      double *arr1_d = arrc1->arr->data;
+      for (unsigned i=0; i<arrc1->arr->size; ++i) {
+        arr1_d[i] = k*100.0 + i*1.0;
+      }
+
+      double *arr2_d  = arrc2->arr->data;
+      for (unsigned i=0; i<arrc2->arr->size; ++i) {
+        arr2_d[i] = k*200.0 + i*2.0;
+      }
+    }
+  }
+
+  // Accumulate arrays.
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+      gkyl_array_accumulate(arrc1->arr, 0.5, arrc2->arr);
+    }
+  }
+
+  // Check results.
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k];
+      double *arr1_d  = arrc1->arr->data;
+      for (unsigned i=0; i<arrc1->arr->size; ++i)
+        TEST_CHECK( gkyl_compare(arr1_d[i], 2.0*(k*100.0+i*1.0), 1e-14) );
+    }
+  }
+
+  // Free objects.
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];;
+      gkyl_array_release(arrc1->arr);
+      gkyl_array_release(arrc2->arr);
+    }
+    gkyl_free(acs1);
+    gkyl_free(acs2);
+  }
+  gkyl_free(cp1);
+  gkyl_free(cp2);
+}
+
+#ifdef GKYL_HAVE_CUDA
+
+/* Function signatures of kernel calls */
+void test_array_container_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1, struct gkyl_array_container *acs2);
+
+void test_array_container_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2);
+
+int test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1);
+
+void test_array_container_accumulate_dev()
+{
+  int arr_ncomp = 1; // Number of components of each array.
+  int arr_size = 10; // Number of elements/cells of each array.
+  int num_containers = 2; // Number of array containers (i.e. no. of arrays).
+
+  // Allocate objects.
+  // These hold the host memory pointers.
+  struct gkyl_array_container *acs1_ho = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+  struct gkyl_array_container *acs2_ho = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1_ho[k], *arrc2 = &acs2_ho[k];
+    arrc1->arr = gkyl_array_cu_dev_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+    arrc2->arr = gkyl_array_cu_dev_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+  }
+
+  // These hold the device-memory pointers.
+  struct gkyl_array_container *acs1_dev = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+  struct gkyl_array_container *acs2_dev = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1_ho = &acs1_ho[k], *arrc2_ho = &acs2_ho[k];
+    struct gkyl_array_container *arrc1_dev = &acs1_dev[k], *arrc2_dev = &acs2_dev[k];
+    arrc1_dev->arr = arrc1_ho->arr->on_dev;
+    arrc2_dev->arr = arrc2_ho->arr->on_dev;
+  }
+
+  // These are pointers to device memory, and they hold the device-memory pointers.
+  struct gkyl_array_container *acs1 = gkyl_cu_malloc(num_containers * sizeof(struct gkyl_array_container));
+  struct gkyl_array_container *acs2 = gkyl_cu_malloc(num_containers * sizeof(struct gkyl_array_container));
+  gkyl_cu_memcpy(acs1, acs1_dev, num_containers * sizeof(struct gkyl_array_container), GKYL_CU_MEMCPY_H2D);
+  gkyl_cu_memcpy(acs2, acs2_dev, num_containers * sizeof(struct gkyl_array_container), GKYL_CU_MEMCPY_H2D);
+  // We can free the _dev ones because we don't need them anymore.
+  gkyl_free(acs1_dev);
+  gkyl_free(acs2_dev);
+
+  // Assign arrays.
+  test_array_container_accumulate_dev_assign_cu(arr_ncomp, arr_size, num_containers, acs1, acs2);
+
+  // Accumulate arrays.
+  test_array_container_accumulate_dev_accumulate_cu(arr_ncomp, arr_size, num_containers, acs1, 0.5, acs2);
+
+  // Check results.
+  int nfail = test_array_container_accumulate_dev_check_cu(arr_ncomp, arr_size, num_containers, acs1);
+  TEST_CHECK( nfail == 0 );
+
+  // Free objects.
+  // Note that when you call array_release here you also free the
+  // memory that the pointers in acs1/acs2 point to.
+  gkyl_cu_free(acs1);
+  gkyl_cu_free(acs2);
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1_ho[k], *arrc2 = &acs2_ho[k];;
+    gkyl_array_release(arrc1->arr);
+    gkyl_array_release(arrc2->arr);
+  }
+  gkyl_free(acs1_ho);
+  gkyl_free(acs2_ho);
+}
+
+void test_container_pack_accumulate_dev()
+{
+  // MF 2024/10/21: In this test we assume that the container_pack holds pointers to host
+  // memory. I think it could be made so that it points to device memory instead too.
+  int arr_ncomp = 1; // Number of components of each array.
+  int arr_size = 10; // Number of elements/cells of each array.
+  int num_containers = 2; // Number of array containers (i.e. no. of arrays).
+  int num_packs = 3; // Number of container packs (e.g. number of arrays of containers)
+
+  // Allocate objects.
+  // These hold the host memory pointers.
+  struct gkyl_container_pack *cp1_ho = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  struct gkyl_container_pack *cp2_ho = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+
+  for (int j=0; j<num_packs; j++) {
+    cp1_ho[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+    cp2_ho[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+
+    struct gkyl_array_container *acs1 = cp1_ho[j].ac, *acs2 = cp2_ho[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+      arrc1->arr = gkyl_array_cu_dev_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+      arrc2->arr = gkyl_array_cu_dev_new(GKYL_DOUBLE, arr_ncomp, arr_size);
+    }
+  }
+
+  // These hold the device-memory pointers.
+  struct gkyl_container_pack *cp1_dev = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  struct gkyl_container_pack *cp2_dev = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  for (int j=0; j<num_packs; j++) {
+    cp1_dev[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+    cp2_dev[j].ac = gkyl_malloc(num_containers * sizeof(struct gkyl_array_container));
+
+    struct gkyl_array_container *acs1_ho = cp1_ho[j].ac, *acs2_ho = cp2_ho[j].ac;
+    struct gkyl_array_container *acs1_dev = cp1_dev[j].ac, *acs2_dev = cp2_dev[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1_ho = &acs1_ho[k], *arrc2_ho = &acs2_ho[k];
+      struct gkyl_array_container *arrc1_dev = &acs1_dev[k], *arrc2_dev = &acs2_dev[k];
+      arrc1_dev->arr = arrc1_ho->arr->on_dev;
+      arrc2_dev->arr = arrc2_ho->arr->on_dev;
+    }
+  }
+
+  // These are pointers to host memory, and they hold the device-memory pointers.
+  struct gkyl_container_pack *cp1 = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  struct gkyl_container_pack *cp2 = gkyl_malloc(num_packs * sizeof(struct gkyl_container_pack));
+  for (int j=0; j<num_packs; j++) {
+    cp1[j].ac = gkyl_cu_malloc(num_containers * sizeof(struct gkyl_array_container));
+    cp2[j].ac = gkyl_cu_malloc(num_containers * sizeof(struct gkyl_array_container));
+    gkyl_cu_memcpy(cp1[j].ac, cp1_dev[j].ac, num_containers * sizeof(struct gkyl_array_container), GKYL_CU_MEMCPY_H2D);
+    gkyl_cu_memcpy(cp2[j].ac, cp2_dev[j].ac, num_containers * sizeof(struct gkyl_array_container), GKYL_CU_MEMCPY_H2D);
+  }
+  // We can free the _dev ones because we don't need them anymore.
+  for (int j=0; j<num_packs; j++) {
+    gkyl_free(cp1_dev[j].ac);
+    gkyl_free(cp2_dev[j].ac);
+  }
+  gkyl_free(cp1_dev);
+  gkyl_free(cp2_dev);
+
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1[j].ac, *acs2 = cp2[j].ac;
+
+    // Assign arrays.
+    test_array_container_accumulate_dev_assign_cu(arr_ncomp, arr_size, num_containers, acs1, acs2);
+
+    // Accumulate arrays.
+    test_array_container_accumulate_dev_accumulate_cu(arr_ncomp, arr_size, num_containers, acs1, 0.5, acs2);
+
+    // Check results.
+    int nfail = test_array_container_accumulate_dev_check_cu(arr_ncomp, arr_size, num_containers, acs1);
+    TEST_CHECK( nfail == 0 );
+  }
+
+  // Free objects.
+  // Note that when you call array_release here you also free the
+  // memory that the pointers in cp1/cp2 point to.
+  for (int j=0; j<num_packs; j++) {
+    gkyl_cu_free(cp1[j].ac);
+    gkyl_cu_free(cp2[j].ac);
+  }
+  gkyl_free(cp1);
+  gkyl_free(cp2);
+  for (int j=0; j<num_packs; j++) {
+    struct gkyl_array_container *acs1 = cp1_ho[j].ac, *acs2 = cp2_ho[j].ac;
+    for (int k=0; k<num_containers; k++) {
+      struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];;
+      gkyl_array_release(arrc1->arr);
+      gkyl_array_release(arrc2->arr);
+    }
+    gkyl_free(acs1);
+    gkyl_free(acs2);
+  }
+  gkyl_free(cp1_ho);
+  gkyl_free(cp2_ho);
+}
+
+#endif
+
+TEST_LIST = {
+  { "array_container_accumulate_ho", test_array_container_accumulate_ho },
+  { "container_pack_accumulate_ho", test_container_pack_accumulate_ho },
+#ifdef GKYL_HAVE_CUDA
+  { "array_container_accumulate_dev", test_array_container_accumulate_dev },
+  { "container_pack_accumulate_dev", test_container_pack_accumulate_dev },
+#endif
+  { NULL, NULL },
+};

--- a/unit/ctest_struct_of_arrays_cu.cu
+++ b/unit/ctest_struct_of_arrays_cu.cu
@@ -6,13 +6,6 @@ extern "C" {
 #include <gkyl_array_ops.h>
 #include <gkyl_util.h>
 #include <gkyl_alloc.h>
-  // Functions for test_array_container.
-  void test_array_container_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_containers,
-    struct gkyl_array_container *acs1, struct gkyl_array_container *acs2);
-  void test_array_container_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_containers,
-    struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2);
-  int test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
-    struct gkyl_array_container *acs1);
 
   struct gkyl_array_container {
     struct gkyl_array *arr;
@@ -21,6 +14,27 @@ extern "C" {
   struct gkyl_container_pack {
     struct gkyl_array_container *ac;
   };
+
+  struct gkyl_array_bag {
+    struct gkyl_array *arr;
+    struct gkyl_array_bag *bag;
+  };
+
+  // Functions for test_array_container.
+  void test_array_container_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1, struct gkyl_array_container *acs2);
+  void test_array_container_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2);
+  int test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1);
+
+  // Functions for test_array_bag.
+  void test_array_bag_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_bags,
+    struct gkyl_array_bag *bag1, struct gkyl_array_bag *bag2);
+  void test_array_bag_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_bags,
+    struct gkyl_array_bag *bag1, double a, struct gkyl_array_bag *bag2);
+  int test_array_bag_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_bags,
+    struct gkyl_array_bag *bag1);
 }
 
 #define START_ID (threadIdx.x + blockIdx.x*blockDim.x)
@@ -117,6 +131,94 @@ test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int nu
 }
 
 //
-// Functions for test_container_pack.
+// Functions for test_array_bag.
 //
 
+__global__
+void ker_cu_array_bag_accumulate_dev_assign(int num_arrays,
+  struct gkyl_array_bag *bag1, struct gkyl_array_bag *bag2)
+{
+  for (int k=0; k<num_arrays; k++) {
+    struct gkyl_array_bag *innerbag1 = &bag1[k];
+    struct gkyl_array *arr1 = innerbag1->arr;
+    double *arr1_d = (double *) arr1->data;
+    for (unsigned long linc = START_ID; linc < NELM(arr1); linc += blockDim.x*gridDim.x) {
+      arr1_d[linc] = k*100.0 + linc*1.0;
+    }
+
+    struct gkyl_array_bag *innerbag2 = &bag2[k];
+    struct gkyl_array *arr2 = innerbag2->arr;
+    double *arr2_d = (double *) arr2->data;
+    for (unsigned long linc = START_ID; linc < NELM(arr2); linc += blockDim.x*gridDim.x) {
+      arr2_d[linc] = k*200.0 + linc*2.0;
+    }
+  }
+}
+
+void
+test_array_bag_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_arrays,
+  struct gkyl_array_bag *innerbag1, struct gkyl_array_bag *innerbag2)
+{
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_bag_accumulate_dev_assign<<<nblocks,nthreads>>>(num_arrays, innerbag1, innerbag2);
+}
+
+__global__
+void ker_cu_array_bag_accumulate_dev_accumulate(int num_bags, 
+  struct gkyl_array_bag *bag1, double a, struct gkyl_array_bag *bag2)
+{
+  for (int k=0; k<num_bags; k++) {
+    struct gkyl_array_bag *innerbag1 = &bag1[k];
+    struct gkyl_array *arr1 = innerbag1->arr;
+    double *arr1_d = (double *) arr1->data;
+
+    struct gkyl_array_bag *innerbag2 = &bag2[k];
+    struct gkyl_array *arr2 = innerbag2->arr;
+    double *arr2_d = (double *) arr2->data;
+
+    for (unsigned long linc = START_ID; linc < NELM(arr1); linc += blockDim.x*gridDim.x) {
+      arr1_d[linc] += a*arr2_d[linc];
+    }
+  }
+}
+
+void
+test_array_bag_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_bags,
+  struct gkyl_array_bag *innerbag1, double a, struct gkyl_array_bag *innerbag2)
+{
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_bag_accumulate_dev_accumulate<<<nblocks,nthreads>>>(num_bags, innerbag1, a, innerbag2);
+}
+
+__global__
+void ker_cu_array_bag_accumulate_dev_check(int num_bags, 
+  struct gkyl_array_bag *bag1, int *nfail)
+{
+  for (int k=0; k<num_bags; k++) {
+    struct gkyl_array_bag *innerbag1 = &bag1[k];
+    struct gkyl_array *arr1 = innerbag1->arr;
+    double *arr1_d = (double *) arr1->data;
+    for (unsigned long linc = START_ID; linc < NELM(arr1); linc += blockDim.x*gridDim.x) {
+      GKYL_CU_CHECK( arr1_d[linc] == 2.0*(k*100.0+linc*1.0), nfail );
+    }
+  }
+}
+
+int
+test_array_bag_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_bags,
+  struct gkyl_array_bag *innerbag1)
+{
+  int *nfail_dev = (int *) gkyl_cu_malloc(sizeof(int));
+
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_bag_accumulate_dev_check<<<nblocks,nthreads>>>(num_bags, innerbag1, nfail_dev);
+
+  int nfail;
+  gkyl_cu_memcpy(&nfail, nfail_dev, sizeof(int), GKYL_CU_MEMCPY_D2H);
+  gkyl_cu_free(nfail_dev);
+
+  return nfail;
+}

--- a/unit/ctest_struct_of_arrays_cu.cu
+++ b/unit/ctest_struct_of_arrays_cu.cu
@@ -1,0 +1,116 @@
+/* -*- c -*- */
+
+#include <stdio.h>
+
+extern "C" {
+#include <gkyl_array_ops.h>
+#include "gkyl_struct_of_arrays.h"
+#include <gkyl_util.h>
+#include <gkyl_alloc.h>
+  // Functions for test_array_container.
+  void test_array_container_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1, struct gkyl_array_container *acs2);
+  void test_array_container_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2);
+  int test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
+    struct gkyl_array_container *acs1);
+  // Functions for test_container_pack.
+}
+
+#define START_ID (threadIdx.x + blockIdx.x*blockDim.x)
+// Compute number of elements stored in array 'arr'
+#define NELM(arr) (arr->size*arr->ncomp)
+// Compute size of 'arr'
+#define NSIZE(arr) (arr->size)
+// Compute number of components stored in array 'arr'
+#define NCOM(arr) (arr->ncomp)
+
+//
+// Functions for test_array_container.
+//
+
+__global__
+void ker_cu_array_container_accumulate_dev_assign(int num_containers,
+  struct gkyl_array_container *acs1, struct gkyl_array_container *acs2)
+{
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k];
+    double *arr1_d = (double*) arrc1->arr->data;
+    for (unsigned long linc = START_ID; linc < NELM(arrc1->arr); linc += blockDim.x*gridDim.x) {
+      arr1_d[linc] = k*100.0 + linc*1.0;
+    }
+
+    struct gkyl_array_container *arrc2 = &acs2[k];
+    double *arr2_d  = (double*) arrc2->arr->data;
+    for (unsigned long linc = START_ID; linc < NELM(arrc2->arr); linc += blockDim.x*gridDim.x) {
+      arr2_d[linc] = k*200.0 + linc*2.0;
+    }
+  }
+}
+
+void
+test_array_container_accumulate_dev_assign_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1, struct gkyl_array_container *acs2)
+{
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_container_accumulate_dev_assign<<<nblocks,nthreads>>>(num_containers, acs1, acs2);
+}
+
+__global__
+void ker_cu_array_container_accumulate_dev_accumulate(int num_containers, 
+  struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2)
+{
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k], *arrc2 = &acs2[k];
+    double *arr1_d = (double*) arrc1->arr->data;
+    double *arr2_d  = (double*) arrc2->arr->data;
+    for (unsigned long linc = START_ID; linc < NELM(arrc1->arr); linc += blockDim.x*gridDim.x) {
+      arr1_d[linc] += a*arr2_d[linc];
+    }
+  }
+}
+
+void
+test_array_container_accumulate_dev_accumulate_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2)
+{
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_container_accumulate_dev_accumulate<<<nblocks,nthreads>>>(num_containers, acs1, a, acs2);
+}
+
+__global__
+void ker_cu_array_container_accumulate_dev_check(int num_containers, 
+  struct gkyl_array_container *acs1, int *nfail)
+{
+  for (int k=0; k<num_containers; k++) {
+    struct gkyl_array_container *arrc1 = &acs1[k];
+    double *arr1_d = (double*) arrc1->arr->data;
+    for (unsigned long linc = START_ID; linc < NELM(arrc1->arr); linc += blockDim.x*gridDim.x) {
+      GKYL_CU_CHECK( arr1_d[linc] == 2.0*(k*100.0+linc*1.0), nfail );
+    }
+  }
+}
+
+int
+test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
+  struct gkyl_array_container *acs1)
+{
+  int *nfail_dev = (int *) gkyl_cu_malloc(sizeof(int));
+
+  int nthreads = GKYL_DEFAULT_NUM_THREADS;
+  int nblocks = gkyl_int_div_up(arr_size*arr_ncomp, nthreads);
+  ker_cu_array_container_accumulate_dev_check<<<nblocks,nthreads>>>(num_containers, acs1, nfail_dev);
+
+  int nfail;
+  gkyl_cu_memcpy(&nfail, nfail_dev, sizeof(int), GKYL_CU_MEMCPY_D2H);
+  gkyl_cu_free(nfail_dev);
+
+  return nfail;
+}
+
+//
+// Functions for test_container_pack.
+//
+

--- a/unit/ctest_struct_of_arrays_cu.cu
+++ b/unit/ctest_struct_of_arrays_cu.cu
@@ -4,7 +4,6 @@
 
 extern "C" {
 #include <gkyl_array_ops.h>
-#include "gkyl_struct_of_arrays.h"
 #include <gkyl_util.h>
 #include <gkyl_alloc.h>
   // Functions for test_array_container.
@@ -14,7 +13,14 @@ extern "C" {
     struct gkyl_array_container *acs1, double a, struct gkyl_array_container *acs2);
   int test_array_container_accumulate_dev_check_cu(int arr_ncomp, int arr_size, int num_containers,
     struct gkyl_array_container *acs1);
-  // Functions for test_container_pack.
+
+  struct gkyl_array_container {
+    struct gkyl_array *arr;
+  };
+  
+  struct gkyl_container_pack {
+    struct gkyl_array_container *ac;
+  };
 }
 
 #define START_ID (threadIdx.x + blockIdx.x*blockDim.x)

--- a/unit/gkyl_struct_of_arrays.h
+++ b/unit/gkyl_struct_of_arrays.h
@@ -1,0 +1,9 @@
+#include <gkyl_array.h>
+
+struct gkyl_array_container {
+  struct gkyl_array *arr;
+};
+
+struct gkyl_container_pack {
+  struct gkyl_array_container *ac;
+};

--- a/unit/gkyl_struct_of_arrays.h
+++ b/unit/gkyl_struct_of_arrays.h
@@ -1,9 +1,0 @@
-#include <gkyl_array.h>
-
-struct gkyl_array_container {
-  struct gkyl_array *arr;
-};
-
-struct gkyl_container_pack {
-  struct gkyl_array_container *ac;
-};


### PR DESCRIPTION
Just a unit test showing how to use structs to wrap arrays to create arrays of gkyl_arrays, or arrays of arrays of gkyl_arrays.
It's kind of amazing that one can do this, especially since I think (not tested, just though of this now) you could simply use a single struct with recursion and create arrays of arrays of arrays of..

We are trying to use similar workflows in radiation, so I wanted to demo/test it here.

FYI @jRoeltgen