### PR TITLE
Single species positivity fix

### DIFF
--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -606,9 +606,20 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
     }
   }
 
-  // Positivity enforcing by shifting f.
   if (app->enforce_positivity) {
+    // Positivity enforcing by shifting f (ps=positivity shift).
     gks->ps_delta_m0 = mkarr(app->use_gpu, app->confBasis.num_basis, app->local_ext.volume);
+
+    // Set pointers to total ion/electron Delta m0.
+    if (gks->info.charge > 0.0) {
+      gks->ps_delta_m0s_tot = gkyl_array_acquire(app->ps_delta_m0_ions);
+      gks->ps_delta_m0r_tot = gkyl_array_acquire(app->ps_delta_m0_elcs);
+    }
+    else {
+      gks->ps_delta_m0s_tot = gkyl_array_acquire(app->ps_delta_m0_elcs);
+      gks->ps_delta_m0r_tot = gkyl_array_acquire(app->ps_delta_m0_ions);
+    }
+
     gks->pos_shift_op = gkyl_positivity_shift_gyrokinetic_new(app->confBasis, app->basis,
       gks->grid, gks->info.mass, app->gk_geom, gks->vel_map, &app->local_ext, app->use_gpu);
 
@@ -925,6 +936,8 @@ gk_species_release(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
 
   if (app->enforce_positivity) {
     gkyl_array_release(s->ps_delta_m0);
+    gkyl_array_release(s->ps_delta_m0s_tot);
+    gkyl_array_release(s->ps_delta_m0r_tot);
     gkyl_positivity_shift_gyrokinetic_release(s->pos_shift_op);
     gk_species_moment_release(app, &s->ps_moms);
     gkyl_dynvec_release(s->ps_integ_diag);

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -559,6 +559,8 @@ struct gk_species {
   // Updater that enforces positivity by shifting f.
   struct gkyl_positivity_shift_gyrokinetic *pos_shift_op;
   struct gkyl_array *ps_delta_m0; // Number density of the positivity shift.
+  struct gkyl_array *ps_delta_m0s_tot; // Density of total positivity shift (like-species).
+  struct gkyl_array *ps_delta_m0r_tot; // Density of total positivity shift (other species).
   struct gk_species_moment ps_moms; // Positivity shift diagnostic moments.
   gkyl_dynvec ps_integ_diag; // Integrated moments of the positivity shift.
   bool is_first_ps_integ_write_call; // Flag first time writing ps_integ_diag.
@@ -760,6 +762,7 @@ struct gkyl_gyrokinetic_app {
   int num_species;
   struct gk_species *species; // data for each species
   struct gkyl_array *ps_delta_m0_ions; // Number density of the total ion positivity shift.
+  struct gkyl_array *ps_delta_m0_elcs; // Number density of the total elc positivity shift.
   
   // neutral species data
   int num_neut_species;

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -159,8 +159,6 @@ gkyl_gyrokinetic_app_new(struct gkyl_gk *gk)
   app->use_gpu = false; // can't use GPUs if we don't have them!
 #endif
 
-  app->enforce_positivity = gk->enforce_positivity;
-
   app->num_periodic_dir = gk->num_periodic_dir;
   for (int d=0; d<cdim; ++d)
     app->periodic_dirs[d] = gk->periodic_dirs[d];
@@ -369,6 +367,13 @@ gkyl_gyrokinetic_app_new(struct gkyl_gk *gk)
   app->update_field = !gk->skip_field; // note inversion of truth value (default: update field)
   app->field = gk_field_new(gk, app); // initialize field, even if we are skipping field updates
 
+  app->enforce_positivity = gk->enforce_positivity;
+  if (app->enforce_positivity) {
+    // Number of density of the positivity shift added over all the ions.
+    app->ps_delta_m0_ions = mkarr(app->use_gpu, app->confBasis.num_basis, app->local_ext.volume);
+    app->ps_delta_m0_elcs = mkarr(app->use_gpu, app->confBasis.num_basis, app->local_ext.volume);
+  }
+
   // initialize each species
   for (int i=0; i<ns; ++i) 
     gk_species_init(gk, app, &app->species[i]);
@@ -423,11 +428,6 @@ gkyl_gyrokinetic_app_new(struct gkyl_gk *gk)
   }
   for (int i=0; i<neuts; ++i) {
     gk_neut_species_source_init(app, &app->neut_species[i], &app->neut_species[i].src);
-  }
-
-  if (app->enforce_positivity) {
-    // Number of density of the positivity shift added over all the ions.
-    app->ps_delta_m0_ions = mkarr(app->use_gpu, app->confBasis.num_basis, app->local_ext.volume);
   }
 
   // initialize stat object
@@ -2405,8 +2405,8 @@ rk3(gkyl_gyrokinetic_app* app, double dt0)
 
           if (app->enforce_positivity) {
             // Apply positivity shift if requested.
-            int elc_idx = -1;
             gkyl_array_clear(app->ps_delta_m0_ions, 0.0);
+            gkyl_array_clear(app->ps_delta_m0_elcs, 0.0);
             for (int i=0; i<app->num_species; ++i) {
               struct gk_species *gks = &app->species[i];
 
@@ -2417,25 +2417,15 @@ rk3(gkyl_gyrokinetic_app* app, double dt0)
               gkyl_positivity_shift_gyrokinetic_advance(gks->pos_shift_op, &app->local, &gks->local,
                 gks->f, gks->m0.marr, gks->ps_delta_m0);
 
-              // Accumulate the shift density of all ions:
-              if (gks->info.charge > 0.0)
-                gkyl_array_accumulate(app->ps_delta_m0_ions, 1.0, gks->ps_delta_m0);
-              else if (gks->info.charge < 0.0) 
-                elc_idx = i;
+              // Accumulate the shift density of all like-species:
+              gkyl_array_accumulate(gks->ps_delta_m0s_tot, 1.0, gks->ps_delta_m0);
             }
 
             // Rescale each species to enforce quasineutrality.
             for (int i=0; i<app->num_species; ++i) {
               struct gk_species *gks = &app->species[i];
-              if (gks->info.charge > 0.0 && app->num_species > 1) {
-                struct gk_species *gkelc = &app->species[elc_idx];
-                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
-                  gks->ps_delta_m0, app->ps_delta_m0_ions, gkelc->ps_delta_m0, gks->m0.marr, gks->f);
-              }
-              else {
-                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
-                  gks->ps_delta_m0, gks->ps_delta_m0, app->ps_delta_m0_ions, gks->m0.marr, gks->f);
-              }
+              gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
+                gks->ps_delta_m0, gks->ps_delta_m0s_tot, gks->ps_delta_m0r_tot, gks->m0.marr, gks->f);
 
               gkyl_array_accumulate(gks->fnew, 1.0, gks->f);
             }
@@ -2948,6 +2938,7 @@ gkyl_gyrokinetic_app_release(gkyl_gyrokinetic_app* app)
 {
   if (app->enforce_positivity) {
     gkyl_array_release(app->ps_delta_m0_ions);
+    gkyl_array_release(app->ps_delta_m0_elcs);
   }
 
   gkyl_gk_geometry_release(app->gk_geom);

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -2427,7 +2427,7 @@ rk3(gkyl_gyrokinetic_app* app, double dt0)
             // Rescale each species to enforce quasineutrality.
             for (int i=0; i<app->num_species; ++i) {
               struct gk_species *gks = &app->species[i];
-              if (gks->info.charge > 0.0) {
+              if (gks->info.charge > 0.0 && app->num_species > 1) {
                 struct gk_species *gkelc = &app->species[elc_idx];
                 gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
                   gks->ps_delta_m0, app->ps_delta_m0_ions, gkelc->ps_delta_m0, gks->m0.marr, gks->f);

--- a/zero/gkyl_positivity_shift_gyrokinetic.h
+++ b/zero/gkyl_positivity_shift_gyrokinetic.h
@@ -55,10 +55,8 @@ gkyl_positivity_shift_gyrokinetic_advance(gkyl_positivity_shift_gyrokinetic* up,
  * @param conf_rng Config-space range.
  * @param phase_rng Phase-space range.
  * @param delta_m0s M0 moment of the shift in fs.
- * @param delta_m0s_tot M0 moment of the shift in electrons (if scaling electrons)
- *                      or the total shift for all ions (if scaling ions).
- * @param delta_m0r M0 moment of the shift in electrons (if scaling ions) or of
- *                  the total shift for all ions (if scaling electrons).
+ * @param delta_m0s_tot Sum of M0 moment of the shift in species with same charge sign.
+ * @param delta_m0r_tot Sum of M0 moment of the shift in species with opposite charge sign.
  * @param m0s M0 moment of fs.
  * @param fs Distribution function of the species we wish to scale.
  */
@@ -66,7 +64,7 @@ void
 gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gkyl_positivity_shift_gyrokinetic* up,
   const struct gkyl_range *conf_rng, const struct gkyl_range *phase_rng,
   const struct gkyl_array *GKYL_RESTRICT delta_m0s, const struct gkyl_array *GKYL_RESTRICT delta_m0s_tot,
-  const struct gkyl_array *GKYL_RESTRICT delta_m0r, const struct gkyl_array *GKYL_RESTRICT m0s,
+  const struct gkyl_array *GKYL_RESTRICT delta_m0r_tot, const struct gkyl_array *GKYL_RESTRICT m0s,
   struct gkyl_array *GKYL_RESTRICT fs);
 
 /**

--- a/zero/positivity_shift_gyrokinetic.c
+++ b/zero/positivity_shift_gyrokinetic.c
@@ -175,7 +175,11 @@ gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gkyl_positivity_shift_gy
     const double *delta_m0r_c = gkyl_array_cfetch(delta_m0r, clinidx);
     const double *delta_m0s_tot_c = gkyl_array_cfetch(delta_m0s_tot, clinidx);
 
-    if (delta_m0r_c[0] > delta_m0s_tot_c[0]) {
+    // First condition in this if-statement is equivalent to
+    //   max((delta_m0r_c[0]-delta_m0s_tot_c[0])/abs(delta_m0r_c[0]-delta_m0s_tot_c[0]))
+    // and the second condition is to avoid division by 0.
+    if (delta_m0r_c[0] > delta_m0s_tot_c[0] &&
+        delta_m0s_tot_c[0] > 0.0) {
 
       const double *delta_m0s_c = gkyl_array_cfetch(delta_m0s, clinidx);
       const double *m0s_c = gkyl_array_cfetch(m0s, clinidx);

--- a/zero/positivity_shift_gyrokinetic_cu.cu
+++ b/zero/positivity_shift_gyrokinetic_cu.cu
@@ -240,7 +240,7 @@ gkyl_positivity_shift_gyrokinetic_quasineutrily_scale_cu_ker(
   struct gkyl_positivity_shift_gyrokinetic_kernels *kers,
   const struct gkyl_range conf_rng, const struct gkyl_range phase_rng,
   const struct gkyl_array *GKYL_RESTRICT delta_m0s, const struct gkyl_array *GKYL_RESTRICT delta_m0s_tot,
-  const struct gkyl_array *GKYL_RESTRICT delta_m0r, const struct gkyl_array *GKYL_RESTRICT m0s,
+  const struct gkyl_array *GKYL_RESTRICT delta_m0r_tot, const struct gkyl_array *GKYL_RESTRICT m0s,
   struct gkyl_array *GKYL_RESTRICT fs)
 {
   int pidx[GKYL_MAX_DIM];
@@ -253,23 +253,25 @@ gkyl_positivity_shift_gyrokinetic_quasineutrily_scale_cu_ker(
 
     long clinidx = gkyl_range_idx(&conf_rng, pidx);
 
-    const double *delta_m0r_c = (const double*) gkyl_array_cfetch(delta_m0r, clinidx);
+    const double *delta_m0r_tot_c = (const double*) gkyl_array_cfetch(delta_m0r_tot, clinidx);
     const double *delta_m0s_tot_c = (const double*) gkyl_array_cfetch(delta_m0s_tot, clinidx);
 
-    if (delta_m0r_c[0] > delta_m0s_tot_c[0]) {
+    // First condition in this if-statement is equivalent to
+    //   max((delta_m0r_tot_c[0]-delta_m0s_tot_c[0])/abs(delta_m0r_tot_c[0]-delta_m0s_tot_c[0]))
+    // and the second condition is to avoid division by 0.
+    if (delta_m0r_tot_c[0] > delta_m0s_tot_c[0] &&
+        delta_m0s_tot_c[0] > 0.0) {
+
       const double *delta_m0s_c = (const double*) gkyl_array_cfetch(delta_m0s, clinidx);
       const double *m0s_c = (const double*) gkyl_array_cfetch(m0s, clinidx);
 
-      // Compute the scaling factor (n_s+h)/n_s with h=(Delta n_r - Delta_n_s,tot) * Delta n_s/Delta_n_s,tot
-      // where for electrons:
-      //   - Delta n_r = Delta n_i,tot
-      //   - Delta n_s,tot = Delta n_e
-      // and for ions:
-      //   - Delta n_r = Delta n_e
-      //   - Delta n_s,tot = Delta n_i,tot
+      // Compute the scaling factor (n_s+h)/n_s with h=(Delta n_r,tot - Delta_n_s,tot) * Delta n_s/Delta_n_s,tot
+      //   - Delta n_s = shift in density of this species due to positivity shift.
+      //   - Delta n_s,tot = sum of Delta n for species with same charge sign.
+      //   - Delta n_r,tot = sum of Delta n for species with opposite charge sign.
       double delta_m0fac_c[num_cbasis];
-      for (int k=0; k<delta_m0r->ncomp; k++)
-        delta_m0fac_c[k] = delta_m0r_c[k] - delta_m0s_tot_c[k];
+      for (int k=0; k<delta_m0r_tot->ncomp; k++)
+        delta_m0fac_c[k] = delta_m0r_tot_c[k] - delta_m0s_tot_c[k];
 
       kers->conf_mul_op(delta_m0fac_c, delta_m0s_c, delta_m0fac_c);
 
@@ -297,11 +299,11 @@ void
 gkyl_positivity_shift_gyrokinetic_quasineutrality_scale_cu(gkyl_positivity_shift_gyrokinetic* up,
   const struct gkyl_range *conf_rng, const struct gkyl_range *phase_rng,
   const struct gkyl_array *GKYL_RESTRICT delta_m0s, const struct gkyl_array *GKYL_RESTRICT delta_m0s_tot,
-  const struct gkyl_array *GKYL_RESTRICT delta_m0r, const struct gkyl_array *GKYL_RESTRICT m0s,
+  const struct gkyl_array *GKYL_RESTRICT delta_m0r_tot, const struct gkyl_array *GKYL_RESTRICT m0s,
   struct gkyl_array *GKYL_RESTRICT fs)
 {
   int nblocks = phase_rng->nblocks, nthreads = phase_rng->nthreads;
   gkyl_positivity_shift_gyrokinetic_quasineutrily_scale_cu_ker<<<nblocks, nthreads>>>(
     up->kernels, *conf_rng, *phase_rng, delta_m0s->on_dev, delta_m0s_tot->on_dev,
-    delta_m0r->on_dev, m0s->on_dev, fs->on_dev);
+    delta_m0r_tot->on_dev, m0s->on_dev, fs->on_dev);
 }


### PR DESCRIPTION
There is a single line of code changed here. I think that the positivity fix should be fine by just skipping the electron loading in line 2431. The else statement in the loop should just evaluate everything to 1 because it's not loading the moments of the electrons. Addressing issue #494 