### PR TITLE
Stellar-amd Rfit Tolerance Bug Fix

### DIFF
--- a/zero/efit_utils.c
+++ b/zero/efit_utils.c
@@ -72,7 +72,7 @@ newton_raphson(struct gkyl_efit *up, const double *coeffs, double *xsol, bool cu
     errf = 0.0;
     for (int i=0;i<n;i++) errf += fvec[i]*fvec[i];
     errf = sqrt(errf);
-    if (errf <= 1e-19) {
+    if (errf <= 1e-18) {
       for (int i=0;i<n;i++) xsol[i] = x[i];
       return true;
     }


### PR DESCRIPTION
Increase tolerance in x-point finder to 1e-18: Low tolerance ( grad(psi) < 1e-19 ) was causing the x-point not to be found on stellar-amd for the rt_gk_step_out_2x2v_p1 regrssion test. Perlmutter, local linux machine, stellar-intel, and local mac machine were fine. This change does not affect the result on local linux machine.