### PR TITLE
Add bflux calculation to restarts

### DIFF
--- a/apps/vlasov.c
+++ b/apps/vlasov.c
@@ -1356,6 +1356,8 @@ gkyl_vlasov_app_from_file_species(gkyl_vlasov_app *app, int sidx,
     if (app->use_gpu)
       gkyl_array_copy(vm_s->f, vm_s->f_host);
     if (GKYL_ARRAY_RIO_SUCCESS == rstat.io_status) {
+      if (vm_s->calc_bflux)                                                                
+        vm_species_bflux_rhs(app, vm_s, &vm_s->bflux, vm_s->f, vm_s->f);
       vm_species_apply_bc(app, vm_s, vm_s->f, rstat.stime);
       if (vm_s->source_id)
         vm_species_source_calc(app, vm_s, &vm_s->src, 0.0);


### PR DESCRIPTION
For the emission BCs to restart correctly, the boundary fluxes must be calculated prior to the boundary conditions being applied. This was in place on one of the production branches, but seems to have been lost at some point during one of the branch merges.