### PR TITLE
MB app update and other methods

### DIFF
--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -169,7 +169,6 @@ struct gkyl_gyrokinetic_multib {
   struct gkyl_comm *comm;  
 };
 
-
 /**
  * Construct a new gk multi-block app.
  *
@@ -209,7 +208,6 @@ void gkyl_gyrokinetic_multib_app_apply_ic_species(gkyl_gyrokinetic_multib_app* a
  * @param t0 Time for initial conditions
  */
 void gkyl_gyrokinetic_multib_app_apply_ic_neut_species(gkyl_gyrokinetic_multib_app* app, int sidx, double t0);
-
 
 /**
  * Initialize field from file

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -687,18 +687,18 @@ void gkyl_gyrokinetic_multib_app_write_conf(gkyl_gyrokinetic_multib_app* app, do
 void gkyl_gyrokinetic_multib_app_write(gkyl_gyrokinetic_multib_app* app, double tm, int frame);
 
 /**
- * Read geometry file.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_multib_app_read_geometry(gkyl_gyrokinetic_multib_app *app);
-
-/**
  * Write stats to file. Data is written in json format.
  *
  * @param app App object.
  */
 void gkyl_gyrokinetic_multib_app_stat_write(gkyl_gyrokinetic_multib_app* app);
+
+/**
+ * Read geometry file.
+ *
+ * @param app App object.
+ */
+void gkyl_gyrokinetic_multib_app_read_geometry(gkyl_gyrokinetic_multib_app *app);
 
 /**
  * Write output to console: this is mainly for diagnostic messages the

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -165,7 +165,7 @@ struct gkyl_gyrokinetic_multib {
   // field inputs
   struct gkyl_gyrokinetic_multib_field field;
 
- // communicator to used  
+  // communicator to use.  
   struct gkyl_comm *comm;  
 };
 

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -180,8 +180,8 @@ struct gkyl_gyrokinetic_multib {
 gkyl_gyrokinetic_multib_app* gkyl_gyrokinetic_multib_app_new(const struct gkyl_gyrokinetic_multib *mbinp);
 
 /**
- * Initialize species and field by projecting initial conditions on
- * basis functions.
+ * Initialize species by projecting initial conditions on
+ * basis functions, and the field by solving the field equations.
  *
  * @param app App object.
  * @param t0 Time for initial conditions.
@@ -300,12 +300,20 @@ void gkyl_gyrokinetic_multib_app_cout(const gkyl_gyrokinetic_multib_app* app, FI
 void gkyl_gyrokinetic_multib_app_write_topo(const gkyl_gyrokinetic_multib_app* app);
 
 /**
- * Calculate integrated diagnostic moments for plasma species (including sources).
+ * Write geometry file.
  *
- * @param tm Time at which integrated diagnostics are to be computed
  * @param app App object.
  */
-void gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app* app, double tm);
+void gkyl_gyrokinetic_multib_app_write_geometry(gkyl_gyrokinetic_multib_app *app);
+
+/**
+ * Write field data to file.
+ * 
+ * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_field(gkyl_gyrokinetic_multib_app* app, double tm, int frame);
 
 /**
  * Calculate integrated field energy
@@ -316,22 +324,12 @@ void gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app
 void gkyl_gyrokinetic_multib_app_calc_field_energy(gkyl_gyrokinetic_multib_app* app, double tm);
 
 /**
- * Write field and species data to file.
+ * Write field energy to file. Field energy data is appended to the
+ * same file.
  * 
  * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write(const gkyl_gyrokinetic_multib_app* app, double tm, int frame);
-
-/**
- * Write field data to file.
- * 
- * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_multib_app_write_field(const gkyl_gyrokinetic_multib_app* app, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_field_energy(gkyl_gyrokinetic_multib_app* app);
 
 /**
  * Write species data to file.
@@ -341,8 +339,7 @@ void gkyl_gyrokinetic_multib_app_write_field(const gkyl_gyrokinetic_multib_app* 
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_species(const gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
-
+void gkyl_gyrokinetic_multib_app_write_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
 
 /**
  * Write neutral species data to file.
@@ -352,114 +349,293 @@ void gkyl_gyrokinetic_multib_app_write_species(const gkyl_gyrokinetic_multib_app
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_neut_species(const gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_neut_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
 
 /**
- * Write source species data to file.
+ * Write diagnostic moments for species to file.
  * 
  * @param app App object.
  * @param sidx Index of species to initialize.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_source_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
 
 /**
- * Write source neutral species data to file.
+ * Write diagnostic moments for neutral species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments for a plasma species.
+ *
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_multib_app_calc_species_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm);
+
+/**
+ * Calculate integrated diagnostic moments for a neutral species.
+ *
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_multib_app_calc_neut_species_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm);
+
+/**
+ * Write integrated diagnostic moments for charged species to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ */
+void gkyl_gyrokinetic_multib_app_write_species_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx);
+
+/**
+ * Write integrated diagnostic moments for neutral species to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to initialize.
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx);
+
+/**
+ * Write species source to file.
  * 
  * @param app App object.
  * @param sidx Index of species to initialize.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_source_neut_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_source(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
 
 /**
- * Write collisional moments for species to file.
+ * Write neutral species source to file.
  * 
  * @param app App object.
  * @param sidx Index of species to initialize.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_coll_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_neut_species_source(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to initialize.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_species_source_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for neutral species source to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_source_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments for a plasma species source.
+ *
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_multib_app_calc_species_source_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm);
+
+/**
+ * Calculate integrated diagnostic moments for a neutral species source.
+ *
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_multib_app_calc_neut_species_source_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm);
+
+/**
+ * Write integrated diagnostic moments for charged species source to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ */
+void gkyl_gyrokinetic_multib_app_write_species_source_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx);
+
+/**
+ * Write integrated diagnostic moments for neutral species source to file. Integrated
+ * moments are appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of neutral species to write.
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_source_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx);
+
+/**
+ * Write LBO collisional moments for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_species_lbo_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+
+/**
+ * Write integrated correct Maxwellian status of the species BGK distribution function
+ * to file. Correct Maxwellian status is appended to the same file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ */
+void gkyl_gyrokinetic_multib_app_write_species_bgk_max_corr_status(gkyl_gyrokinetic_multib_app *app, int sidx);
 
 /**
  * Write radiation drag coefficients for species to file.
  * 
  * @param app App object.
- * @param sidx Index of species to initialize.
+ * @param sidx Index of species to write.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_rad_drag(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_rad_drag(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
 
 /**
  * Write radiation emissivity of each species that species sidx collides with
  * 
  * @param app App object.
- * @param sidx Index of species to initialize.
+ * @param sidx Index of species to write.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_rad_emissivity(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_rad_emissivity(gkyl_gyrokinetic_multib_app *app, int sidx, double tm, int frame);
+
+/**
+ * Calculate integrated diagnostic moments of the radiation model.
+ *
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time at which integrated diagnostics are to be computed
+ */
+void gkyl_gyrokinetic_multib_app_calc_species_rad_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm);
 
 /**
  * Write integrated moments of radiation rhs for radiating species 
  * 
  * @param app App object.
  * @param sidx Index of species from which to write radiation.
- * @param tm Time-stamp
  */
-void gkyl_gyrokinetic_multib_app_write_rad_integrated_moms(gkyl_gyrokinetic_multib_app *app, int sidx, double tm);
-
+void gkyl_gyrokinetic_multib_app_write_species_rad_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx);
 
 /**
  * Write iz react rate coefficients for species to file.
  * 
  * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_iz_react(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
-
-/**
- * Write recomb react rate coefficients for species to file.
- * 
- * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
- * @param tm Time-stamp
- * @param frame Frame number
- */
-void gkyl_gyrokinetic_multib_app_write_recomb_react(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_iz_react(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
 
 /**
  * Write iz react rate coefficients for species to file.
  * 
  * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_iz_react_neut(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_iz_react_neut(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
 
 /**
  * Write recomb react rate coefficients for species to file.
  * 
  * @param app App object.
- * @param sidx Index of species to initialize.
- * @param ridx Index of reaction to initialize.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
  * @param tm Time-stamp
  * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_recomb_react_neut(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_write_species_recomb_react(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
 
 /**
- * Write diagnostic moments for species to file.
+ * Write recomb react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_species_recomb_react_neut(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write cx react rate coefficients for species to file.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param ridx Index of reaction to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_cx_react_neut(gkyl_gyrokinetic_multib_app* app, int sidx, int ridx, double tm, int frame);
+
+/**
+ * Write the phase-space diagnostics for a charged species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_species_phase(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the phase-space diagnostics for a neutral species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_phase(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the conf-space diagnostics for a charged species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_species_conf(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write the conf-space diagnostics for a neutral species.
+ * 
+ * @param app App object.
+ * @param sidx Index of species to write.
+ * @param tm Time-stamp
+ * @param frame Frame number
+ */
+void gkyl_gyrokinetic_multib_app_write_neut_species_conf(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame);
+
+/**
+ * Write diagnostic moments for all species (including sources) to file.
  * 
  * @param app App object.
  * @param tm Time-stamp
@@ -468,52 +644,47 @@ void gkyl_gyrokinetic_multib_app_write_recomb_react_neut(gkyl_gyrokinetic_multib
 void gkyl_gyrokinetic_multib_app_write_mom(gkyl_gyrokinetic_multib_app *app, double tm, int frame);
 
 /**
- * Write diagnostic moments for species source to file.
- * 
+ * Calculate integrated diagnostic moments for all species (including sources).
+ *
  * @param app App object.
- * @param tm Time-stamp
- * @param frame Frame number
+ * @param tm Time at which integrated diagnostics are to be computed
  */
-void gkyl_gyrokinetic_multib_app_write_source_mom(gkyl_gyrokinetic_multib_app *app, double tm, int frame);
+void gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app* app, double tm);
 
 /**
- * Write integrated diagnostic moments for species to file. Integrated
- * moments are appended to the same file.
+ * Write integrated diagnostic moments for all species (including sources)
+ * to file. Integrated moments are appended to the same file.
  * 
  * @param app App object.
  */
 void gkyl_gyrokinetic_multib_app_write_integrated_mom(gkyl_gyrokinetic_multib_app *app);
 
 /**
- * Write integrated diagnostic moments for sources to file. Integrated
- * moments are appended to the same file.
+ * Write phase space diagnostics to file.
  * 
  * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_integrated_source_mom(gkyl_gyrokinetic_multib_app *app);
+void gkyl_gyrokinetic_multib_app_write_phase(gkyl_gyrokinetic_multib_app* app, double tm, int frame);
 
 /**
- * Write field energy to file. Field energy data is appended to the
- * same file.
+ * Write configuration space diagnostics to file.
  * 
  * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_field_energy(gkyl_gyrokinetic_multib_app* app);
+void gkyl_gyrokinetic_multib_app_write_conf(gkyl_gyrokinetic_multib_app* app, double tm, int frame);
 
 /**
- * Write integrated correct Maxwellian status of the species distribution function to file. Correct
- * Maxwellian status is appended to the same file.
+ * Write both conf and phase-space diagnostics to file.
  * 
  * @param app App object.
+ * @param tm Time-stamp
+ * @param frame Frame number
  */
-void gkyl_gyrokinetic_multib_app_write_max_corr_status(gkyl_gyrokinetic_multib_app *app);
-
-/**
- * Write geometry file.
- *
- * @param app App object.
- */
-void gkyl_gyrokinetic_multib_app_write_geometry(gkyl_gyrokinetic_multib_app *app);
+void gkyl_gyrokinetic_multib_app_write(gkyl_gyrokinetic_multib_app* app, double tm, int frame);
 
 /**
  * Read geometry file.

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -104,6 +104,7 @@ struct gkyl_gyrokinetic_multib_field_pb {
   int block_id; // block ID
 
   double polarization_bmag; 
+  enum gkyl_fem_parproj_bc_type fem_parbc;
 
   void *phi_wall_lo_ctx; // context for biased wall potential on lower wall
   // pointer to biased wall potential on lower wall function
@@ -125,7 +126,6 @@ struct gkyl_gyrokinetic_multib_field {
   // parameters for adiabatic electrons simulations
   double electron_mass, electron_charge, electron_density, electron_temp;
 
-  //enum gkyl_fem_parproj_bc_type fem_parbc;
   //struct gkyl_poisson_bc poisson_bcs;
 
   bool duplicate_across_blocks; // set to true if all blocks are identical  

--- a/apps/gkyl_gyrokinetic_multib_priv.h
+++ b/apps/gkyl_gyrokinetic_multib_priv.h
@@ -8,6 +8,7 @@
 struct gkyl_gyrokinetic_multib_app {
   char name[128]; // name of app
   struct gkyl_comm *comm; // global communicator to use
+  bool use_gpu; // Whether to use the GPU.
   
  // geometry and topology of all blocks in simulation
   struct gkyl_block_geom *block_geom;
@@ -16,7 +17,10 @@ struct gkyl_gyrokinetic_multib_app {
   double cfl_frac; // CFL fraction to use
   int num_species; // number of species
   int num_neut_species; // number of neutral species
+
   bool update_field; // true if there solving Poisson equation
+  struct gk_field *field; // Field object. MF 2024/10/20: will replace this
+                          // with MB field object.
 
   char species_name[GKYL_MAX_SPECIES][128]; // name of each species
   char neut_species_name[GKYL_MAX_SPECIES][128]; // name of each neutral species  
@@ -42,3 +46,35 @@ struct gyrokinetic_multib_output_meta {
   const char *app_name; // name of App
   const char *topo_file_name; // name of topology file
 };
+
+/** Time stepping API */
+
+/**
+ * Compute the gyrokinetic fields.
+ *
+ * @param app Multiblock gyrokinetic app.
+ * @param tcurr Current simulation time.
+ * @param fin Array of distribution functions (one for each species) .
+ */
+void gyrokinetic_multib_calc_field(struct gkyl_gyrokinetic_multib_app* app, double tcurr, const struct gkyl_array *fin[]);
+
+/**
+ * Compute the gyrokinetic fields and apply boundary conditions.
+ *
+ * @param app Gyrokinetic app.
+ * @param tcurr Current simulation time.
+ * @param distf Array of distribution functions (for each charged species).
+ * @param distf_neut Array of distribution functions (for each neutral species).
+ */
+void gyrokinetic_multib_calc_field_and_apply_bc(struct gkyl_gyrokinetic_multib_app* app, double tcurr,
+  struct gkyl_array *distf[], struct gkyl_array *distf_neut[]);
+
+/**
+ * Take time-step using the RK3 method. Also sets the status object
+ * which has the actual and suggested dts used. These can be different
+ * from the actual time-step.
+ *
+ * @param app Gyrokinetic app.
+ * @param dt0 Suggessted time step.
+ */
+struct gkyl_update_status gyrokinetic_multib_update_ssp_rk3(struct gkyl_gyrokinetic_multib_app* app, double dt0);

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1616,3 +1616,53 @@ void gk_field_calc_energy(gkyl_gyrokinetic_app *app, double tm, const struct gk_
  * @param f Field object to release
  */
 void gk_field_release(const gkyl_gyrokinetic_app* app, struct gk_field *f);
+
+/** Time stepping PI */
+
+/**
+ * Compute the gyrokinetic fields.
+ *
+ * @param app Gyrokinetic app.
+ * @param tcurr Current simulation time.
+ * @param fin Array of distribution functions (one for each species) .
+ */
+void gyrokinetic_calc_field(gkyl_gyrokinetic_app* app, double tcurr, const struct gkyl_array *fin[]);
+
+/**
+ * Compute the gyrokinetic fields and apply boundary conditions.
+ *
+ * @param app Gyrokinetic app.
+ * @param tcurr Current simulation time.
+ * @param distf Array of distribution functions (for each charged species).
+ * @param distf_neut Array of distribution functions (for each neutral species).
+ */
+void gyrokinetic_calc_field_and_apply_bc(gkyl_gyrokinetic_app* app, double tcurr,
+  struct gkyl_array *distf[], struct gkyl_array *distf_neut[]);
+
+/**
+ * Compute the RHS of the gyrokinetic equation (df/dt) and the minimum time
+ * step it requires for stability based on the CFL constraint.
+ *
+ * @param app Gyrokinetic app.
+ * @param tcurr Current simulation time.
+ * @param dt Suggested time step.
+ * @param fin Input array of charged-species distribution functions.
+ * @param fin_neut Input array of neutral-species distribution functions.
+ * @param fout Output array of charged-species distribution functions.
+ * @param fout_neut Output array of neutral-species distribution functions.
+ * @param st Time stepping status object.
+ */
+void gyrokinetic_rhs(gkyl_gyrokinetic_app* app, double tcurr, double dt,
+  const struct gkyl_array *fin[], struct gkyl_array *fout[], 
+  const struct gkyl_array *fin_neut[], struct gkyl_array *fout_neut[], 
+  struct gkyl_update_status *st); 
+
+/**
+ * Take time-step using the RK3 method. Also sets the status object
+ * which has the actual and suggested dts used. These can be different
+ * from the actual time-step.
+ *
+ * @param app Gyrokinetic app.
+ * @param dt0 Suggessted time step.
+ */
+struct gkyl_update_status gyrokinetic_update_ssp_rk3(gkyl_gyrokinetic_app* app, double dt0);

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1617,7 +1617,7 @@ void gk_field_calc_energy(gkyl_gyrokinetic_app *app, double tm, const struct gk_
  */
 void gk_field_release(const gkyl_gyrokinetic_app* app, struct gk_field *f);
 
-/** Time stepping PI */
+/** Time stepping API */
 
 /**
  * Compute the gyrokinetic fields.

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -440,10 +440,11 @@ gkyl_gyrokinetic_app_new(struct gkyl_gk *gk)
   return app;
 }
 
-// Compute fields.
-static void
-calc_field(gkyl_gyrokinetic_app* app, double tcurr, const struct gkyl_array *fin[])
+void
+gyrokinetic_calc_field(gkyl_gyrokinetic_app* app, double tcurr, const struct gkyl_array *fin[])
 {
+  // Compute fields.
+
   if (app->update_field) {
     // Compute electrostatic potential from gyrokinetic Poisson's equation.
     gk_field_accumulate_rho_c(app, app->field, fin);
@@ -466,15 +467,16 @@ calc_field(gkyl_gyrokinetic_app* app, double tcurr, const struct gkyl_array *fin
   }
 }
 
-// Compute fields and apply BCs.
-static void
-calc_field_and_apply_bc(gkyl_gyrokinetic_app* app, double tcurr, struct gkyl_array *distf[], struct gkyl_array *distf_neut[])
+void
+gyrokinetic_calc_field_and_apply_bc(gkyl_gyrokinetic_app* app, double tcurr,
+  struct gkyl_array *distf[], struct gkyl_array *distf_neut[])
 {
+  // Compute fields and apply BCs.
 
   // Compute the field.
   // MF 2024/09/27/: Need the cast here for consistency. Fixing
   // this may require removing 'const' from a lot of places.
-  calc_field(app, tcurr, (const struct gkyl_array **) distf);
+  gyrokinetic_calc_field(app, tcurr, (const struct gkyl_array **) distf);
 
   // Apply boundary conditions.
   for (int i=0; i<app->num_species; ++i) {
@@ -559,7 +561,7 @@ gkyl_gyrokinetic_app_apply_ic(gkyl_gyrokinetic_app* app, double t0)
       gk_species_bflux_rhs(app, s, &s->bflux, distf[i], distf[i]);
     }
   }
-  calc_field_and_apply_bc(app, 0., distf, distf_neut);
+  gyrokinetic_calc_field_and_apply_bc(app, 0., distf, distf_neut);
 }
 
 void
@@ -2122,19 +2124,12 @@ gkyl_gyrokinetic_app_write(gkyl_gyrokinetic_app* app, double tm, int frame)
 // ............. End of write functions ............... //
 // 
 
-// Take a forward Euler step with the suggested time-step dt. This may
-// not be the actual time-step taken. However, the function will never
-// take a time-step larger than dt even if it is allowed by
-// stability. The actual time-step and dt_suggested are returned in
-// the status object.
-static void
-forward_euler(gkyl_gyrokinetic_app* app, double tcurr, double dt,
+void
+gyrokinetic_rhs(gkyl_gyrokinetic_app* app, double tcurr, double dt,
   const struct gkyl_array *fin[], struct gkyl_array *fout[], 
   const struct gkyl_array *fin_neut[], struct gkyl_array *fout_neut[], 
   struct gkyl_update_status *st)
 {
-  app->stat.nfeuler += 1;
-
   double dtmin = DBL_MAX;
 
   // Compute necessary moments and boundary corrections for collisions.
@@ -2240,224 +2235,6 @@ forward_euler(gkyl_gyrokinetic_app* app, double tcurr, double dt,
   double dta = st->dt_actual = dt < dtmin ? dt : dtmin;
   st->dt_suggested = dtmin;
 
-  // Complete update of distribution functions.
-  for (int i=0; i<app->num_species; ++i) {
-    gkyl_array_accumulate(gkyl_array_scale(fout[i], dta), 1.0, fin[i]);
-  }
-  for (int i=0; i<app->num_neut_species; ++i) {
-    if (!app->neut_species[i].info.is_static) {
-      gkyl_array_accumulate(gkyl_array_scale(fout_neut[i], dta), 1.0, fin_neut[i]);
-    }
-  }
-
-}
-
-// Take time-step using the RK3 method. Also sets the status object
-// which has the actual and suggested dts used. These can be different
-// from the actual time-step.
-static struct gkyl_update_status
-rk3(gkyl_gyrokinetic_app* app, double dt0)
-{
-  const struct gkyl_array *fin[app->num_species];
-  struct gkyl_array *fout[app->num_species];
-  const struct gkyl_array *fin_neut[app->num_neut_species];
-  struct gkyl_array *fout_neut[app->num_neut_species];
-  struct gkyl_update_status st = { .success = true };
-
-  // time-stepper state
-  enum { RK_STAGE_1, RK_STAGE_2, RK_STAGE_3, RK_COMPLETE } state = RK_STAGE_1;
-
-  double tcurr = app->tcurr, dt = dt0;
-  while (state != RK_COMPLETE) {
-    switch (state) {
-      case RK_STAGE_1:
-        for (int i=0; i<app->num_species; ++i) {
-          fin[i] = app->species[i].f;
-          fout[i] = app->species[i].f1;
-        }
-        for (int i=0; i<app->num_neut_species; ++i) {
-          fin_neut[i] = app->neut_species[i].f;
-          if (!app->neut_species[i].info.is_static) {
-            fout_neut[i] = app->neut_species[i].f1;
-          }
-        }
-
-        forward_euler(app, tcurr, dt, fin, fout, fin_neut, fout_neut, &st);
-        // Compute the fields and apply BCs.
-        calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
-
-        dt = st.dt_actual;
-        state = RK_STAGE_2;
-        break;
-
-      case RK_STAGE_2:
-        for (int i=0; i<app->num_species; ++i) {
-          fin[i] = app->species[i].f1;
-          fout[i] = app->species[i].fnew;
-        }
-        for (int i=0; i<app->num_neut_species; ++i) {
-          if (!app->neut_species[i].info.is_static) {
-            fin_neut[i] = app->neut_species[i].f1;
-            fout_neut[i] = app->neut_species[i].fnew;
-          }
-          else {
-            fin_neut[i] = app->neut_species[i].f;
-          }
-        }
-
-        forward_euler(app, tcurr+dt, dt, fin, fout, fin_neut, fout_neut, &st);
-
-        if (st.dt_actual < dt) {
-
-          // Recalculate the field.
-          for (int i=0; i<app->num_species; ++i)
-            fin[i] = app->species[i].f;
-          calc_field(app, tcurr, fin);
-
-          // collect stats
-          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
-          app->stat.stage_2_dt_diff[0] = fmin(app->stat.stage_2_dt_diff[0],
-            dt_rel_diff);
-          app->stat.stage_2_dt_diff[1] = fmax(app->stat.stage_2_dt_diff[1],
-            dt_rel_diff);
-          app->stat.nstage_2_fail += 1;
-
-          dt = st.dt_actual;
-          state = RK_STAGE_1; // restart from stage 1
-
-        } 
-        else {
-          for (int i=0; i<app->num_species; ++i) {
-            array_combine(app->species[i].f1,
-              3.0/4.0, app->species[i].f, 1.0/4.0, app->species[i].fnew, &app->species[i].local_ext);
-          }
-          for (int i=0; i<app->num_neut_species; ++i) {
-            if (!app->neut_species[i].info.is_static) {
-              array_combine(app->neut_species[i].f1,
-                3.0/4.0, app->neut_species[i].f, 1.0/4.0, app->neut_species[i].fnew, &app->neut_species[i].local_ext);
-            }
-          }
-
-          // Compute the fields and apply BCs.
-          for (int i=0; i<app->num_species; ++i) {
-            fout[i] = app->species[i].f1;
-          }
-          for (int i=0; i<app->num_neut_species; ++i) {
-            fout_neut[i] = app->neut_species[i].f1;
-          }
-          calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
-
-          state = RK_STAGE_3;
-        }
-        break;
-
-      case RK_STAGE_3:
-        for (int i=0; i<app->num_species; ++i) {
-          fin[i] = app->species[i].f1;
-          fout[i] = app->species[i].fnew;
-        }
-        for (int i=0; i<app->num_neut_species; ++i) {
-          if (!app->neut_species[i].info.is_static) {
-            fin_neut[i] = app->neut_species[i].f1;
-            fout_neut[i] = app->neut_species[i].fnew;
-          }
-          else {
-            fin_neut[i] = app->neut_species[i].f;
-          }          
-        }
-
-        forward_euler(app, tcurr+dt/2, dt, fin, fout, fin_neut, fout_neut, &st);
-
-        if (st.dt_actual < dt) {
-          // Recalculate the field.
-          for (int i=0; i<app->num_species; ++i)
-            fin[i] = app->species[i].f;
-          calc_field(app, tcurr, fin);
-
-          // collect stats
-          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
-          app->stat.stage_3_dt_diff[0] = fmin(app->stat.stage_3_dt_diff[0],
-            dt_rel_diff);
-          app->stat.stage_3_dt_diff[1] = fmax(app->stat.stage_3_dt_diff[1],
-            dt_rel_diff);
-          app->stat.nstage_3_fail += 1;
-
-          dt = st.dt_actual;
-          state = RK_STAGE_1; // restart from stage 1
-
-          app->stat.nstage_2_fail += 1;
-        }
-        else {
-          for (int i=0; i<app->num_species; ++i) {
-            array_combine(app->species[i].f1,
-              1.0/3.0, app->species[i].f, 2.0/3.0, app->species[i].fnew, &app->species[i].local_ext);
-            gkyl_array_copy_range(app->species[i].f, app->species[i].f1, &app->species[i].local_ext);
-          }
-          for (int i=0; i<app->num_neut_species; ++i) {
-            if (!app->neut_species[i].info.is_static) {
-              array_combine(app->neut_species[i].f1,
-                1.0/3.0, app->neut_species[i].f, 2.0/3.0, app->neut_species[i].fnew, &app->neut_species[i].local_ext);
-              gkyl_array_copy_range(app->neut_species[i].f, app->neut_species[i].f1, &app->neut_species[i].local_ext);
-            }
-          }
-
-          if (app->enforce_positivity) {
-            // Apply positivity shift if requested.
-            int elc_idx = -1;
-            gkyl_array_clear(app->ps_delta_m0_ions, 0.0);
-            for (int i=0; i<app->num_species; ++i) {
-              struct gk_species *gks = &app->species[i];
-
-              // Copy f so we can calculate the moments of the change later. 
-              gkyl_array_set(gks->fnew, -1.0, gks->f);
-
-              // Shift each species.
-              gkyl_positivity_shift_gyrokinetic_advance(gks->pos_shift_op, &app->local, &gks->local,
-                gks->f, gks->m0.marr, gks->ps_delta_m0);
-
-              // Accumulate the shift density of all ions:
-              if (gks->info.charge > 0.0)
-                gkyl_array_accumulate(app->ps_delta_m0_ions, 1.0, gks->ps_delta_m0);
-              else if (gks->info.charge < 0.0) 
-                elc_idx = i;
-            }
-
-            // Rescale each species to enforce quasineutrality.
-            for (int i=0; i<app->num_species; ++i) {
-              struct gk_species *gks = &app->species[i];
-              if (gks->info.charge > 0.0) {
-                struct gk_species *gkelc = &app->species[elc_idx];
-                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
-                  gks->ps_delta_m0, app->ps_delta_m0_ions, gkelc->ps_delta_m0, gks->m0.marr, gks->f);
-              }
-              else {
-                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
-                  gks->ps_delta_m0, gks->ps_delta_m0, app->ps_delta_m0_ions, gks->m0.marr, gks->f);
-              }
-
-              gkyl_array_accumulate(gks->fnew, 1.0, gks->f);
-            }
-          }
-
-          // Compute the fields and apply BCs
-          for (int i=0; i<app->num_species; ++i) {
-            fout[i] = app->species[i].f;
-          }
-          for (int i=0; i<app->num_neut_species; ++i) {
-            fout_neut[i] = app->neut_species[i].f;
-          }
-          calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
-
-          state = RK_COMPLETE;
-        }
-        break;
-
-      case RK_COMPLETE: // can't happen: suppresses warning
-        break;
-    }
-  }
-
-  return st;
 }
 
 struct gkyl_update_status
@@ -2466,7 +2243,7 @@ gkyl_gyrokinetic_update(gkyl_gyrokinetic_app* app, double dt)
   app->stat.nup += 1;
   struct timespec wst = gkyl_wall_clock();
 
-  struct gkyl_update_status status = rk3(app, dt);
+  struct gkyl_update_status status = gyrokinetic_update_ssp_rk3(app, dt);
   app->tcurr += status.dt_actual;
 
   app->stat.total_tm += gkyl_time_diff_now_sec(wst);
@@ -2914,7 +2691,7 @@ gkyl_gyrokinetic_app_read_from_frame(gkyl_gyrokinetic_app *app, int frame)
         gk_species_bflux_rhs(app, s, &s->bflux, distf[i], distf[i]);
       }
     }
-    calc_field_and_apply_bc(app, rstat.stime, distf, distf_neut);
+    gyrokinetic_calc_field_and_apply_bc(app, rstat.stime, distf, distf_neut);
   }
 
   app->field->is_first_energy_write_call = false; // Append to existing diagnostic.

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -561,7 +561,7 @@ gkyl_gyrokinetic_app_apply_ic(gkyl_gyrokinetic_app* app, double t0)
       gk_species_bflux_rhs(app, s, &s->bflux, distf[i], distf[i]);
     }
   }
-  gyrokinetic_calc_field_and_apply_bc(app, 0., distf, distf_neut);
+  gyrokinetic_calc_field_and_apply_bc(app, t0, distf, distf_neut);
 }
 
 void

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -566,8 +566,8 @@ void
 gkyl_gyrokinetic_multib_app_apply_ic_species(gkyl_gyrokinetic_multib_app* app, int sidx, double t0)
 {
   app->tcurr = t0;
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_apply_ic_species(app->singleb_apps[i], sidx, t0);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_apply_ic_species(app->singleb_apps[b], sidx, t0);
   }
   gkyl_comm_barrier(app->comm);
 }
@@ -576,8 +576,8 @@ void
 gkyl_gyrokinetic_multib_app_apply_ic_neut_species(gkyl_gyrokinetic_multib_app* app, int sidx, double t0)
 {
   app->tcurr = t0;
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_apply_ic_neut_species(app->singleb_apps[i], sidx, t0);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_apply_ic_neut_species(app->singleb_apps[b], sidx, t0);
   }
   gkyl_comm_barrier(app->comm);
 }
@@ -669,8 +669,8 @@ gkyl_gyrokinetic_multib_app_write_topo(const gkyl_gyrokinetic_multib_app* app)
 void
 gkyl_gyrokinetic_multib_app_write_field(gkyl_gyrokinetic_multib_app *app, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_field(app->singleb_apps[i], tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_field(app->singleb_apps[b], tm, frame);
   }
 
 // MF 2024/10/20: This stuff is corrupting the file.
@@ -700,8 +700,8 @@ gkyl_gyrokinetic_multib_app_write_field(gkyl_gyrokinetic_multib_app *app, double
 void
 gkyl_gyrokinetic_multib_app_write_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_species(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species(app->singleb_apps[b], sidx, tm, frame);
   }
 
 // MF 2024/10/20: This stuff is corrupting the file.
@@ -729,8 +729,8 @@ gkyl_gyrokinetic_multib_app_write_species(gkyl_gyrokinetic_multib_app* app, int 
 void
 gkyl_gyrokinetic_multib_app_write_neut_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_neut_species(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species(app->singleb_apps[b], sidx, tm, frame);
   }
 
 // MF 2024/10/20: This stuff is corrupting the file.
@@ -765,16 +765,16 @@ gkyl_gyrokinetic_multib_app_write_neut_species(gkyl_gyrokinetic_multib_app* app,
 void
 gkyl_gyrokinetic_multib_app_write_species_source(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_species_source(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_source(app->singleb_apps[b], sidx, tm, frame);
   }
 }
 
 void
 gkyl_gyrokinetic_multib_app_write_neut_species_source(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_neut_species_source(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_source(app->singleb_apps[b], sidx, tm, frame);
   }
 }
 
@@ -802,16 +802,16 @@ gkyl_gyrokinetic_multib_app_write_neut_species_phase(gkyl_gyrokinetic_multib_app
 void
 gkyl_gyrokinetic_multib_app_write_species_conf(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_species_conf(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_conf(app->singleb_apps[b], sidx, tm, frame);
   }
 }
 
 void
 gkyl_gyrokinetic_multib_app_write_neut_species_conf(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
-  for (int i=0; i<app->num_local_blocks; ++i) {
-    gkyl_gyrokinetic_app_write_neut_species_conf(app->singleb_apps[i], sidx, tm, frame);
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_conf(app->singleb_apps[b], sidx, tm, frame);
   }
 }
 
@@ -865,20 +865,51 @@ struct gkyl_update_status gkyl_gyrokinetic_multib_update(gkyl_gyrokinetic_multib
   app->tcurr += status.dt_actual;
 
   app->stat.total_tm += gkyl_time_diff_now_sec(wst);
+
   // Check for any CUDA errors during time step
   if (app->use_gpu)
     checkCuda(cudaGetLastError());
+
   return status;
 }
 
-struct gkyl_gyrokinetic_stat gkyl_gyrokinetic_multib_app_stat(gkyl_gyrokinetic_multib_app* app)
+struct gkyl_gyrokinetic_stat
+gkyl_gyrokinetic_multib_app_stat(gkyl_gyrokinetic_multib_app* app)
 {
+  app->stat.species_rhs_tm = 0.0;
+  for (int i=0; i<app->num_species; ++i) {
+    app->stat.species_lbo_coll_diff_tm[i] = 0.0;
+    app->stat.species_lbo_coll_drag_tm[i] = 0.0;
+  }
+
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+    gk_species_tm(sbapp);
+    for (int i=0; i<app->num_species; ++i) {
+      app->stat.species_rhs_tm += sbapp->stat.species_rhs_tm;
+    }
+
+    gk_species_coll_tm(sbapp);
+    for (int i=0; i<app->num_species; ++i) {
+      app->stat.species_lbo_coll_diff_tm[i] += sbapp->stat.species_lbo_coll_diff_tm[i];
+      app->stat.species_lbo_coll_drag_tm[i] += sbapp->stat.species_lbo_coll_drag_tm[i];
+    }
+  }
   return app->stat;
 }
 
 void gkyl_gyrokinetic_multib_app_species_ktm_rhs(gkyl_gyrokinetic_multib_app* app, int update_vol_term)
 {
   // TO DO
+}
+
+void
+gkyl_gyrokinetic_multib_app_stat_write(gkyl_gyrokinetic_multib_app* app)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+    gkyl_gyrokinetic_app_stat_write(sbapp);
+  }
 }
 
 void gkyl_gyrokinetic_multib_app_release(gkyl_gyrokinetic_multib_app* mbapp)

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -1136,7 +1136,8 @@ gkyl_gyrokinetic_multib_app_write(gkyl_gyrokinetic_multib_app* app, double tm, i
 // ............. End of write functions ............... //
 // 
 
-struct gkyl_update_status gkyl_gyrokinetic_multib_update(gkyl_gyrokinetic_multib_app* app, double dt)
+struct gkyl_update_status
+gkyl_gyrokinetic_multib_update(gkyl_gyrokinetic_multib_app* app, double dt)
 {
   app->stat.nup += 1;
   struct timespec wst = gkyl_wall_clock();

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -406,8 +406,11 @@ gkyl_gyrokinetic_multib_app* gkyl_gyrokinetic_multib_app_new(const struct gkyl_g
 
   int tot_max[2];
   calc_tot_and_max_cuts(mbinp->block_geom, tot_max);
-  if ((num_ranks > tot_max[0]) || (num_ranks < tot_max[1]))
+  if ((num_ranks > tot_max[0]) || (num_ranks < tot_max[1])) {
+    fprintf(stderr, "\nSpecified %d total cuts but provided %d processes, \
+and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot_max[1]);
     return 0;
+  }
 
   struct gkyl_gyrokinetic_multib_app *mbapp = gkyl_malloc(sizeof(*mbapp));
 
@@ -464,6 +467,8 @@ gkyl_gyrokinetic_multib_app* gkyl_gyrokinetic_multib_app_new(const struct gkyl_g
       branks[i], rank_list, mbapp->decomp[i], &status);
   }
   gkyl_free(rank_list);
+  gkyl_free(branks);
+
   mbapp->num_local_blocks = num_local_blocks;  
 
   printf("Rank %d handles %d Apps\n", my_rank, num_local_blocks);
@@ -493,11 +498,8 @@ gkyl_gyrokinetic_multib_app* gkyl_gyrokinetic_multib_app_new(const struct gkyl_g
   for (int i=0; i<num_local_blocks; ++i)
     mbapp->singleb_apps[i] = singleb_app_new(mbinp, mbapp->local_blocks[i], mbapp);
 
-  mbapp->stat = (struct gkyl_gyrokinetic_stat) {
-  };
+  mbapp->stat = (struct gkyl_gyrokinetic_stat) {};
 
-  gkyl_free(branks);
-  
   return mbapp;
 }
 

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -355,6 +355,14 @@ singleb_app_new(const struct gkyl_gyrokinetic_multib *mbinp, int bid,
   }
 
   // choose proper block-specific field input
+  for (int i=0; i<num_blocks; ++i) {
+    if (bid == fld->blocks[i].block_id) {
+      const struct gkyl_gyrokinetic_multib_field_pb *fld_pb = &fld->blocks[i];
+      field_inp.fem_parbc = fld_pb->fem_parbc;
+      break;
+    }
+  }
+
   const struct gkyl_gyrokinetic_multib_field_pb *fld_pb = &fld->blocks[0];
   if (!fld->duplicate_across_blocks) {
     for (int i=0; i<num_blocks; ++i) {

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -885,19 +885,43 @@ struct gkyl_gyrokinetic_stat
 gkyl_gyrokinetic_multib_app_stat(gkyl_gyrokinetic_multib_app* app)
 {
   app->stat.species_rhs_tm = 0.0;
+  app->stat.field_rhs_tm = 0.0;
+  app->stat.species_coll_mom_tm = 0.0;
+  app->stat.species_coll_tm = 0.0;
+  app->stat.species_bc_tm = 0.0;
+  app->stat.field_bc_tm = 0.0;
+  app->stat.nspecies_omega_cfl = 0;
+  app->stat.species_omega_cfl_tm = 0.0;
+  app->stat.nmom = 0;
+  app->stat.mom_tm = 0.0;
+  app->stat.ndiag = 0;
+  app->stat.diag_tm = 0.0;
+  app->stat.nio = 0;
+  app->stat.io_tm = 0.0;
   for (int i=0; i<app->num_species; ++i) {
     app->stat.species_lbo_coll_diff_tm[i] = 0.0;
     app->stat.species_lbo_coll_drag_tm[i] = 0.0;
   }
 
   for (int b=0; b<app->num_local_blocks; ++b) {
+    // Add time spent on various operations for each local block.
     struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
-    gk_species_tm(sbapp);
-    for (int i=0; i<app->num_species; ++i) {
-      app->stat.species_rhs_tm += sbapp->stat.species_rhs_tm;
-    }
+    struct gkyl_gyrokinetic_stat sb_stat = gkyl_gyrokinetic_app_stat(sbapp);
 
-    gk_species_coll_tm(sbapp);
+    app->stat.species_rhs_tm += sb_stat.species_rhs_tm;
+    app->stat.field_rhs_tm += sb_stat.field_rhs_tm;
+    app->stat.species_coll_mom_tm += sb_stat.species_coll_mom_tm;
+    app->stat.species_coll_tm += sb_stat.species_coll_tm;
+    app->stat.species_bc_tm += sb_stat.species_bc_tm;
+    app->stat.field_bc_tm += sb_stat.field_bc_tm;
+    app->stat.nspecies_omega_cfl += sb_stat.nspecies_omega_cfl;
+    app->stat.species_omega_cfl_tm += sb_stat.species_omega_cfl_tm;
+    app->stat.nmom += sb_stat.nmom;
+    app->stat.mom_tm += sb_stat.mom_tm;
+    app->stat.ndiag += sb_stat.ndiag;
+    app->stat.diag_tm += sb_stat.diag_tm;
+    app->stat.nio += sb_stat.nio;
+    app->stat.io_tm += sb_stat.io_tm;
     for (int i=0; i<app->num_species; ++i) {
       app->stat.species_lbo_coll_diff_tm[i] += sbapp->stat.species_lbo_coll_diff_tm[i];
       app->stat.species_lbo_coll_drag_tm[i] += sbapp->stat.species_lbo_coll_drag_tm[i];

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -645,7 +645,7 @@ gkyl_gyrokinetic_multib_app_from_frame_neut_species(gkyl_gyrokinetic_multib_app 
 
 // private function to handle variable argument list for printing
 static void
-v_gyrokinetic_app_cout(const gkyl_gyrokinetic_multib_app* app, FILE *fp, const char *fmt, va_list argp)
+v_gyrokinetic_multib_app_cout(const gkyl_gyrokinetic_multib_app* app, FILE *fp, const char *fmt, va_list argp)
 {
   int rank;
   gkyl_comm_get_rank(app->comm, &rank);
@@ -658,7 +658,7 @@ gkyl_gyrokinetic_multib_app_cout(const gkyl_gyrokinetic_multib_app* app, FILE *f
 {
   va_list argp;
   va_start(argp, fmt);
-  v_gyrokinetic_app_cout(app, fp, fmt, argp);
+  v_gyrokinetic_multib_app_cout(app, fp, fmt, argp);
   va_end(argp);
 }
 
@@ -705,6 +705,29 @@ gkyl_gyrokinetic_multib_app_write_field(gkyl_gyrokinetic_multib_app *app, double
 //  gkyl_comm_barrier(app->comm);
 }
 
+void
+gkyl_gyrokinetic_multib_app_calc_field_energy(gkyl_gyrokinetic_multib_app* app, double tm)
+{
+  if (app->update_field) {
+    for (int b=0; b<app->num_local_blocks; ++b) {
+      gkyl_gyrokinetic_app_calc_field_energy(app->singleb_apps[b], tm);
+    }
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_field_energy(gkyl_gyrokinetic_multib_app* app)
+{
+  if (app->update_field) {
+    for (int b=0; b<app->num_local_blocks; ++b) {
+      gkyl_gyrokinetic_app_write_field_energy(app->singleb_apps[b]);
+    }
+  }
+}
+
+//
+// ............. Species outputs ............... //
+// 
 void
 gkyl_gyrokinetic_multib_app_write_species(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
 {
@@ -763,9 +786,53 @@ gkyl_gyrokinetic_multib_app_write_neut_species(gkyl_gyrokinetic_multib_app* app,
 //  gkyl_comm_barrier(app->comm);
 }
 
-//
-// ............. Species outputs ............... //
-// 
+void
+gkyl_gyrokinetic_multib_app_write_species_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_mom(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_neut_species_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_mom(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_species_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_calc_species_integrated_mom(app->singleb_apps[b], sidx, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_neut_species_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_calc_neut_species_integrated_mom(app->singleb_apps[b], sidx, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_species_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_integrated_mom(app->singleb_apps[b], sidx);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_neut_species_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_integrated_mom(app->singleb_apps[b], sidx);
+  }
+}
 
 //
 // ............. Source outputs ............... //
@@ -786,6 +853,108 @@ gkyl_gyrokinetic_multib_app_write_neut_species_source(gkyl_gyrokinetic_multib_ap
   }
 }
 
+void
+gkyl_gyrokinetic_multib_app_write_species_source_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_source_mom(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_neut_species_source_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_source_mom(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_species_source_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_calc_species_source_integrated_mom(app->singleb_apps[b], sidx, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_neut_species_source_integrated_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_calc_neut_species_source_integrated_mom(app->singleb_apps[b], sidx, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_species_source_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_source_integrated_mom(app->singleb_apps[b], sidx);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_neut_species_source_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_neut_species_source_integrated_mom(app->singleb_apps[b], sidx);
+  }
+}
+
+//
+// ............. Collision outputs ............... //
+// 
+void
+gkyl_gyrokinetic_multib_app_write_species_lbo_mom(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_lbo_mom(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_species_bgk_max_corr_status(gkyl_gyrokinetic_multib_app* app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_bgk_max_corr_status(app->singleb_apps[b], sidx);
+  }
+}
+
+//
+// ............. Radiation outputs ............... //
+// 
+void
+gkyl_gyrokinetic_multib_app_write_species_rad_drag(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_rad_drag(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_species_rad_emissivity(gkyl_gyrokinetic_multib_app* app, int sidx, double tm, int frame)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_rad_emissivity(app->singleb_apps[b], sidx, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_species_rad_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx, double tm)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_calc_species_rad_integrated_mom(app->singleb_apps[b], sidx, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_species_rad_integrated_mom(gkyl_gyrokinetic_multib_app *app, int sidx)
+{
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    gkyl_gyrokinetic_app_write_species_rad_integrated_mom(app->singleb_apps[b], sidx);
+  }
+}
+
 //
 // ............. Functions that group several outputs for a single species ............... //
 //
@@ -796,7 +965,7 @@ gkyl_gyrokinetic_multib_app_write_species_phase(gkyl_gyrokinetic_multib_app* app
 
   gkyl_gyrokinetic_multib_app_write_species_source(app, sidx, tm, frame);
 
-//  gkyl_gyrokinetic_multib_app_write_species_rad_drag(app, sidx, tm, frame);
+  gkyl_gyrokinetic_multib_app_write_species_rad_drag(app, sidx, tm, frame);
 }
 
 void
@@ -826,6 +995,53 @@ gkyl_gyrokinetic_multib_app_write_neut_species_conf(gkyl_gyrokinetic_multib_app*
 //
 // ............. Functions that group several species outputs ............... //
 // 
+void
+gkyl_gyrokinetic_multib_app_write_mom(gkyl_gyrokinetic_multib_app* app, double tm, int frame)
+{
+  for (int i=0; i<app->num_species; ++i) {
+    gkyl_gyrokinetic_multib_app_write_species_mom(app, i, tm, frame);
+    gkyl_gyrokinetic_multib_app_write_species_source_mom(app, i, tm, frame);
+    gkyl_gyrokinetic_multib_app_write_species_lbo_mom(app, i, tm, frame);
+    gkyl_gyrokinetic_multib_app_write_species_rad_emissivity(app, i, tm, frame);
+  }
+
+  for (int i=0; i<app->num_neut_species; ++i) {
+    gkyl_gyrokinetic_multib_app_write_neut_species_mom(app, i, tm, frame);
+    gkyl_gyrokinetic_multib_app_write_neut_species_source_mom(app, i, tm, frame);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_calc_integrated_mom(gkyl_gyrokinetic_multib_app* app, double tm)
+{
+  for (int i=0; i<app->num_species; ++i) {
+    gkyl_gyrokinetic_multib_app_calc_species_integrated_mom(app, i, tm);
+    gkyl_gyrokinetic_multib_app_calc_species_source_integrated_mom(app, i, tm);
+    gkyl_gyrokinetic_multib_app_calc_species_rad_integrated_mom(app, i, tm);
+  }
+
+  for (int i=0; i<app->num_neut_species; ++i) {
+    gkyl_gyrokinetic_multib_app_calc_neut_species_integrated_mom(app, i, tm);
+    gkyl_gyrokinetic_multib_app_calc_neut_species_source_integrated_mom(app, i, tm);
+  }
+}
+
+void
+gkyl_gyrokinetic_multib_app_write_integrated_mom(gkyl_gyrokinetic_multib_app *app)
+{
+  for (int i=0; i<app->num_species; ++i) {
+    gkyl_gyrokinetic_multib_app_write_species_integrated_mom(app, i);
+    gkyl_gyrokinetic_multib_app_write_species_source_integrated_mom(app, i);
+    gkyl_gyrokinetic_multib_app_write_species_bgk_max_corr_status(app, i);
+    gkyl_gyrokinetic_multib_app_write_species_rad_integrated_mom(app, i);
+  }
+
+  for (int i=0; i<app->num_neut_species; ++i) {
+    gkyl_gyrokinetic_multib_app_write_neut_species_integrated_mom(app, i);
+    gkyl_gyrokinetic_multib_app_write_neut_species_source_integrated_mom(app, i);
+  }
+}
+
 void
 gkyl_gyrokinetic_multib_app_write_conf(gkyl_gyrokinetic_multib_app* app, double tm, int frame)
 {

--- a/apps/gyrokinetic_multib_update_ssp_rk3.c
+++ b/apps/gyrokinetic_multib_update_ssp_rk3.c
@@ -1,0 +1,307 @@
+#include <gkyl_gyrokinetic_multib_priv.h>
+
+static void
+gyrokinetic_multib_forward_euler(struct gkyl_gyrokinetic_multib_app* app, double tcurr, double dt,
+  const struct gkyl_array *fin[], struct gkyl_array *fout[], 
+  const struct gkyl_array *fin_neut[], struct gkyl_array *fout_neut[], 
+  struct gkyl_update_status *st)
+{
+  // Take a forward Euler step with the suggested time-step dt. This may
+  // not be the actual time-step taken. However, the function will never
+  // take a time-step larger than dt even if it is allowed by
+  // stability. The actual time-step and dt_suggested are returned in
+  // the status object.
+  app->stat.nfeuler += 1;
+
+  double dtmin = DBL_MAX;
+
+  // Compute the time rate of change of the distributions, df/dt.
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    int li_charged = b * app->num_species;
+    int li_neut = b * app->num_neut_species;
+    gyrokinetic_rhs(app->singleb_apps[b], tcurr, dt, &fin[li_charged], &fout[li_charged],
+      &fin_neut[li_neut], &fout_neut[li_neut], st);
+    dtmin = fmin(dtmin, st->dt_actual);
+  }
+
+  // Reduce the time step across all non-local blocks.
+  double dt_max_rel_diff = 0.01;
+  // Check if dtmin is slightly smaller than dt. Use dt if it is
+  // (avoids retaking steps if dt changes are very small).
+  double dt_rel_diff = (dt-dtmin)/dt;
+  if (dt_rel_diff > 0 && dt_rel_diff < dt_max_rel_diff)
+    dtmin = dt;
+
+  // Compute minimum time-step across all processors.
+  double dtmin_local = dtmin, dtmin_global;
+  gkyl_comm_allreduce_host(app->comm, GKYL_DOUBLE, GKYL_MIN, 1, &dtmin_local, &dtmin_global);
+  dtmin = dtmin_global;
+
+  // Don't take a time-step larger that input dt.
+  double dta = st->dt_actual = dt < dtmin ? dt : dtmin;
+  st->dt_suggested = dtmin;
+
+  // Complete update of distribution functions.
+  for (int b=0; b<app->num_local_blocks; ++b) {
+    int li_charged = b * app->num_species;
+    int li_neut = b * app->num_neut_species;
+    for (int i=0; i<app->num_species; ++i) {
+      gkyl_array_accumulate(gkyl_array_scale(fout[li_charged+i], dta), 1.0, fin[li_charged+i]);
+    }
+    for (int i=0; i<app->num_neut_species; ++i) {
+      if (!app->singleb_apps[b]->neut_species[i].info.is_static) {
+        gkyl_array_accumulate(gkyl_array_scale(fout_neut[li_neut+i], dta), 1.0, fin_neut[li_neut+i]);
+      }
+    }
+  }
+
+}
+
+struct gkyl_update_status
+gyrokinetic_multib_update_ssp_rk3(struct gkyl_gyrokinetic_multib_app* app, double dt0)
+{
+  // Take time-step using the RK3 method. Also sets the status object
+  // which has the actual and suggested dts used. These can be different
+  // from the actual time-step.
+  const struct gkyl_array *fin[app->num_species * app->num_local_blocks];
+  struct gkyl_array *fout[app->num_species * app->num_local_blocks];
+  const struct gkyl_array *fin_neut[app->num_neut_species * app->num_local_blocks];
+  struct gkyl_array *fout_neut[app->num_neut_species * app->num_local_blocks];
+  struct gkyl_update_status st = { .success = true };
+
+  // time-stepper state
+  enum { RK_STAGE_1, RK_STAGE_2, RK_STAGE_3, RK_COMPLETE } state = RK_STAGE_1;
+
+  double tcurr = app->tcurr, dt = dt0;
+  while (state != RK_COMPLETE) {
+    switch (state) {
+      case RK_STAGE_1:
+        for (int b=0; b<app->num_local_blocks; ++b) {
+          struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+          int li_charged = b * app->num_species;
+          int li_neut = b * app->num_neut_species;
+          for (int i=0; i<app->num_species; ++i) {
+            fin[li_charged+i] = sbapp->species[i].f;
+            fout[li_charged+i] = sbapp->species[i].f1;
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            fin_neut[li_neut+i] = sbapp->neut_species[i].f;
+            if (!sbapp->neut_species[i].info.is_static) {
+              fout_neut[li_neut+i] = sbapp->neut_species[i].f1;
+            }
+          }
+        }
+
+        gyrokinetic_multib_forward_euler(app, tcurr, dt, fin, fout, fin_neut, fout_neut, &st);
+        // Compute the fields and apply BCs.
+        gyrokinetic_multib_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+        dt = st.dt_actual;
+        state = RK_STAGE_2;
+        break;
+
+      case RK_STAGE_2:
+        for (int b=0; b<app->num_local_blocks; ++b) {
+          struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+          int li_charged = b * app->num_species;
+          int li_neut = b * app->num_neut_species;
+          for (int i=0; i<app->num_species; ++i) {
+            fin[li_charged+i] = sbapp->species[i].f1;
+            fout[li_charged+i] = sbapp->species[i].fnew;
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            if (!sbapp->neut_species[i].info.is_static) {
+              fin_neut[li_neut+i] = sbapp->neut_species[i].f1;
+              fout_neut[li_neut+i] = sbapp->neut_species[i].fnew;
+            }
+            else {
+              fin_neut[i] = sbapp->neut_species[i].f;
+            }
+          }
+        }
+
+        gyrokinetic_multib_forward_euler(app, tcurr+dt, dt, fin, fout, fin_neut, fout_neut, &st);
+
+        if (st.dt_actual < dt) {
+
+          // Recalculate the field.
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            int li_charged = b * app->num_species;
+            for (int i=0; i<app->num_species; ++i)
+              fin[li_charged+i] = sbapp->species[i].f;
+          }
+          gyrokinetic_multib_calc_field(app, tcurr, fin);
+
+          // collect stats
+          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
+          app->stat.stage_2_dt_diff[0] = fmin(app->stat.stage_2_dt_diff[0],
+            dt_rel_diff);
+          app->stat.stage_2_dt_diff[1] = fmax(app->stat.stage_2_dt_diff[1],
+            dt_rel_diff);
+          app->stat.nstage_2_fail += 1;
+
+          dt = st.dt_actual;
+          state = RK_STAGE_1; // restart from stage 1
+
+        } 
+        else {
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            for (int i=0; i<app->num_species; ++i) {
+              array_combine(sbapp->species[i].f1,
+                3.0/4.0, sbapp->species[i].f, 1.0/4.0, sbapp->species[i].fnew, &sbapp->species[i].local_ext);
+            }
+            for (int i=0; i<app->num_neut_species; ++i) {
+              if (!sbapp->neut_species[i].info.is_static) {
+                array_combine(sbapp->neut_species[i].f1,
+                  3.0/4.0, sbapp->neut_species[i].f, 1.0/4.0, sbapp->neut_species[i].fnew, &sbapp->neut_species[i].local_ext);
+              }
+            }
+          }
+
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            int li_charged = b * app->num_species;
+            int li_neut = b * app->num_neut_species;
+            // Compute the fields and apply BCs.
+            for (int i=0; i<app->num_species; ++i) {
+              fout[li_charged+i] = sbapp->species[i].f1;
+            }
+            for (int i=0; i<app->num_neut_species; ++i) {
+              fout_neut[li_neut+i] = sbapp->neut_species[i].f1;
+            }
+          }
+          gyrokinetic_multib_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+          state = RK_STAGE_3;
+        }
+        break;
+
+      case RK_STAGE_3:
+        for (int b=0; b<app->num_local_blocks; ++b) {
+          struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+          int li_charged = b * app->num_species;
+          int li_neut = b * app->num_neut_species;
+          for (int i=0; i<app->num_species; ++i) {
+            fin[li_charged+i] = sbapp->species[i].f1;
+            fout[li_charged+i] = sbapp->species[i].fnew;
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            if (!sbapp->neut_species[i].info.is_static) {
+              fin_neut[li_neut+i] = sbapp->neut_species[i].f1;
+              fout_neut[li_neut+i] = sbapp->neut_species[i].fnew;
+            }
+            else {
+              fin_neut[li_neut+i] = sbapp->neut_species[i].f;
+            }          
+          }
+        }
+
+        gyrokinetic_multib_forward_euler(app, tcurr+dt/2, dt, fin, fout, fin_neut, fout_neut, &st);
+
+        if (st.dt_actual < dt) {
+          // Recalculate the field.
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            int li_charged = b * app->num_species;
+            for (int i=0; i<app->num_species; ++i)
+              fin[li_charged+i] = sbapp->species[i].f;
+          }
+          gyrokinetic_multib_calc_field(app, tcurr, fin);
+
+          // collect stats
+          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
+          app->stat.stage_3_dt_diff[0] = fmin(app->stat.stage_3_dt_diff[0],
+            dt_rel_diff);
+          app->stat.stage_3_dt_diff[1] = fmax(app->stat.stage_3_dt_diff[1],
+            dt_rel_diff);
+          app->stat.nstage_3_fail += 1;
+
+          dt = st.dt_actual;
+          state = RK_STAGE_1; // restart from stage 1
+
+          app->stat.nstage_2_fail += 1;
+        }
+        else {
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            for (int i=0; i<app->num_species; ++i) {
+              array_combine(sbapp->species[i].f1,
+                1.0/3.0, sbapp->species[i].f, 2.0/3.0, sbapp->species[i].fnew, &sbapp->species[i].local_ext);
+              gkyl_array_copy_range(sbapp->species[i].f, sbapp->species[i].f1, &sbapp->species[i].local_ext);
+            }
+            for (int i=0; i<app->num_neut_species; ++i) {
+              if (!sbapp->neut_species[i].info.is_static) {
+                array_combine(sbapp->neut_species[i].f1,
+                  1.0/3.0, sbapp->neut_species[i].f, 2.0/3.0, sbapp->neut_species[i].fnew, &sbapp->neut_species[i].local_ext);
+                gkyl_array_copy_range(sbapp->neut_species[i].f, sbapp->neut_species[i].f1, &sbapp->neut_species[i].local_ext);
+              }
+            }
+          }
+
+//          if (app->enforce_positivity) {
+//            // Apply positivity shift if requested.
+//            int elc_idx = -1;
+//            gkyl_array_clear(app->ps_delta_m0_ions, 0.0);
+//            for (int i=0; i<app->num_species; ++i) {
+//              struct gk_species *gks = &app->species[i];
+//
+//              // Copy f so we can calculate the moments of the change later. 
+//              gkyl_array_set(gks->fnew, -1.0, gks->f);
+//
+//              // Shift each species.
+//              gkyl_positivity_shift_gyrokinetic_advance(gks->pos_shift_op, &app->local, &gks->local,
+//                gks->f, gks->m0.marr, gks->ps_delta_m0);
+//
+//              // Accumulate the shift density of all ions:
+//              if (gks->info.charge > 0.0)
+//                gkyl_array_accumulate(app->ps_delta_m0_ions, 1.0, gks->ps_delta_m0);
+//              else if (gks->info.charge < 0.0) 
+//                elc_idx = i;
+//            }
+//
+//            // Rescale each species to enforce quasineutrality.
+//            for (int i=0; i<app->num_species; ++i) {
+//              struct gk_species *gks = &app->species[i];
+//              if (gks->info.charge > 0.0) {
+//                struct gk_species *gkelc = &app->species[elc_idx];
+//                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
+//                  gks->ps_delta_m0, app->ps_delta_m0_ions, gkelc->ps_delta_m0, gks->m0.marr, gks->f);
+//              }
+//              else {
+//                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
+//                  gks->ps_delta_m0, gks->ps_delta_m0, app->ps_delta_m0_ions, gks->m0.marr, gks->f);
+//              }
+//
+//              gkyl_array_accumulate(gks->fnew, 1.0, gks->f);
+//            }
+//          }
+
+          // Compute the fields and apply BCs
+          for (int b=0; b<app->num_local_blocks; ++b) {
+            struct gkyl_gyrokinetic_app *sbapp = app->singleb_apps[b];
+            int li_charged = b * app->num_species;
+            int li_neut = b * app->num_neut_species;
+            for (int i=0; i<app->num_species; ++i) {
+              fout[li_charged+i] = sbapp->species[i].f;
+            }
+            for (int i=0; i<app->num_neut_species; ++i) {
+              fout_neut[li_neut+i] = sbapp->neut_species[i].f;
+            }
+          }
+          gyrokinetic_multib_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+          state = RK_COMPLETE;
+        }
+        break;
+
+      case RK_COMPLETE: // can't happen: suppresses warning
+        break;
+    }
+  }
+
+  return st;
+}
+
+

--- a/apps/gyrokinetic_update_ssp_rk3.c
+++ b/apps/gyrokinetic_update_ssp_rk3.c
@@ -1,0 +1,239 @@
+#include <gkyl_gyrokinetic_priv.h>
+
+static void
+gyrokinetic_forward_euler(gkyl_gyrokinetic_app* app, double tcurr, double dt,
+  const struct gkyl_array *fin[], struct gkyl_array *fout[], 
+  const struct gkyl_array *fin_neut[], struct gkyl_array *fout_neut[], 
+  struct gkyl_update_status *st)
+{
+  // Take a forward Euler step with the suggested time-step dt. This may
+  // not be the actual time-step taken. However, the function will never
+  // take a time-step larger than dt even if it is allowed by
+  // stability. The actual time-step and dt_suggested are returned in
+  // the status object.
+  app->stat.nfeuler += 1;
+
+  // Compute the time rate of change of the distributions, df/dt.
+  gyrokinetic_rhs(app, tcurr, dt, fin, fout, fin_neut, fout_neut, st);
+
+  // Complete update of distribution functions.
+  double dta = st->dt_actual;
+  for (int i=0; i<app->num_species; ++i) {
+    gkyl_array_accumulate(gkyl_array_scale(fout[i], dta), 1.0, fin[i]);
+  }
+  for (int i=0; i<app->num_neut_species; ++i) {
+    if (!app->neut_species[i].info.is_static) {
+      gkyl_array_accumulate(gkyl_array_scale(fout_neut[i], dta), 1.0, fin_neut[i]);
+    }
+  }
+
+}
+
+struct gkyl_update_status
+gyrokinetic_update_ssp_rk3(gkyl_gyrokinetic_app* app, double dt0)
+{
+  // Take time-step using the RK3 method. Also sets the status object
+  // which has the actual and suggested dts used. These can be different
+  // from the actual time-step.
+  const struct gkyl_array *fin[app->num_species];
+  struct gkyl_array *fout[app->num_species];
+  const struct gkyl_array *fin_neut[app->num_neut_species];
+  struct gkyl_array *fout_neut[app->num_neut_species];
+  struct gkyl_update_status st = { .success = true };
+
+  // time-stepper state
+  enum { RK_STAGE_1, RK_STAGE_2, RK_STAGE_3, RK_COMPLETE } state = RK_STAGE_1;
+
+  double tcurr = app->tcurr, dt = dt0;
+  while (state != RK_COMPLETE) {
+    switch (state) {
+      case RK_STAGE_1:
+        for (int i=0; i<app->num_species; ++i) {
+          fin[i] = app->species[i].f;
+          fout[i] = app->species[i].f1;
+        }
+        for (int i=0; i<app->num_neut_species; ++i) {
+          fin_neut[i] = app->neut_species[i].f;
+          if (!app->neut_species[i].info.is_static) {
+            fout_neut[i] = app->neut_species[i].f1;
+          }
+        }
+
+        gyrokinetic_forward_euler(app, tcurr, dt, fin, fout, fin_neut, fout_neut, &st);
+        // Compute the fields and apply BCs.
+        gyrokinetic_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+        dt = st.dt_actual;
+        state = RK_STAGE_2;
+        break;
+
+      case RK_STAGE_2:
+        for (int i=0; i<app->num_species; ++i) {
+          fin[i] = app->species[i].f1;
+          fout[i] = app->species[i].fnew;
+        }
+        for (int i=0; i<app->num_neut_species; ++i) {
+          if (!app->neut_species[i].info.is_static) {
+            fin_neut[i] = app->neut_species[i].f1;
+            fout_neut[i] = app->neut_species[i].fnew;
+          }
+          else {
+            fin_neut[i] = app->neut_species[i].f;
+          }
+        }
+
+        gyrokinetic_forward_euler(app, tcurr+dt, dt, fin, fout, fin_neut, fout_neut, &st);
+
+        if (st.dt_actual < dt) {
+
+          // Recalculate the field.
+          for (int i=0; i<app->num_species; ++i)
+            fin[i] = app->species[i].f;
+          gyrokinetic_calc_field(app, tcurr, fin);
+
+          // collect stats
+          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
+          app->stat.stage_2_dt_diff[0] = fmin(app->stat.stage_2_dt_diff[0],
+            dt_rel_diff);
+          app->stat.stage_2_dt_diff[1] = fmax(app->stat.stage_2_dt_diff[1],
+            dt_rel_diff);
+          app->stat.nstage_2_fail += 1;
+
+          dt = st.dt_actual;
+          state = RK_STAGE_1; // restart from stage 1
+
+        } 
+        else {
+          for (int i=0; i<app->num_species; ++i) {
+            array_combine(app->species[i].f1,
+              3.0/4.0, app->species[i].f, 1.0/4.0, app->species[i].fnew, &app->species[i].local_ext);
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            if (!app->neut_species[i].info.is_static) {
+              array_combine(app->neut_species[i].f1,
+                3.0/4.0, app->neut_species[i].f, 1.0/4.0, app->neut_species[i].fnew, &app->neut_species[i].local_ext);
+            }
+          }
+
+          // Compute the fields and apply BCs.
+          for (int i=0; i<app->num_species; ++i) {
+            fout[i] = app->species[i].f1;
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            fout_neut[i] = app->neut_species[i].f1;
+          }
+          gyrokinetic_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+          state = RK_STAGE_3;
+        }
+        break;
+
+      case RK_STAGE_3:
+        for (int i=0; i<app->num_species; ++i) {
+          fin[i] = app->species[i].f1;
+          fout[i] = app->species[i].fnew;
+        }
+        for (int i=0; i<app->num_neut_species; ++i) {
+          if (!app->neut_species[i].info.is_static) {
+            fin_neut[i] = app->neut_species[i].f1;
+            fout_neut[i] = app->neut_species[i].fnew;
+          }
+          else {
+            fin_neut[i] = app->neut_species[i].f;
+          }          
+        }
+
+        gyrokinetic_forward_euler(app, tcurr+dt/2, dt, fin, fout, fin_neut, fout_neut, &st);
+
+        if (st.dt_actual < dt) {
+          // Recalculate the field.
+          for (int i=0; i<app->num_species; ++i)
+            fin[i] = app->species[i].f;
+          gyrokinetic_calc_field(app, tcurr, fin);
+
+          // collect stats
+          double dt_rel_diff = (dt-st.dt_actual)/st.dt_actual;
+          app->stat.stage_3_dt_diff[0] = fmin(app->stat.stage_3_dt_diff[0],
+            dt_rel_diff);
+          app->stat.stage_3_dt_diff[1] = fmax(app->stat.stage_3_dt_diff[1],
+            dt_rel_diff);
+          app->stat.nstage_3_fail += 1;
+
+          dt = st.dt_actual;
+          state = RK_STAGE_1; // restart from stage 1
+
+          app->stat.nstage_2_fail += 1;
+        }
+        else {
+          for (int i=0; i<app->num_species; ++i) {
+            array_combine(app->species[i].f1,
+              1.0/3.0, app->species[i].f, 2.0/3.0, app->species[i].fnew, &app->species[i].local_ext);
+            gkyl_array_copy_range(app->species[i].f, app->species[i].f1, &app->species[i].local_ext);
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            if (!app->neut_species[i].info.is_static) {
+              array_combine(app->neut_species[i].f1,
+                1.0/3.0, app->neut_species[i].f, 2.0/3.0, app->neut_species[i].fnew, &app->neut_species[i].local_ext);
+              gkyl_array_copy_range(app->neut_species[i].f, app->neut_species[i].f1, &app->neut_species[i].local_ext);
+            }
+          }
+
+          if (app->enforce_positivity) {
+            // Apply positivity shift if requested.
+            int elc_idx = -1;
+            gkyl_array_clear(app->ps_delta_m0_ions, 0.0);
+            for (int i=0; i<app->num_species; ++i) {
+              struct gk_species *gks = &app->species[i];
+
+              // Copy f so we can calculate the moments of the change later. 
+              gkyl_array_set(gks->fnew, -1.0, gks->f);
+
+              // Shift each species.
+              gkyl_positivity_shift_gyrokinetic_advance(gks->pos_shift_op, &app->local, &gks->local,
+                gks->f, gks->m0.marr, gks->ps_delta_m0);
+
+              // Accumulate the shift density of all ions:
+              if (gks->info.charge > 0.0)
+                gkyl_array_accumulate(app->ps_delta_m0_ions, 1.0, gks->ps_delta_m0);
+              else if (gks->info.charge < 0.0) 
+                elc_idx = i;
+            }
+
+            // Rescale each species to enforce quasineutrality.
+            for (int i=0; i<app->num_species; ++i) {
+              struct gk_species *gks = &app->species[i];
+              if (gks->info.charge > 0.0) {
+                struct gk_species *gkelc = &app->species[elc_idx];
+                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
+                  gks->ps_delta_m0, app->ps_delta_m0_ions, gkelc->ps_delta_m0, gks->m0.marr, gks->f);
+              }
+              else {
+                gkyl_positivity_shift_gyrokinetic_quasineutrality_scale(gks->pos_shift_op, &app->local, &gks->local,
+                  gks->ps_delta_m0, gks->ps_delta_m0, app->ps_delta_m0_ions, gks->m0.marr, gks->f);
+              }
+
+              gkyl_array_accumulate(gks->fnew, 1.0, gks->f);
+            }
+          }
+
+          // Compute the fields and apply BCs
+          for (int i=0; i<app->num_species; ++i) {
+            fout[i] = app->species[i].f;
+          }
+          for (int i=0; i<app->num_neut_species; ++i) {
+            fout_neut[i] = app->neut_species[i].f;
+          }
+          gyrokinetic_calc_field_and_apply_bc(app, tcurr, fout, fout_neut);
+
+          state = RK_COMPLETE;
+        }
+        break;
+
+      case RK_COMPLETE: // can't happen: suppresses warning
+        break;
+    }
+  }
+
+  return st;
+}
+

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -92,7 +92,7 @@ eval_density_ar(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT
 }
 
 void
-eval_density_arion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+eval_density_Ar1(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
   fout[0] = 1.0e5;
 }
@@ -538,7 +538,7 @@ main(int argc, char **argv)
     .projection = {
       .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
       .ctx_density = &ctx,
-      .density = eval_density_arion,
+      .density = eval_density_Ar1,
       .ctx_upar = &ctx,
       .upar= eval_upar,
       .ctx_temp = &ctx,
@@ -655,8 +655,8 @@ main(int argc, char **argv)
   struct gkyl_tok_geo_grid_inp grid_inp = {
       .ftype = GKYL_SOL_DN_OUT_MID, // type of geometry
       .rclose = 6.2,                // closest R to region of interest
-      .rright= 6.2,                 // Closest R to outboard SOL
-      .rleft= 2.0,                  // closest R to inboard SOL
+      .rright = 6.2,                // Closest R to outboard SOL
+      .rleft = 2.0,                 // closest R to inboard SOL
       .rmin = 1.1,                  // smallest R in machine
       .rmax = 6.2,                  // largest R in machine
       .use_cubics = false,          // Whether to use cubic representation of psi(R,Z) for field line tracing

--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -653,13 +653,13 @@ main(int argc, char **argv)
   };
 
   struct gkyl_tok_geo_grid_inp grid_inp = {
-      .ftype = GKYL_SOL_DN_OUT_MID, // type of geometry
-      .rclose = 6.2,                // closest R to region of interest
-      .rright = 6.2,                // Closest R to outboard SOL
-      .rleft = 2.0,                 // closest R to inboard SOL
-      .rmin = 1.1,                  // smallest R in machine
-      .rmax = 6.2,                  // largest R in machine
-      .use_cubics = false,          // Whether to use cubic representation of psi(R,Z) for field line tracing
+    .ftype = GKYL_SOL_DN_OUT_MID, // type of geometry
+    .rclose = 6.2,                // closest R to region of interest
+    .rright = 6.2,                // Closest R to outboard SOL
+    .rleft = 2.0,                 // closest R to inboard SOL
+    .rmin = 1.1,                  // smallest R in machine
+    .rmax = 6.2,                  // largest R in machine
+    .use_cubics = false,          // Whether to use cubic representation of psi(R,Z) for field line tracing
   };
 
   // GK app

--- a/regression/rt_multib_step_2x2v_p1.c
+++ b/regression/rt_multib_step_2x2v_p1.c
@@ -74,12 +74,12 @@ create_block_geom(void)
 
 
   struct gkyl_efit_inp efit_inp = {
-      // psiRZ and related inputs
-      .filepath = "./data/eqdsk/step.geqdsk",
-      .rz_poly_order = 2,
-      .flux_poly_order = 1,
-      .reflect = true,
-    };
+    // psiRZ and related inputs
+    .filepath = "./data/eqdsk/step.geqdsk",
+    .rz_poly_order = 2,
+    .flux_poly_order = 1,
+    .reflect = true,
+  };
 
   struct gkyl_efit *efit = gkyl_efit_new(&efit_inp);
   double psisep = efit->psisep;

--- a/regression/rt_multib_step_b2_2x2v_p1.c
+++ b/regression/rt_multib_step_b2_2x2v_p1.c
@@ -791,7 +791,7 @@ main(int argc, char **argv)
 
     .field = field,
 
-    .comm = comm
+    .comm = comm,
   };
 
   // Create app object.

--- a/regression/rt_multib_step_b2_2x2v_p1.c
+++ b/regression/rt_multib_step_b2_2x2v_p1.c
@@ -386,8 +386,8 @@ void
 calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_multib_app* app, double t_curr, bool force_calc)
 {
   if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
-//    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
-//    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
+    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
   }
 }
 
@@ -400,11 +400,11 @@ write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_multib_app* app, double
 
     gkyl_gyrokinetic_multib_app_write(app, t_curr, frame);
 
-//    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
-//    gkyl_gyrokinetic_multib_app_write_field_energy(app);
-//
-//    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
-//    gkyl_gyrokinetic_multib_app_write_integrated_mom(app);
+    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
+    gkyl_gyrokinetic_multib_app_write_field_energy(app);
+
+    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
+    gkyl_gyrokinetic_multib_app_write_integrated_mom(app);
   }
 }
 
@@ -652,8 +652,8 @@ main(int argc, char **argv)
     .lower = { -ctx.vpar_max_Ar, 0.0},
     .upper = {  ctx.vpar_max_Ar, ctx.mu_max_Ar}, 
     .cells = { cells_v[0], cells_v[1] },
-    .num_diag_moments = 7,
-    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
+    .num_diag_moments = 5,
+    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
 
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,

--- a/regression/rt_multib_step_b2_2x2v_p1.c
+++ b/regression/rt_multib_step_b2_2x2v_p1.c
@@ -63,20 +63,11 @@ create_block_geom(void)
   struct gkyl_efit *efit = gkyl_efit_new(&efit_inp);
   double psisep = efit->psisep;
   gkyl_efit_release(efit);
-  double psi_up_core = 1.8;
-  double psi_up_pf = 1.8;
   double psi_lo_outer_sol = 0.934;
-  double psi_lo_inner_sol = 1.45;
 
   int npsi_outer_sol = 4;
-  int npsi_core = 4;
-  int npsi_inner_sol = 4;
-  int npsi_lower_pf = 4;
-  int npsi_upper_pf = 4;
 
-  double ntheta_lower  = 8;
   double ntheta_middle = 8;
-  double ntheta_upper  = 8;
 
   double Lz = (M_PI-1e-14)*2.0;
   double theta_lo = -Lz/2.0, theta_up = Lz/2.0;
@@ -759,7 +750,7 @@ main(int argc, char **argv)
   // Field object
   struct gkyl_gyrokinetic_multib_field_pb field_blocks[1];
   field_blocks[0] = (struct gkyl_gyrokinetic_multib_field_pb) {
-    // No block specific field info for this simulation
+    .fem_parbc = GKYL_FEM_PARPROJ_NONE,
   };
 
   struct gkyl_block_physical_bcs field_phys_bcs[] = {

--- a/regression/rt_multib_step_b2_2x2v_p1.c
+++ b/regression/rt_multib_step_b2_2x2v_p1.c
@@ -477,10 +477,10 @@ main(int argc, char **argv)
 
   struct gkyl_block_physical_bcs elc_phys_bcs[] = {
     // block 2 BCs
-    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
-    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
   };
 
   struct gkyl_gyrokinetic_multib_species elc = {
@@ -489,7 +489,6 @@ main(int argc, char **argv)
     .lower = { -ctx.vpar_max_elc, 0.0},
     .upper = {  ctx.vpar_max_elc, ctx.mu_max_elc}, 
     .cells = { cells_v[0], cells_v[1] },
-    .no_by = true,
     .num_diag_moments = 7,
     .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
 
@@ -589,10 +588,10 @@ main(int argc, char **argv)
 
   struct gkyl_block_physical_bcs ion_phys_bcs[] = {
     // block 2 BCs
-    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
-    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
   };
 
   struct gkyl_gyrokinetic_multib_species ion = {
@@ -601,7 +600,6 @@ main(int argc, char **argv)
     .lower = { -ctx.vpar_max_ion, 0.0},
     .upper = {  ctx.vpar_max_ion, ctx.mu_max_ion}, 
     .cells = { cells_v[0], cells_v[1] },
-    .no_by = true,
     .num_diag_moments = 7,
     .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
 
@@ -653,8 +651,8 @@ main(int argc, char **argv)
     // block 2 BCs
     { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
     { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
-    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH },
   };
 
   struct gkyl_gyrokinetic_multib_species Ar1 = {
@@ -663,7 +661,6 @@ main(int argc, char **argv)
     .lower = { -ctx.vpar_max_Ar, 0.0},
     .upper = {  ctx.vpar_max_Ar, ctx.mu_max_Ar}, 
     .cells = { cells_v[0], cells_v[1] },
-    .no_by = true,
     .num_diag_moments = 7,
     .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
 
@@ -711,7 +708,6 @@ main(int argc, char **argv)
         },
       },
     },
-
   
     .duplicate_across_blocks = true,
     .blocks = Ar1_blocks,
@@ -739,9 +735,9 @@ main(int argc, char **argv)
   struct gkyl_block_physical_bcs Ar0_phys_bcs[] = {
     // block 2 BCs
     { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
-    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB},
-    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB},
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ZERO_FLUX },
   };
 
   struct gkyl_gyrokinetic_multib_neut_species Ar0 = {
@@ -788,10 +784,7 @@ main(int argc, char **argv)
     .use_gpu = app_args.use_gpu,
 
     .block_geom = bgeom,
-    .cfl_frac = 0.9,
     
-    .enforce_positivity = false,
-
     .num_species = 3,
     .species = { elc, ion, Ar1},
 
@@ -884,10 +877,28 @@ main(int argc, char **argv)
     step += 1;
   }
 
-//  gkyl_gyrokinetic_app_stat_write(app);
-//
-//  // Fetch simulation statistics.
-//  struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_app_stat(app);
+  gkyl_gyrokinetic_multib_app_stat_write(app);
+
+  // Fetch simulation statistics.
+  struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_multib_app_stat(app);
+
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "\n");
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Number of update calls %ld\n", stat.nup);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Number of forward-Euler calls %ld\n", stat.nfeuler);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Number of RK stage-2 failures %ld\n", stat.nstage_2_fail);
+  if (stat.nstage_2_fail > 0) {
+    gkyl_gyrokinetic_multib_app_cout(app, stdout, "Max rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[1]);
+    gkyl_gyrokinetic_multib_app_cout(app, stdout, "Min rel dt diff for RK stage-2 failures %g\n", stat.stage_2_dt_diff[0]);
+  }
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Number of RK stage-3 failures %ld\n", stat.nstage_3_fail);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Species RHS calc took %g secs\n", stat.species_rhs_tm);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Species collisions RHS calc took %g secs\n", stat.species_coll_tm);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Field RHS calc took %g secs\n", stat.field_rhs_tm);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Species collisional moments took %g secs\n", stat.species_coll_mom_tm);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Updates took %g secs\n", stat.total_tm);
+
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "Number of write calls %ld,\n", stat.nio);
+  gkyl_gyrokinetic_multib_app_cout(app, stdout, "IO time took %g secs \n", stat.io_tm);
 
   freeresources:
   // Free resources after simulation completion.

--- a/regression/rt_multib_step_b2_2x2v_p1.c
+++ b/regression/rt_multib_step_b2_2x2v_p1.c
@@ -1,0 +1,904 @@
+#include <gkyl_alloc.h>
+#include <gkyl_const.h>
+#include <gkyl_efit.h>
+#include <gkyl_gyrokinetic_multib.h>
+#include <gkyl_mpi_comm.h>
+#include <gkyl_null_comm.h>
+#include <gkyl_tok_geo.h>
+
+#include <rt_arg_parse.h>
+
+#ifdef GKYL_HAVE_MPI
+#include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#endif
+
+struct gkyl_block_geom*
+create_block_geom(void)
+{
+  // Only do b2 in the block layout below.
+  struct gkyl_block_geom *bgeom = gkyl_block_geom_new(2, 1);
+
+  /* Block layout and coordinates
+
+   x  
+   ^  
+   |
+   4  +------------------+------------------+------------------+
+   |  |b1                |b2                |b3                |
+   |  |lower outer SOL   |middle outer sol  |upper outer sol   |
+   |  |                  |                  |                  |
+   3  +------------------+------------------+------------------+
+   |  |b0               x|o b10            %|$ b4              |
+   |  |lower outer PF   x|o outer core     %|$ upper outer PF  |
+   |  |                 x|o                %|$                 |
+   |  +------------------+------------------+------------------+
+   2  +------------------+------------------+------------------+
+   |  |b9               x|o b11            %|$ b5              |
+   |  |lower inner PF   x|o inner core     %|$ upper inner PF  |
+   |  |                 x|o                %|$                 |
+   1  +------------------+------------------+------------------+
+   |  |b8                |b7                |b6                |
+   |  |lower inner SOL   |middle inner SOL  |upper inner SOL   |
+   |  |                  |                  |                  |
+   0  +------------------+------------------+------------------+
+
+      0 -----------1------------2------------3 -> z
+
+      Edges that touch coincide are physically connected unless
+      otherwise indicated by a special symbol. Edges with a special
+      symbol such as o,x,%, or % are instead connected to the other
+      edge with the same symbol. Edges that do not coincide with
+      another edge are a physical boundary.
+  */  
+
+  struct gkyl_efit_inp efit_inp = {
+    // psiRZ and related inputs
+    .filepath = "./data/eqdsk/step.geqdsk",
+    .rz_poly_order = 2,
+    .flux_poly_order = 1,
+    .reflect = true,
+  };
+
+  struct gkyl_efit *efit = gkyl_efit_new(&efit_inp);
+  double psisep = efit->psisep;
+  gkyl_efit_release(efit);
+  double psi_up_core = 1.8;
+  double psi_up_pf = 1.8;
+  double psi_lo_outer_sol = 0.934;
+  double psi_lo_inner_sol = 1.45;
+
+  int npsi_outer_sol = 4;
+  int npsi_core = 4;
+  int npsi_inner_sol = 4;
+  int npsi_lower_pf = 4;
+  int npsi_upper_pf = 4;
+
+  double ntheta_lower  = 8;
+  double ntheta_middle = 8;
+  double ntheta_upper  = 8;
+
+  double Lz = (M_PI-1e-14)*2.0;
+  double theta_lo = -Lz/2.0, theta_up = Lz/2.0;
+
+  // block 2. Middle outer SOL.
+  gkyl_block_geom_set_block(bgeom, 0, &(struct gkyl_block_geom_info) {
+      .lower = { psi_lo_outer_sol, theta_lo },
+      .upper = { psisep, theta_up },
+      .cells = { npsi_outer_sol, ntheta_middle},
+      .cuts = { 1, 1 },
+      .geometry = {
+        .world = {0.0},
+        .geometry_id = GKYL_TOKAMAK,
+        .efit_info = efit_inp,
+        .tok_grid_info = (struct gkyl_tok_geo_grid_inp) {
+          .ftype = GKYL_SOL_DN_OUT_MID,
+          .rclose = 6.2,                // closest R to region of interest
+          .rright = 6.2,                // Closest R to outboard SOL
+          .rleft = 2.0,                 // closest R to inboard SOL
+          .rmin = 1.1,                  // smallest R in machine
+          .rmax = 6.2,                  // largest R in machine
+          .use_cubics = false,          // Whether to use cubic representation of psi(R,Z) for field line tracing
+        }
+      },
+      
+      .connections[0] = { // x-direction connections
+        { .bid = 0, .dir = 0, .edge = GKYL_PHYSICAL}, // physical boundary
+        { .bid = 0, .dir = 0, .edge = GKYL_PHYSICAL}
+      },
+      .connections[1] = { // z-direction connections
+        { .bid = 0, .dir = 1, .edge = GKYL_PHYSICAL},
+        { .bid = 0, .dir = 1, .edge = GKYL_PHYSICAL}
+      }
+    }
+  );
+
+  return bgeom;
+}
+
+struct gk_step_ctx {
+  int cdim, vdim; // Dimensionality.
+  double chargeElc; // electron charge
+  double massElc; // electron mass
+  double chargeIon; // ion charge
+  double massIon; // ion mass
+  double massAr; // Argon mass
+  double Te; // electron temperature
+  double Ti; // ion temperature
+  double TAr; // Argon temperature
+  double vtIon;
+  double vtElc;
+  double vtAr;
+  double nuElc; // electron collision frequency
+  double nuIon; // ion collision frequency
+  double nuFrac; // Factor to multiply collision frequencies
+  double B0; // reference magnetic field
+  double n0; // reference density
+  double n0Ar; // Argon reference density
+  double nsource;
+  // Source parameters
+  double T_source; // Source electron temperature
+  double cx;
+  double cz;
+  // Space-time parameters.
+  int Nx; // Cell count (configuration space: x-direction).
+  int Nz; // Cell count (configuration space: z-direction).
+  int Nvpar; // Cell count (velocity space: parallel velocity direction).
+  int Nmu; // Cell count (velocity space: magnetic moment direction).
+  int cells[GKYL_MAX_DIM]; // Number of cells in all directions.
+  double vpar_max_elc; // Velocity space extents in vparallel for electrons
+  double mu_max_elc; // Velocity space extents in mu for electrons
+  double vpar_max_ion; // Velocity space extents in vparallel for ions
+  double mu_max_ion; // Velocity space extents in mu for ions
+  double vpar_max_Ar; // Velocity space extents in vparallel for Ar
+  double mu_max_Ar; // Velocity space extents in mu for Ar
+  double t_end; // end time
+  int num_frames; // number of output frames
+  int int_diag_calc_num; // Number of integrated diagnostics computations (=INT_MAX for every step).
+  double dt_failure_tol; // Minimum allowable fraction of initial time-step.
+  int num_failures_max; // Maximum allowable number of consecutive small time-steps.
+};
+
+struct gk_step_ctx
+create_ctx(void)
+{
+  int cdim = 2, vdim = 2; // Dimensionality.
+
+  double eps0 = GKYL_EPSILON0;
+  double eV = GKYL_ELEMENTARY_CHARGE;
+  double mi = 2.014*GKYL_PROTON_MASS; // ion mass
+  double mAr = 39.95*GKYL_PROTON_MASS; // Ar ion mass
+  double me = GKYL_ELECTRON_MASS;
+  double qi = eV; // ion charge
+  double qe = -eV; // electron charge
+
+  double Te = 100*2.8*eV;
+  double Ti = 150*2.8*eV;
+  double TAr = 40.0*eV;
+  double B0 = 2.51; // Magnetic field magnitude in Tesla
+  double n0 = 3.0e19/2.8; // Particle density in 1/m^3
+  double n0Ar = n0*0.0001/3.0; // Particle density in 1/m^3
+                             
+  // Derived parameters.
+  double vtIon = sqrt(Ti/mi);
+  double vtElc = sqrt(Te/me);
+  double vtAr = sqrt(TAr/mAr);
+
+  // Source parameters.
+  double nsource = 3.9e23/2.8; // peak source rate in particles/m^3/s 
+  double T_source = 285*eV*2.8;
+  double cx = 0.0065612*9;
+  double cz = 0.4916200;
+
+  // Collision parameters.
+  double nuFrac = 0.25;
+  double logLambdaElc = 6.6 - 0.5*log(n0/1e20) + 1.5*log(Te/eV);
+  double nuElc = nuFrac*logLambdaElc*pow(eV, 4.0)*n0/(6.0*sqrt(2.0)*M_PI*sqrt(M_PI)*eps0*eps0*sqrt(me)*(Te*sqrt(Te)));  // collision freq
+
+  double logLambdaIon = 6.6 - 0.5*log(n0/1e20) + 1.5*log(Ti/eV);
+  double nuIon = nuFrac*logLambdaIon*pow(eV, 4.0)*n0/(12.0*M_PI*sqrt(M_PI)*eps0*eps0*sqrt(mi)*(Ti*sqrt(Ti)));
+
+  // Simulation box size (m).
+
+  double vpar_max_elc = 4.0*vtElc;
+  double mu_max_elc = 18*me*vtElc*vtElc/(2.0*B0);
+
+  double vpar_max_ion = 4.0*vtIon;
+  double mu_max_ion = 18*mi*vtIon*vtIon/(2.0*B0);
+
+  double vpar_max_Ar = 4.0*vtAr;
+  double mu_max_Ar = 18.*mAr*vtAr*vtAr/(2.0*B0);
+
+  // Number of cells.
+  int Nx = 4;
+  int Nz = 8;
+  int Nvpar = 16;
+  int Nmu = 8;
+
+  double t_end = 5.0e-7; 
+  double num_frames = 1;
+  int int_diag_calc_num = num_frames*100;
+  double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
+  int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
+
+  struct gk_step_ctx ctx = {
+    .cdim = cdim,
+    .vdim = vdim,
+    .chargeElc = qe, 
+    .massElc = me, 
+    .chargeIon = qi, 
+    .massIon = mi,
+    .massAr = mAr,
+    .Te = Te, 
+    .Ti = Ti, 
+    .TAr = TAr, 
+    .vtIon = vtIon,
+    .vtElc = vtElc,
+    .vtAr = vtAr,
+    .nuElc = nuElc, 
+    .nuIon = nuIon, 
+    .nuFrac = nuFrac,
+    .B0 = B0, 
+    .n0 = n0, 
+    .n0Ar = n0Ar,
+    .T_source = T_source, 
+    .nsource = nsource,
+    .cx = cx,
+    .cz = cz,
+    .vpar_max_elc = vpar_max_elc, 
+    .mu_max_elc = mu_max_elc, 
+    .vpar_max_ion = vpar_max_ion, 
+    .mu_max_ion = mu_max_ion, 
+    .vpar_max_Ar = vpar_max_Ar, 
+    .mu_max_Ar = mu_max_Ar, 
+    .Nx = Nx,
+    .Nz = Nz,
+    .Nvpar = Nvpar,
+    .Nmu = Nmu,
+    .cells = {Nx, Nz, Nvpar, Nmu},
+    .t_end = t_end, 
+    .num_frames = num_frames, 
+    .int_diag_calc_num = int_diag_calc_num,
+    .dt_failure_tol = dt_failure_tol,
+    .num_failures_max = num_failures_max,
+  };
+  return ctx;
+}
+
+void
+init_density(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], z = xn[1];
+
+  struct gk_step_ctx *app = ctx;
+  double n0 = app->n0;
+  double cx = app->cx;
+  double cz = app->cz;
+  double xcenter = 1.2014;
+  double n = n0*exp(-(x-xcenter)*(x-xcenter)/2/cx/cx) * exp(-z*z/2/cz/cz);
+  if (n/n0 < 1e-5)
+    n = n0*1e-5;
+  fout[0] = n;
+}
+
+void
+init_density_Ar0(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], z = xn[1];
+
+  struct gk_step_ctx *app = ctx;
+  double n0 = app->n0Ar;
+  double cz = app->cz/1.4/2.0;
+  double zcenter = 3.14;
+  double n = 0.0;
+  if (z>0)
+    n = n0 * exp(-(z-zcenter)*(z-zcenter)/(2.0*cz*cz));
+  else
+    n = n0 * exp(-(z+zcenter)*(z+zcenter)/(2.0*cz*cz));
+  if (n < 1.0e8)
+    n = 1.0e8;
+
+  fout[0] = n;
+}
+
+void
+init_density_Ar1(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  fout[0] = 1.0e5;
+}
+
+void
+init_upar(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  fout[0] = 0.0;
+}
+
+void
+init_udrift_Ar0(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  fout[0] = 0.0; 
+  fout[1] = 0.0;
+  fout[2] = 0.0;
+}
+
+void
+init_temp_elc(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *app = ctx;
+  double T = app->Te;
+  fout[0] = T;
+}
+
+void
+init_temp_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *app = ctx;
+  double T = app->Ti;
+  fout[0] = T;
+}
+
+void
+init_temp_Ar(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *app = ctx;
+  double T = app->TAr;
+  fout[0] = T;
+}
+
+void
+init_density_source(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  double x = xn[0], z = xn[1];
+
+  struct gk_step_ctx *app = ctx;
+  double nsource = app->nsource;
+  double cx = app->cx;
+  double cz = app->cz;
+  double xcenter = 1.2014;
+  double n = nsource*exp(-(x-xcenter)*(x-xcenter)/2/cx/cx) * exp(-z*z/2/cz/cz);
+  if (n/nsource < 1e-5)
+    n = nsource*1e-5;
+  fout[0] = n;
+}
+
+void
+init_upar_source(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  fout[0] = 0.0;
+}
+
+void
+init_temp_source(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *app = ctx;
+  double n0 = app->n0;
+  double T = app->T_source;
+  fout[0] = T;
+}
+
+void
+init_nu_elc(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *input = ctx;
+  fout[0] = input->nuElc;
+}
+
+void
+init_nu_ion(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
+{
+  struct gk_step_ctx *input = ctx;
+  fout[0] = input->nuIon;
+}
+
+
+void
+calc_integrated_diagnostics(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_multib_app* app, double t_curr, bool force_calc)
+{
+  if (gkyl_tm_trigger_check_and_bump(iot, t_curr) || force_calc) {
+//    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
+//    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
+  }
+}
+
+void
+write_data(struct gkyl_tm_trigger* iot, gkyl_gyrokinetic_multib_app* app, double t_curr, bool force_write)
+{
+  bool trig_now = gkyl_tm_trigger_check_and_bump(iot, t_curr);
+  if (trig_now || force_write) {
+    int frame = (!trig_now) && force_write? iot->curr : iot->curr-1;
+
+    gkyl_gyrokinetic_multib_app_write(app, t_curr, frame);
+
+//    gkyl_gyrokinetic_multib_app_calc_field_energy(app, t_curr);
+//    gkyl_gyrokinetic_multib_app_write_field_energy(app);
+//
+//    gkyl_gyrokinetic_multib_app_calc_integrated_mom(app, t_curr);
+//    gkyl_gyrokinetic_multib_app_write_integrated_mom(app);
+  }
+}
+
+int
+main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+
+  // Construct communicator for use in app.
+  struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, stderr);
+
+  if (app_args.trace_mem) {
+    gkyl_cu_dev_mem_debug_set(true);
+    gkyl_mem_debug_set(true);
+  }
+  
+  // Construct block geometry.
+  struct gkyl_block_geom *bgeom = create_block_geom();
+  int nblocks = gkyl_block_geom_num_blocks(bgeom);
+
+  struct gk_step_ctx ctx = create_ctx(); // Context for init functions.
+  int cells_x[ctx.cdim], cells_v[ctx.vdim];
+  for (int d=0; d<ctx.cdim; d++)
+    cells_x[d] = APP_ARGS_CHOOSE(app_args.xcells[d], ctx.cells[d]);
+  for (int d=0; d<ctx.vdim; d++)
+    cells_v[d] = APP_ARGS_CHOOSE(app_args.vcells[d], ctx.cells[ctx.cdim+d]);
+
+  // Elc Species
+  // all data is common across blocks
+  struct gkyl_gyrokinetic_multib_species_pb elc_blocks[1];
+  elc_blocks[0] = (struct gkyl_gyrokinetic_multib_species_pb) {
+
+    .polarization_density = ctx.n0,
+
+    .projection = {
+      .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+      .ctx_density = &ctx,
+      .density = init_density,
+      .ctx_upar = &ctx,
+      .upar = init_upar,
+      .ctx_temp = &ctx,
+      .temp = init_temp_elc,
+    },
+
+    .source = {
+      .source_id = GKYL_PROJ_SOURCE,
+      .num_sources = 1,
+      .projection[0] = {
+        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+        .ctx_density = &ctx,
+        .density = init_density_source,
+        .ctx_upar = &ctx,
+        .upar = init_upar_source,
+        .ctx_temp = &ctx,
+        .temp = init_temp_source,      
+      }, 
+    },
+
+  };
+
+
+  struct gkyl_block_physical_bcs elc_phys_bcs[] = {
+    // block 2 BCs
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+  };
+
+  struct gkyl_gyrokinetic_multib_species elc = {
+    .name = "elc",
+    .charge = ctx.chargeElc, .mass = ctx.massElc,
+    .lower = { -ctx.vpar_max_elc, 0.0},
+    .upper = {  ctx.vpar_max_elc, ctx.mu_max_elc}, 
+    .cells = { cells_v[0], cells_v[1] },
+    .no_by = true,
+    .num_diag_moments = 7,
+    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
+
+    .collisions =  {
+      .collision_id = GKYL_LBO_COLLISIONS,
+      .normNu = true,
+      .nuFrac = ctx.nuFrac,
+      .n_ref = ctx.n0, // Density used to calculate coulomb logarithm
+      .T_ref = ctx.Te, // Temperature used to calculate coulomb logarithm
+      .ctx = &ctx,
+      .self_nu = init_nu_elc,
+      .num_cross_collisions = 2,
+      .collide_with = { "ion", "Ar1" },
+    },
+
+    .diffusion = {
+      .num_diff_dir = 1, 
+      .diff_dirs = { 0 },
+      .D = { 0.03 }, 
+      .order = 2, 
+    }, 
+
+    .radiation = {
+      .radiation_id = GKYL_GK_RADIATION, 
+      .num_cross_collisions = 1, 
+      .collide_with = { "Ar1" },
+      .z = 18,
+      .charge_state = 1,
+      .num_of_densities = 1, // Must be 1 for now
+    },
+
+    .react_neut = {
+      .num_react = 2,
+      .react_type = {
+        { .react_id = GKYL_REACT_IZ,
+          .type_self = GKYL_SELF_ELC,
+          .ion_id = GKYL_ION_AR,
+          .elc_nm = "elc",
+          .ion_nm = "Ar1", // ion is always the higher charge state
+          .donor_nm = "Ar0", // interacts with elc to give up charge
+          .charge_state = 0, // corresponds to lower charge state (donor)
+          .ion_mass = ctx.massAr,
+          .elc_mass = ctx.massElc,
+        },
+        { .react_id = GKYL_REACT_RECOMB,
+          .type_self = GKYL_SELF_ELC,
+          .ion_id = GKYL_ION_AR,
+          .elc_nm = "elc",
+          .ion_nm = "Ar1",
+          .recvr_nm = "Ar0",
+          .charge_state = 0,
+          .ion_mass = ctx.massAr,
+          .elc_mass = ctx.massElc,
+        },
+      },
+    }, 
+
+    .duplicate_across_blocks = true,
+    .blocks = elc_blocks,
+    .num_physical_bcs = 4,
+    .bcs = elc_phys_bcs,
+  };
+
+
+  // Ion Species
+  // all data is common across blocks
+  struct gkyl_gyrokinetic_multib_species_pb ion_blocks[1];
+  ion_blocks[0] = (struct gkyl_gyrokinetic_multib_species_pb) {
+
+    .polarization_density = ctx.n0,
+
+    .projection = {
+      .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+      .ctx_density = &ctx,
+      .density = init_density,
+      .ctx_upar = &ctx,
+      .upar = init_upar,
+      .ctx_temp = &ctx,
+      .temp = init_temp_ion,
+    },
+
+    .source = {
+      .source_id = GKYL_PROJ_SOURCE,
+      .num_sources = 1,
+      .projection[0] = {
+        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+        .ctx_density = &ctx,
+        .density = init_density_source,
+        .ctx_upar = &ctx,
+        .upar = init_upar_source,
+        .ctx_temp = &ctx,
+        .temp = init_temp_source,      
+      }, 
+    },
+
+  };
+
+  struct gkyl_block_physical_bcs ion_phys_bcs[] = {
+    // block 2 BCs
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+  };
+
+  struct gkyl_gyrokinetic_multib_species ion = {
+    .name = "ion",
+    .charge = ctx.chargeIon, .mass = ctx.massIon,
+    .lower = { -ctx.vpar_max_ion, 0.0},
+    .upper = {  ctx.vpar_max_ion, ctx.mu_max_ion}, 
+    .cells = { cells_v[0], cells_v[1] },
+    .no_by = true,
+    .num_diag_moments = 7,
+    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
+
+    .collisions =  {
+      .collision_id = GKYL_LBO_COLLISIONS,
+      .normNu = true,
+      .nuFrac = ctx.nuFrac,
+      .n_ref = ctx.n0, // Density used to calculate coulomb logarithm
+      .T_ref = ctx.Ti, // Temperature used to calculate coulomb logarithm
+      .ctx = &ctx,
+      .self_nu = init_nu_ion,
+      .num_cross_collisions = 2,
+      .collide_with = { "elc", "Ar1" },
+    },
+
+    .diffusion = {
+      .num_diff_dir = 1, 
+      .diff_dirs = { 0 },
+      .D = { 0.03 }, 
+      .order = 2, 
+    }, 
+  
+    .duplicate_across_blocks = true,
+    .blocks = ion_blocks,
+    .num_physical_bcs = 4,
+    .bcs = ion_phys_bcs,
+  };
+
+  // Ar+1 Species
+  // all data is common across blocks
+  struct gkyl_gyrokinetic_multib_species_pb Ar1_blocks[1];
+  Ar1_blocks[0] = (struct gkyl_gyrokinetic_multib_species_pb) {
+
+    .polarization_density = ctx.n0Ar,
+
+    .projection = {
+      .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+      .ctx_density = &ctx,
+      .density = init_density_Ar1,
+      .ctx_upar = &ctx,
+      .upar = init_upar,
+      .ctx_temp = &ctx,
+      .temp = init_temp_Ar,
+    },
+
+  };
+
+  struct gkyl_block_physical_bcs Ar1_phys_bcs[] = {
+    // block 2 BCs
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_GK_SHEATH},
+  };
+
+  struct gkyl_gyrokinetic_multib_species Ar1 = {
+    .name = "Ar1",
+    .charge = ctx.chargeIon, .mass = ctx.massAr,
+    .lower = { -ctx.vpar_max_Ar, 0.0},
+    .upper = {  ctx.vpar_max_Ar, ctx.mu_max_Ar}, 
+    .cells = { cells_v[0], cells_v[1] },
+    .no_by = true,
+    .num_diag_moments = 7,
+    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp", "M3par", "M3perp" },
+
+    .collisions =  {
+      .collision_id = GKYL_LBO_COLLISIONS,
+      .normNu = true,
+      .nuFrac = ctx.nuFrac,
+      .n_ref = ctx.n0Ar, // Density used to calculate coulomb logarithm
+      .T_ref = ctx.TAr, // Temperature used to calculate coulomb logarithm
+      .ctx = &ctx,
+      .self_nu = init_nu_ion,
+      .num_cross_collisions = 2,
+      .collide_with = { "elc", "ion" },
+    },
+
+    .diffusion = {
+      .num_diff_dir = 1, 
+      .diff_dirs = { 0 },
+      .D = { 0.03 }, 
+      .order = 2, 
+    }, 
+
+    .react_neut = {
+      .num_react = 2,
+      .react_type = {
+        { .react_id = GKYL_REACT_IZ,
+          .type_self = GKYL_SELF_ION,
+          .ion_id = GKYL_ION_AR,
+          .elc_nm = "elc",
+          .ion_nm = "Ar1",
+          .donor_nm = "Ar0",
+          .charge_state = 0,
+          .ion_mass = ctx.massAr,
+          .elc_mass = ctx.massElc,
+        },
+        { .react_id = GKYL_REACT_RECOMB,
+          .type_self = GKYL_SELF_ION,
+          .ion_id = GKYL_ION_AR,
+          .elc_nm = "elc",
+          .ion_nm = "Ar1",
+          .recvr_nm = "Ar0",
+          .charge_state = 0,
+          .ion_mass = ctx.massAr,
+          .elc_mass = ctx.massElc,
+        },
+      },
+    },
+
+  
+    .duplicate_across_blocks = true,
+    .blocks = Ar1_blocks,
+    .num_physical_bcs = 4,
+    .bcs = Ar1_phys_bcs,
+  };
+
+  // Neutral Ar0 Species
+  // all data is common across blocks
+  struct gkyl_gyrokinetic_multib_neut_species_pb Ar0_blocks[1];
+  Ar0_blocks[0] = (struct gkyl_gyrokinetic_multib_neut_species_pb) {
+
+    .projection = {
+      .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
+      .ctx_density = &ctx,
+      .density = init_density_Ar0,
+      .ctx_udrift = &ctx,
+      .udrift = init_udrift_Ar0,
+      .ctx_temp = &ctx,
+      .temp = init_temp_Ar,
+    },
+
+  };
+
+  struct gkyl_block_physical_bcs Ar0_phys_bcs[] = {
+    // block 2 BCs
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB },
+    { .bidx = 0, .dir = 1, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_SPECIES_ABSORB},
+    { .bidx = 0, .dir = 1, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_SPECIES_ABSORB},
+  };
+
+  struct gkyl_gyrokinetic_multib_neut_species Ar0 = {
+    .name = "Ar0",
+    .mass = ctx.massAr,
+    .lower = { -ctx.vpar_max_Ar, -ctx.vpar_max_Ar, -ctx.vpar_max_Ar},
+    .upper = {  ctx.vpar_max_Ar,  ctx.vpar_max_Ar,  ctx.vpar_max_Ar },
+    .cells = { cells_v[0], cells_v[0], cells_v[0] },
+    .is_static = true,
+    .num_diag_moments = 3,
+    .diag_moments = { "M0", "M1i", "M2"},
+
+    .duplicate_across_blocks = true,
+    .blocks = Ar0_blocks,
+    .num_physical_bcs = 4,
+    .bcs = Ar0_phys_bcs,
+  };
+
+  // Field object
+  struct gkyl_gyrokinetic_multib_field_pb field_blocks[1];
+  field_blocks[0] = (struct gkyl_gyrokinetic_multib_field_pb) {
+    // No block specific field info for this simulation
+  };
+
+  struct gkyl_block_physical_bcs field_phys_bcs[] = {
+    // block 2 BCs
+    { .bidx = 0, .dir = 0, .edge = GKYL_LOWER_EDGE, .bc_type = GKYL_POISSON_DIRICHLET},
+    { .bidx = 0, .dir = 0, .edge = GKYL_UPPER_EDGE, .bc_type = GKYL_POISSON_DIRICHLET},
+  };
+
+  struct gkyl_gyrokinetic_multib_field field = {
+    .duplicate_across_blocks = true,
+    .blocks = field_blocks, 
+    .num_physical_bcs = 2,
+    .bcs = field_phys_bcs,
+  };
+
+  struct gkyl_gyrokinetic_multib app_inp = {
+    .name = "multib_step_b2_2x2v_p1",
+
+    .cdim = ctx.cdim, .vdim = ctx.vdim,
+    .poly_order = 1,
+    .basis_type = app_args.basis_type,
+    .use_gpu = app_args.use_gpu,
+
+    .block_geom = bgeom,
+    .cfl_frac = 0.9,
+    
+    .enforce_positivity = false,
+
+    .num_species = 3,
+    .species = { elc, ion, Ar1},
+
+    .num_neut_species = 1,
+    .neut_species = { Ar0 },
+
+    .field = field,
+
+    .comm = comm
+  };
+
+  // Create app object.
+  struct gkyl_gyrokinetic_multib_app *app = gkyl_gyrokinetic_multib_app_new(&app_inp);
+
+  // Initial and final simulation times.
+  int frame_curr = 0;
+  double t_curr = 0.0, t_end = ctx.t_end;
+  // Initialize simulation.
+//  if (app_args.is_restart) {
+//    struct gkyl_app_restart_status status = gkyl_gyrokinetic_app_read_from_frame(app, app_args.restart_frame);
+//
+//    if (status.io_status != GKYL_ARRAY_RIO_SUCCESS) {
+//      gkyl_gyrokinetic_multib_app_cout(app, stderr, "*** Failed to read restart file! (%s)\n",
+//        gkyl_array_rio_status_msg(status.io_status));
+//      goto freeresources;
+//    }
+//
+//    frame_curr = status.frame;
+//    t_curr = status.stime;
+//
+//    gkyl_gyrokinetic_multib_app_cout(app, stdout, "Restarting from frame %d", frame_curr);
+//    gkyl_gyrokinetic_multib_app_cout(app, stdout, " at time = %g\n", t_curr);
+//  }
+//  else {
+    gkyl_gyrokinetic_multib_app_apply_ic(app, t_curr);
+//  }
+
+  // Create triggers for IO.
+  int num_frames = ctx.num_frames, num_int_diag_calc = ctx.int_diag_calc_num;
+  struct gkyl_tm_trigger trig_write = { .dt = t_end/num_frames, .tcurr = t_curr, .curr = frame_curr };
+  struct gkyl_tm_trigger trig_calc_intdiag = { .dt = t_end/GKYL_MAX2(num_frames, num_int_diag_calc),
+    .tcurr = t_curr, .curr = frame_curr };
+
+  // Write out ICs (if restart, it overwrites the restart frame).
+  calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, false);
+  write_data(&trig_write, app, t_curr, false);
+
+  double dt = t_end-t_curr; // Initial time step.
+  // Initialize small time-step check.
+  double dt_init = -1.0, dt_failure_tol = ctx.dt_failure_tol;
+  int num_failures = 0, num_failures_max = ctx.num_failures_max;
+
+  long step = 1, num_steps = app_args.num_steps;
+  while ((t_curr < t_end) && (step <= num_steps)) {
+    gkyl_gyrokinetic_multib_app_cout(app, stdout, "Taking time-step %ld at t = %g ...", step, t_curr);
+    struct gkyl_update_status status = gkyl_gyrokinetic_multib_update(app, dt);
+    gkyl_gyrokinetic_multib_app_cout(app, stdout, " dt = %g\n", status.dt_actual);
+
+    if (!status.success) {
+      gkyl_gyrokinetic_multib_app_cout(app, stdout, "** Update method failed! Aborting simulation ....\n");
+      break;
+    }
+    t_curr += status.dt_actual;
+    dt = status.dt_suggested;
+
+    calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, t_curr > t_end);
+    write_data(&trig_write, app, t_curr, t_curr > t_end);
+
+    if (dt_init < 0.0) {
+      dt_init = status.dt_actual;
+    }
+    else if (status.dt_actual < dt_failure_tol * dt_init) {
+      num_failures += 1;
+
+      gkyl_gyrokinetic_multib_app_cout(app, stdout, "WARNING: Time-step dt = %g", status.dt_actual);
+      gkyl_gyrokinetic_multib_app_cout(app, stdout, " is below %g*dt_init ...", dt_failure_tol);
+      gkyl_gyrokinetic_multib_app_cout(app, stdout, " num_failures = %d\n", num_failures);
+      if (num_failures >= num_failures_max) {
+        gkyl_gyrokinetic_multib_app_cout(app, stdout, "ERROR: Time-step was below %g*dt_init ", dt_failure_tol);
+        gkyl_gyrokinetic_multib_app_cout(app, stdout, "%d consecutive times. Aborting simulation ....\n", num_failures_max);
+        calc_integrated_diagnostics(&trig_calc_intdiag, app, t_curr, true);
+        write_data(&trig_write, app, t_curr, true);
+        break;
+      }
+    }
+    else {
+      num_failures = 0;
+    }
+
+    step += 1;
+  }
+
+//  gkyl_gyrokinetic_app_stat_write(app);
+//
+//  // Fetch simulation statistics.
+//  struct gkyl_gyrokinetic_stat stat = gkyl_gyrokinetic_app_stat(app);
+
+  freeresources:
+  // Free resources after simulation completion.
+  gkyl_block_geom_release(bgeom);
+  gkyl_gyrokinetic_multib_app_release(app);
+  gkyl_gyrokinetic_comms_release(comm);
+
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi)
+    MPI_Finalize();
+#endif
+  
+  return 0;
+}

--- a/zero/efit_utils.c
+++ b/zero/efit_utils.c
@@ -51,10 +51,12 @@ newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cu
   double fjac_inv[2][2];
   double fvec[2];
   double p[2];
-  int ntrial=100;
+  int ntrial = 100;
   double errx = 0.0;
   double errf = 0.0;
-  for(int niter = 0; niter < ntrial; niter++) {
+  for (int i=0;i<n;i++) xsol[i] = 0.0;
+
+  for (int niter = 0; niter < ntrial; niter++) {
     if (cubics) {
       for(int i=0; i<n; i++) fvec[i] = up->rzbasis_cubic.eval_grad_expand(i,x,coeffs);
       fjac[0][0] = up->evf->eval_cubic_laplacian(0,x,coeffs);
@@ -93,7 +95,7 @@ newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cu
       x[i] += dx[i];
     }
 
-    if(errx<=1e-18) {
+    if (errx<=1e-18) {
       for (int i=0;i<n;i++) xsol[i] = x[i];
       return true;
     }
@@ -106,102 +108,102 @@ newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cu
 int
 find_xpts(gkyl_efit* up, double *Rxpt, double *Zxpt)
 {
-    bool found_xpt = false;
-    double Rsep, Zsep;
-    double psisep = DBL_MAX;
-    struct gkyl_range_iter iter;
-    gkyl_range_iter_init(&iter, &up->rzlocal);
-    while (gkyl_range_iter_next(&iter)) {
-      if ((iter.idx[1] < gkyl_range_shape(&up->rzlocal,1)/2 + 1) || (!up->reflect)) {
-        const double* psi = gkyl_array_cfetch(up->psizr, gkyl_range_idx(&up->rzlocal, iter.idx));
-        double xsol[2];
-        bool status = newton_raphson(up, psi, xsol, false);
-        double x0 = xsol[0];
-        double y0 = xsol[1];
-        double psi0 = up->rzbasis.eval_expand(xsol, psi);
-        if (x0 >= -1 && x0 <= 1 && y0 >= -1 && y0 <= 1 && status) {
-          found_xpt = true;
-          double xc[2];
-          gkyl_rect_grid_cell_center(&up->rzgrid, iter.idx, xc);
-          double R0 = up->rzgrid.dx[0]*x0/2.0 + xc[0];
-          double Z0 = up->rzgrid.dx[1]*y0/2.0 + xc[1];
-          if(fabs(psi0 - up->sibry) <= fabs(psisep - up->sibry)) {
-              Rsep = R0;
-              Zsep = Z0;
-              psisep = psi0;
-          }
+  bool found_xpt = false;
+  double Rsep, Zsep;
+  double psisep = DBL_MAX;
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &up->rzlocal);
+  while (gkyl_range_iter_next(&iter)) {
+    if ((iter.idx[1] < gkyl_range_shape(&up->rzlocal,1)/2 + 1) || (!up->reflect)) {
+      const double* psi = gkyl_array_cfetch(up->psizr, gkyl_range_idx(&up->rzlocal, iter.idx));
+      double xsol[2];
+      bool status = newton_raphson(up, psi, xsol, false);
+      double x0 = xsol[0];
+      double y0 = xsol[1];
+      double psi0 = up->rzbasis.eval_expand(xsol, psi);
+      if (x0 >= -1 && x0 <= 1 && y0 >= -1 && y0 <= 1 && status) {
+        found_xpt = true;
+        double xc[2];
+        gkyl_rect_grid_cell_center(&up->rzgrid, iter.idx, xc);
+        double R0 = up->rzgrid.dx[0]*x0/2.0 + xc[0];
+        double Z0 = up->rzgrid.dx[1]*y0/2.0 + xc[1];
+        if (fabs(psi0 - up->sibry) <= fabs(psisep - up->sibry)) {
+          Rsep = R0;
+          Zsep = Z0;
+          psisep = psi0;
         }
       }
     }
+  }
 
-    int num_xpts = 0;
-    if (found_xpt) {
-      if (up->reflect) {
-        num_xpts = 2;
-        Rxpt[0] = Rsep;
-        Rxpt[1] = Rsep;
-        Zxpt[0] = Zsep;
-        Zxpt[1] = -Zsep;
-        up->psisep = psisep;
-      }
-      else {
-        num_xpts = 1;
-        Rxpt[0] = Rsep;
-        Zxpt[0] = Zsep;
-        up->psisep = psisep;
-      }
+  int num_xpts = 0;
+  if (found_xpt) {
+    if (up->reflect) {
+      num_xpts = 2;
+      Rxpt[0] = Rsep;
+      Rxpt[1] = Rsep;
+      Zxpt[0] = Zsep;
+      Zxpt[1] = -Zsep;
+      up->psisep = psisep;
     }
+    else {
+      num_xpts = 1;
+      Rxpt[0] = Rsep;
+      Zxpt[0] = Zsep;
+      up->psisep = psisep;
+    }
+  }
   return num_xpts;
 }
 
 int
 find_xpts_cubic(gkyl_efit* up, double *Rxpt, double *Zxpt)
 {
-    bool found_xpt = false;
-    double Rsep, Zsep;
-    double psisep = DBL_MAX;
-    struct gkyl_range_iter iter;
-    gkyl_range_iter_init(&iter, &up->rzlocal_cubic);
-    while (gkyl_range_iter_next(&iter)) {
-      if ((iter.idx[1] < gkyl_range_shape(&up->rzlocal_cubic,1)/2 + 1) || (!up->reflect)) {
-        const double* psi = gkyl_array_cfetch(up->psizr_cubic, gkyl_range_idx(&up->rzlocal_cubic, iter.idx));
-        double xsol[2];
-        bool status = newton_raphson(up, psi, xsol, true);
-        double x0 = xsol[0];
-        double y0 = xsol[1];
-        double psi0 = up->rzbasis_cubic.eval_expand(xsol, psi);
-        if (x0 >= -1 && x0 <= 1 && y0 >= -1 && y0 <= 1 && status) {
-          found_xpt = true;
-          double xc[2];
-          gkyl_rect_grid_cell_center(&up->rzgrid_cubic, iter.idx, xc);
-          double R0 = up->rzgrid_cubic.dx[0]*x0/2.0 + xc[0];
-          double Z0 = up->rzgrid_cubic.dx[1]*y0/2.0 + xc[1];
-          if(fabs(psi0 - up->sibry) <= fabs(psisep - up->sibry)) {
-              Rsep = R0;
-              Zsep = Z0;
-              psisep = psi0;
-          }
+  bool found_xpt = false;
+  double Rsep, Zsep;
+  double psisep = DBL_MAX;
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &up->rzlocal_cubic);
+  while (gkyl_range_iter_next(&iter)) {
+    if ((iter.idx[1] < gkyl_range_shape(&up->rzlocal_cubic,1)/2 + 1) || (!up->reflect)) {
+      const double* psi = gkyl_array_cfetch(up->psizr_cubic, gkyl_range_idx(&up->rzlocal_cubic, iter.idx));
+      double xsol[2];
+      bool status = newton_raphson(up, psi, xsol, true);
+      double x0 = xsol[0];
+      double y0 = xsol[1];
+      double psi0 = up->rzbasis_cubic.eval_expand(xsol, psi);
+      if (x0 >= -1 && x0 <= 1 && y0 >= -1 && y0 <= 1 && status) {
+        found_xpt = true;
+        double xc[2];
+        gkyl_rect_grid_cell_center(&up->rzgrid_cubic, iter.idx, xc);
+        double R0 = up->rzgrid_cubic.dx[0]*x0/2.0 + xc[0];
+        double Z0 = up->rzgrid_cubic.dx[1]*y0/2.0 + xc[1];
+        if (fabs(psi0 - up->sibry) <= fabs(psisep - up->sibry)) {
+          Rsep = R0;
+          Zsep = Z0;
+          psisep = psi0;
         }
       }
     }
+  }
 
-    int num_xpts = 0;
-    if (found_xpt) {
-      if (up->reflect) {
-        num_xpts = 2;
-        Rxpt[0] = Rsep;
-        Rxpt[1] = Rsep;
-        Zxpt[0] = Zsep;
-        Zxpt[1] = -Zsep;
-        up->psisep_cubic = psisep;
-      }
-      else {
-        num_xpts = 1;
-        Rxpt[0] = Rsep;
-        Zxpt[0] = Zsep;
-        up->psisep_cubic = psisep;
-      }
+  int num_xpts = 0;
+  if (found_xpt) {
+    if (up->reflect) {
+      num_xpts = 2;
+      Rxpt[0] = Rsep;
+      Rxpt[1] = Rsep;
+      Zxpt[0] = Zsep;
+      Zxpt[1] = -Zsep;
+      up->psisep_cubic = psisep;
     }
+    else {
+      num_xpts = 1;
+      Rxpt[0] = Rsep;
+      Zxpt[0] = Zsep;
+      up->psisep_cubic = psisep;
+    }
+  }
   return num_xpts;
 }
 


### PR DESCRIPTION
Add the GK multiblock (MB) update method, and I/O methods that mimic the single block methods. These changes are the minimum necessary for the MB to run with a single block, producing identical results to the single block app, while also setting a path for running with multiple blocks with minimal changes.

**Update method:**

This required splitting the forward Euler in the single block app so that we can compute df/dt (in the _rhs method) without performing an actual time step. The single block _rhs method still reduces the CFL frequency in its block, and returns a minimum dt, `dt_min` (we may want to change/move this, more on this below). 

The MB update calls the MB ssp_rk3, and in each stage it does 4 things:
1. It loops over the blocks, calling gyrokinetic_rhs for each. Again, this produces a min dt for each block.
2. Perform a reduction over all ranks (with app->comm) of the min dt.
3. Do a forward euler in each block (and for each species).
4. Call the field solver and apply BCs.

There is something that's not ideal about the current workflow: gyrokinetic_rhs does a reduction of `dt_min` over the block (with allreduce). But then the MB forward_euler, when reducing `dt_min` over all blocks that are not local, it does so using the MB app communicator (`app->comm`) which contains all the ranks. This means that a lot of the ranks participate, unnecessarily, in two reductions. For now this seems fine and is just a likely small inefficiency, but one easy improvement might be to move the reduction over a single block out of gyrokinetic_rhs, and allow the MB app to perform a single reduction over all ranks in every block at once.

Lastly, because we don't yet have a MB field object, step 4 above is currently just using the field object inside the single block app, since this PR is only meant to support a single block for now.

**I/O methods:**

We gave the GK MB API nearly every I/O method that the single block GK app has, allowing for granularity in outputting, restarting, and reporting timings. Many of this _write methods in the MB app simply loop over blocks and call the corresponding method of the single block app in each block.

There's one notable feature in the current implementation: integrated diagnostics are written out per block, i.e. a 2-block step simulation would produce
```
multib_step_2x2v_p1_b0-field_energy.gkyl
multib_step_2x2v_p1_b1-field_energy.gkyl
```
This is because the I/O is much simpler if we do it this way for now, and in postprocessing one can simply add these two dynvectors. Performing the reduction over blocks will be trickier and is postponed until we have a multiblock comm object with more shape.

Tests performed
----------------

Since this is meant to only support a single block sim for now we created the `rt_multib_step_b2_2x2v_p1` regression test, which contains block 2 of a 12-block double null STEP simulation and is meant to be equivalent to the `rt_gk_step_out_2x2v_p1` test (which runs through the single block app).

- The initial conditions for these two tests are identical.
- When run in serial these two tests produce identical results.
- When run in parallel these two tests produce identical results.
- When restarted, in serial or parallel, these two tests produce identical results.

An additional note
------------------
The current GK MB API doesn't give us the flexibility we need for setting BCs for the field solver, so to make the above tests work we added fem_parbc to the input structs and we leverage the fact that the DIRICHLET value is 0, but we are not providing that in the input file (because we can't), the code is simply using some variable that is initialized as 0. I'll describe this problem and possible solutions in a DR.