### PR TITLE
Fix VP restart

### DIFF
--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -1391,10 +1391,16 @@ gkyl_vlasov_app_from_file_fluid_species(gkyl_vlasov_app *app, int sidx,
 struct gkyl_app_restart_status
 gkyl_vlasov_app_from_frame_field(gkyl_vlasov_app *app, int frame)
 {
-  cstr fileNm = cstr_from_fmt("%s-%s_%d.gkyl", app->name, "field", frame);
-  struct gkyl_app_restart_status rstat = gkyl_vlasov_app_from_file_field(app, fileNm.str);
+  struct gkyl_app_restart_status rstat;
+  if (app->has_field) {
+    if (app->field->field_id == GKYL_FIELD_E_B) {
+      cstr fileNm = cstr_from_fmt("%s-%s_%d.gkyl", app->name, "field", frame);
+      rstat = gkyl_vlasov_app_from_file_field(app, fileNm.str);
+      cstr_drop(&fileNm);
+    }
+  }
+
   app->field->is_first_energy_write_call = false; // append to existing diagnostic
-  cstr_drop(&fileNm);
   
   return rstat;
 }
@@ -1434,6 +1440,17 @@ gkyl_vlasov_app_read_from_frame(gkyl_vlasov_app *app, int frame)
   }
   for (int i=0; i<app->num_fluid_species; i++) {
     rstat = gkyl_vlasov_app_from_frame_fluid_species(app, i, frame);
+  }
+
+  if (rstat.io_status == GKYL_ARRAY_RIO_SUCCESS) {
+    // Compute the fields and apply BCs.
+    if ((app->field->field_id != GKYL_FIELD_E_B) && (app->field->field_id != GKYL_FIELD_NULL)) {
+      struct gkyl_array *distf[app->num_species];
+      for (int i=0; i<app->num_species; ++i)
+        distf[i] = app->species[i].f;
+
+      vp_calc_field_and_apply_bc(app, rstat.stime, distf);
+    }
   }
 
   return rstat;

--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -1449,7 +1449,13 @@ gkyl_vlasov_app_read_from_frame(gkyl_vlasov_app *app, int frame)
       for (int i=0; i<app->num_species; ++i)
         distf[i] = app->species[i].f;
 
-      vp_calc_field_and_apply_bc(app, rstat.stime, distf);
+      // MF 2024/09/27/: Need the cast here for consistency. Fixing
+      // this may require removing 'const' from a lot of places.
+      vp_field_apply_ic(app, app->field, (const struct gkyl_array **) distf, rstat.stime);
+      // Apply boundary conditions.
+      for (int i=0; i<app->num_species; ++i) {
+        vm_species_apply_bc(app, &app->species[i], distf[i], rstat.stime);
+      }
     }
   }
 


### PR DESCRIPTION
Somehow it slipped under our noses that there were issues with VP restarts. They were working in an earlier iteration, but at some point they broke because they were calling a VM method that doesn't exist for VP.

Fix restarts by:
- Putting an if-statement in the app_read_from_frame method checking that we are not doing VP before calling `vm_field_apply_bc`.
- If doing VP, compute the initial field, external fields, and apply BCs.

Tested with:
- rt_vlasov_weibel
- rt_vlasov_poisson_sheath_Bext
both sims ran with a single run, or with 1 restart, getting visually identical field-energy time traces in each case.