### PR TITLE
Add Magnitude of Dual Vectors to gk_geometry

### DIFF
--- a/unit/ctest_gk_geometry.c
+++ b/unit/ctest_gk_geometry.c
@@ -134,7 +134,30 @@ test_3x_p1()
       }
   }
 
+  // Check that the duals are what they should be
+  struct gkyl_array* dualmag_nodal_fld = gkyl_array_new(GKYL_DOUBLE, grid.ndim, nrange.volume);
+  gkyl_nodal_ops_m2n(n2m, &basis, &grid, &nrange, &range, 3, dualmag_nodal_fld, gk_geom->dualmag);
+  struct gkyl_array* mapc2p_nodal_fld = gkyl_array_new(GKYL_DOUBLE, grid.ndim, nrange.volume);
+  gkyl_nodal_ops_m2n(n2m, &basis, &grid, &nrange, &range, 3, mapc2p_nodal_fld, gk_geom->mc2p);
+  for(int ia=nrange.lower[AL_IDX]; ia<=nrange.upper[AL_IDX]; ++ia){
+      for (int ip=nrange.lower[PSI_IDX]; ip<=nrange.upper[PSI_IDX]; ++ip) {
+          for (int it=nrange.lower[TH_IDX]; it<=nrange.upper[TH_IDX]; ++it) {
+              cidx[PSI_IDX] = ip;
+              cidx[AL_IDX] = ia;
+              cidx[TH_IDX] = it;
+              double *dualmag_n = gkyl_array_fetch(dualmag_nodal_fld, gkyl_range_idx(&nrange, cidx));
+              double *mapc2p_n = gkyl_array_fetch(mapc2p_nodal_fld, gkyl_range_idx(&nrange, cidx));
+              double e2mag = sqrt(1/(mapc2p_n[0]*mapc2p_n[0] +  mapc2p_n[1]*mapc2p_n[1]));
+              TEST_CHECK( gkyl_compare( dualmag_n[0], 1.0, 1e-8) );
+              TEST_CHECK( gkyl_compare( dualmag_n[1], e2mag, 1e-8) );
+              TEST_CHECK( gkyl_compare( dualmag_n[2], 1.0, 1e-8) );
+          }
+      }
+  }
+
   gkyl_array_release(bhat_nodal_fld);
+  gkyl_array_release(dualmag_nodal_fld);
+  gkyl_array_release(mapc2p_nodal_fld);
   gkyl_nodal_ops_release(n2m);
   gkyl_gk_geometry_release(gk_geom);
 }

--- a/zero/calc_metric.c
+++ b/zero/calc_metric.c
@@ -52,6 +52,7 @@ void gkyl_calc_metric_advance_rz(
   struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld,
   struct gkyl_array *tanvecFld,
   struct gkyl_array *dualFld,
+  struct gkyl_array *dualmagFld,
   struct gkyl_array *normFld,
   struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range)
 {
@@ -60,6 +61,7 @@ void gkyl_calc_metric_advance_rz(
   struct gkyl_array* bcartFld_nodal = gkyl_array_new(GKYL_DOUBLE, 3, nrange->volume);
   struct gkyl_array* tanvecFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   struct gkyl_array* dualFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
+  struct gkyl_array* dualmagFld_nodal = gkyl_array_new(GKYL_DOUBLE, 3, nrange->volume);
   struct gkyl_array* normFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   enum { PSI_IDX, AL_IDX, TH_IDX }; // arrangement of computational coordinates
   enum { R_IDX, Z_IDX, PHI_IDX }; // arrangement of cartesian coordinates
@@ -189,6 +191,11 @@ void gkyl_calc_metric_advance_rz(
               double norm1 = sqrt(dualFld_n[0]*dualFld_n[0] + dualFld_n[1]*dualFld_n[1] + dualFld_n[2]*dualFld_n[2]);
               double norm2 = sqrt(dualFld_n[3]*dualFld_n[3] + dualFld_n[4]*dualFld_n[4] + dualFld_n[5]*dualFld_n[5]);
               double norm3 = sqrt(dualFld_n[6]*dualFld_n[6] + dualFld_n[7]*dualFld_n[7] + dualFld_n[8]*dualFld_n[8]);
+
+              double *dualmagFld_n = gkyl_array_fetch(dualmagFld_nodal, gkyl_range_idx(nrange, cidx));
+              dualmagFld_n[0] = norm1;
+              dualmagFld_n[1] = norm2;
+              dualmagFld_n[2] = norm3;
               
               // Set normal vectors
               double *normFld_n = gkyl_array_fetch(normFld_nodal, gkyl_range_idx(nrange, cidx));
@@ -211,12 +218,14 @@ void gkyl_calc_metric_advance_rz(
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 3, bcartFld_nodal, bcartFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, tanvecFld_nodal, tanvecFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, dualFld_nodal, dualFld);
+  gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 3, dualmagFld_nodal, dualmagFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, normFld_nodal, normFld);
   gkyl_array_release(gFld_nodal);
   gkyl_array_release(jFld_nodal);
   gkyl_array_release(bcartFld_nodal);
   gkyl_array_release(tanvecFld_nodal);
   gkyl_array_release(dualFld_nodal);
+  gkyl_array_release(dualmagFld_nodal);
   gkyl_array_release(normFld_nodal);
 }
 
@@ -226,6 +235,7 @@ void gkyl_calc_metric_advance_mirror(
   struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld,
   struct gkyl_array *tanvecFld,
   struct gkyl_array *dualFld,
+  struct gkyl_array *dualmagFld,
   struct gkyl_array *normFld,
   struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range)
 {
@@ -234,6 +244,7 @@ void gkyl_calc_metric_advance_mirror(
   struct gkyl_array* bcartFld_nodal = gkyl_array_new(GKYL_DOUBLE, 3, nrange->volume);
   struct gkyl_array* tanvecFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   struct gkyl_array* dualFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
+  struct gkyl_array* dualmagFld_nodal = gkyl_array_new(GKYL_DOUBLE, 3, nrange->volume);
   struct gkyl_array* normFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   enum { PSI_IDX, AL_IDX, TH_IDX }; // arrangement of computational coordinates
   enum { R_IDX, Z_IDX, PHI_IDX }; // arrangement of cartesian coordinates
@@ -355,6 +366,11 @@ void gkyl_calc_metric_advance_mirror(
               double norm1 = sqrt(dualFld_n[0]*dualFld_n[0] + dualFld_n[1]*dualFld_n[1] + dualFld_n[2]*dualFld_n[2]);
               double norm2 = sqrt(dualFld_n[3]*dualFld_n[3] + dualFld_n[4]*dualFld_n[4] + dualFld_n[5]*dualFld_n[5]);
               double norm3 = sqrt(dualFld_n[6]*dualFld_n[6] + dualFld_n[7]*dualFld_n[7] + dualFld_n[8]*dualFld_n[8]);
+
+              double *dualmagFld_n = gkyl_array_fetch(dualmagFld_nodal, gkyl_range_idx(nrange, cidx));
+              dualmagFld_n[0] = norm1;
+              dualmagFld_n[1] = norm2;
+              dualmagFld_n[2] = norm3;
               
               // Set normal vectors
               double *normFld_n = gkyl_array_fetch(normFld_nodal, gkyl_range_idx(nrange, cidx));
@@ -377,6 +393,7 @@ void gkyl_calc_metric_advance_mirror(
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 3, bcartFld_nodal, bcartFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, tanvecFld_nodal, tanvecFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, dualFld_nodal, dualFld);
+  gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 3, dualmagFld_nodal, dualmagFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, normFld_nodal, normFld);
   gkyl_array_release(gFld_nodal);
   gkyl_array_release(jFld_nodal);
@@ -392,12 +409,14 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange,
   struct gkyl_array *gFld,
   struct gkyl_array *tanvecFld,
   struct gkyl_array *dualFld,
+  struct gkyl_array *dualmagFld,
   struct gkyl_array *normFld,
   const struct gkyl_range *update_range)
 {
   struct gkyl_array* gFld_nodal = gkyl_array_new(GKYL_DOUBLE, 6, nrange->volume);
   struct gkyl_array* tanvecFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   struct gkyl_array* dualFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
+  struct gkyl_array* dualmagFld_nodal = gkyl_array_new(GKYL_DOUBLE, 3, nrange->volume);
   struct gkyl_array* normFld_nodal = gkyl_array_new(GKYL_DOUBLE, 9, nrange->volume);
   enum { PSI_IDX, AL_IDX, TH_IDX }; // arrangement of computational coordinates
   enum { X_IDX, Y_IDX, Z_IDX }; // arrangement of cartesian coordinates
@@ -505,6 +524,11 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange,
               double norm1 = sqrt(dualFld_n[0]*dualFld_n[0] + dualFld_n[1]*dualFld_n[1] + dualFld_n[2]*dualFld_n[2]);
               double norm2 = sqrt(dualFld_n[3]*dualFld_n[3] + dualFld_n[4]*dualFld_n[4] + dualFld_n[5]*dualFld_n[5]);
               double norm3 = sqrt(dualFld_n[6]*dualFld_n[6] + dualFld_n[7]*dualFld_n[7] + dualFld_n[8]*dualFld_n[8]);
+
+              double *dualmagFld_n = gkyl_array_fetch(dualmagFld_nodal, gkyl_range_idx(nrange, cidx));
+              dualmagFld_n[0] = norm1;
+              dualmagFld_n[1] = norm2;
+              dualmagFld_n[2] = norm3;
               
               // Set normal vectors
               double *normFld_n = gkyl_array_fetch(normFld_nodal, gkyl_range_idx(nrange, cidx));
@@ -525,6 +549,7 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange,
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 6, gFld_nodal, gFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, tanvecFld_nodal, tanvecFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, dualFld_nodal, dualFld);
+  gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 3, dualmagFld_nodal, dualmagFld);
   gkyl_nodal_ops_n2m(up->n2m, up->cbasis, up->grid, nrange, update_range, 9, normFld_nodal, normFld);
   gkyl_array_release(gFld_nodal);
   gkyl_array_release(tanvecFld_nodal);

--- a/zero/calc_metric.c
+++ b/zero/calc_metric.c
@@ -554,6 +554,7 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange,
   gkyl_array_release(gFld_nodal);
   gkyl_array_release(tanvecFld_nodal);
   gkyl_array_release(dualFld_nodal);
+  gkyl_array_release(dualmagFld_nodal);
   gkyl_array_release(normFld_nodal);
 }
 

--- a/zero/calc_metric.c
+++ b/zero/calc_metric.c
@@ -400,6 +400,7 @@ void gkyl_calc_metric_advance_mirror(
   gkyl_array_release(bcartFld_nodal);
   gkyl_array_release(tanvecFld_nodal);
   gkyl_array_release(dualFld_nodal);
+  gkyl_array_release(dualmagFld_nodal);
   gkyl_array_release(normFld_nodal);
 }
 

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -34,6 +34,7 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->dzdx = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
+  up->dualmag = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
   up->normals = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
@@ -221,6 +222,7 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->dzdx = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
+  up->dualmag = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
   up->normals = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
@@ -255,6 +257,7 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->g_ij, up->g_ij, 6);
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->dxdz, up->dxdz, 9);
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->dzdx, up->dzdx, 9);
+  gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->dualmag, up->dualmag, 3);
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->normals, up->normals, 9);
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->jacobgeo, up->jacobgeo, 1);
   gkyl_deflate_geo_advance(deflator, &up_3d->local, &up->local, up_3d->jacobgeo_inv, up->jacobgeo_inv, 1);
@@ -293,6 +296,7 @@ gkyl_gk_geometry_free(const struct gkyl_ref_count *ref)
   gkyl_array_release(up->jacobgeo_inv);
   gkyl_array_release(up->dxdz);
   gkyl_array_release(up->dzdx);
+  gkyl_array_release(up->dualmag);
   gkyl_array_release(up->normals);
   gkyl_array_release(up->gij);
   gkyl_array_release(up->b_i);

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -28,6 +28,7 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   struct gkyl_array *g_ij_dev = gkyl_array_cu_dev_new(geo_host->g_ij->type, geo_host->g_ij->ncomp, geo_host->g_ij->size);
   struct gkyl_array *dxdz_dev = gkyl_array_cu_dev_new(geo_host->dxdz->type, geo_host->dxdz->ncomp, geo_host->dxdz->size);
   struct gkyl_array *dzdx_dev = gkyl_array_cu_dev_new(geo_host->dzdx->type, geo_host->dzdx->ncomp, geo_host->dzdx->size);
+  struct gkyl_array *dualmag_dev = gkyl_array_cu_dev_new(geo_host->dualmag->type, geo_host->dualmag->ncomp, geo_host->dualmag->size);
   struct gkyl_array *normals_dev = gkyl_array_cu_dev_new(geo_host->normals->type, geo_host->normals->ncomp, geo_host->normals->size);
   struct gkyl_array *jacobgeo_dev = gkyl_array_cu_dev_new(geo_host->jacobgeo->type, geo_host->jacobgeo->ncomp, geo_host->jacobgeo->size);
   struct gkyl_array *jacobgeo_inv_dev = gkyl_array_cu_dev_new(geo_host->jacobgeo_inv->type, geo_host->jacobgeo_inv->ncomp, geo_host->jacobgeo_inv->size);
@@ -51,6 +52,7 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   gkyl_array_copy(g_ij_dev, geo_host->g_ij);
   gkyl_array_copy(dxdz_dev, geo_host->dxdz);
   gkyl_array_copy(dzdx_dev, geo_host->dzdx);
+  gkyl_array_copy(dualmag_dev, geo_host->dualmag);
   gkyl_array_copy(normals_dev, geo_host->normals);
   gkyl_array_copy(jacobgeo_dev , geo_host->jacobgeo);
   gkyl_array_copy(jacobgeo_inv_dev, geo_host->jacobgeo_inv);
@@ -75,6 +77,7 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->g_ij  = g_ij_dev->on_dev;
   up->dxdz  = dxdz_dev->on_dev;
   up->dzdx  = dzdx_dev->on_dev;
+  up->dualmag  = dualmag_dev->on_dev;
   up->normals  = normals_dev->on_dev;
   up->jacobgeo  = jacobgeo_dev->on_dev;
   up->jacobgeo_inv = jacobgeo_inv_dev->on_dev;
@@ -108,6 +111,7 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->g_ij  = g_ij_dev;
   up->dxdz  = dxdz_dev;
   up->dzdx  = dzdx_dev;
+  up->dualmag  = dualmag_dev;
   up->normals  = normals_dev;
   up->jacobgeo  = jacobgeo_dev;
   up->jacobgeo_inv = jacobgeo_inv_dev;

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -141,7 +141,7 @@ void gkyl_gk_geometry_mapc2p_advance(struct gk_geometry* up, struct gkyl_range *
 
   // now calculate the metrics
   struct gkyl_calc_metric* mcalc = gkyl_calc_metric_new(&up->basis, &up->grid, &up->global, &up->global_ext, &up->local, &up->local_ext, false);
-  gkyl_calc_metric_advance(mcalc, nrange, mc2p_nodal_fd, dzc, up->g_ij, up->dxdz, up->dzdx, up->normals, &up->local);
+  gkyl_calc_metric_advance(mcalc, nrange, mc2p_nodal_fd, dzc, up->g_ij, up->dxdz, up->dzdx, up->dualmag, up->normals, &up->local);
   
   // calculate the derived geometric quantities
   struct gkyl_calc_derived_geo *jcalculator = gkyl_calc_derived_geo_new(&up->basis, &up->grid, false);
@@ -191,6 +191,7 @@ gkyl_gk_geometry_mapc2p_new(struct gkyl_gk_geometry_inp *geometry_inp)
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->dzdx = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
+  up->dualmag = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
   up->normals = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);

--- a/zero/gk_geometry_mirror.c
+++ b/zero/gk_geometry_mirror.c
@@ -54,6 +54,7 @@ gkyl_gk_geometry_mirror_new(struct gkyl_gk_geometry_inp *geometry_inp)
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->dzdx = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
+  up->dualmag = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
   up->normals = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
@@ -92,7 +93,7 @@ gkyl_gk_geometry_mirror_new(struct gkyl_gk_geometry_inp *geometry_inp)
 
   // Now calculate the metrics
   struct gkyl_calc_metric* mcalc = gkyl_calc_metric_new(&up->basis, &up->grid, &up->global, &up->global_ext, &up->local, &up->local_ext, false);
-  gkyl_calc_metric_advance_mirror(mcalc, &nrange, mc2p_nodal_fd, bmag_nodal, dzc, up->g_ij, up->dxdz, up->dzdx, up->normals, up->jacobgeo, up->bcart, &up->local);
+  gkyl_calc_metric_advance_mirror(mcalc, &nrange, mc2p_nodal_fd, bmag_nodal, dzc, up->g_ij, up->dxdz, up->dzdx, up->dualmag, up->normals, up->jacobgeo, up->bcart, &up->local);
   // calculate the derived geometric quantities
   gkyl_tok_calc_derived_geo *jcalculator = gkyl_tok_calc_derived_geo_new(&up->basis, &up->grid, false);
   gkyl_tok_calc_derived_geo_advance(jcalculator, &up->local, up->g_ij, up->bmag, 

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -55,6 +55,7 @@ gkyl_gk_geometry_tok_new(struct gkyl_gk_geometry_inp *geometry_inp)
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->dzdx = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
+  up->dualmag = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
   up->normals = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
@@ -92,7 +93,7 @@ gkyl_gk_geometry_tok_new(struct gkyl_gk_geometry_inp *geometry_inp)
 
   // Now calculate the metrics
   struct gkyl_calc_metric* mcalc = gkyl_calc_metric_new(&up->basis, &up->grid, &up->global, &up->global_ext, &up->local, &up->local_ext, false);
-  gkyl_calc_metric_advance_rz(mcalc, &nrange, mc2p_nodal_fd, dphidtheta_nodal, bmag_nodal, dzc, up->g_ij, up->dxdz, up->dzdx, up->normals, up->jacobgeo, up->bcart, &up->local);
+  gkyl_calc_metric_advance_rz(mcalc, &nrange, mc2p_nodal_fd, dphidtheta_nodal, bmag_nodal, dzc, up->g_ij, up->dxdz, up->dzdx, up->dualmag, up->normals, up->jacobgeo, up->bcart, &up->local);
   // calculate the derived geometric quantities
   gkyl_tok_calc_derived_geo *jcalculator = gkyl_tok_calc_derived_geo_new(&up->basis, &up->grid, false);
   gkyl_tok_calc_derived_geo_advance(jcalculator, &up->local, up->g_ij, up->bmag, 

--- a/zero/gkyl_calc_metric.h
+++ b/zero/gkyl_calc_metric.h
@@ -42,6 +42,7 @@ gkyl_calc_metric* gkyl_calc_metric_new(const struct gkyl_basis *cbasis,
  * @param gFld output field where metric modal coefficients will be placed
  * @param tanvecFld output field where tangent vector modal coefficients will be placed
  * @param dualFld output field where dual vector modal coefficients will be placed
+ * @param dualmagFld output field where magnitude of the dual vectors will be placed
  * @param normFld output field where dual vector modal coefficients will be placed
  * @param update range. Modal range over which metric coefficients and tangent vectors will be calculated
  */
@@ -62,6 +63,7 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange, s
  * @param bmag_nodal input nodal array containing B at nodes
  * @param tanvecFld output field where tangent vector modal coefficients will be placed
  * @param dualFld output field where dual vector modal coefficients will be placed
+ * @param dualmagFld output field where magnitude of the dual vectors will be placed
  * @param normFld output field where dual vector modal coefficients will be placed
  * @param jFld output field where jacobian modal coefficients will be placed
  * @param bcartFld output field where cartesian compnents of b modal coefficients will be placed
@@ -82,6 +84,7 @@ void gkyl_calc_metric_advance_rz(gkyl_calc_metric *up, struct gkyl_range *nrange
  * @param bmag_nodal input nodal array containing B at nodes
  * @param tanvecFld output field where tangent vector modal coefficients will be placed
  * @param dualFld output field where dual vector modal coefficients will be placed
+ * @param dualmagFld output field where magnitude of the dual vectors will be placed
  * @param normFld output field where dual vector modal coefficients will be placed
  * @param jFld output field where jacobian modal coefficients will be placed
  * @param bcartFld output field where cartesian compnents of b modal coefficients will be placed

--- a/zero/gkyl_calc_metric.h
+++ b/zero/gkyl_calc_metric.h
@@ -45,7 +45,7 @@ gkyl_calc_metric* gkyl_calc_metric_new(const struct gkyl_basis *cbasis,
  * @param normFld output field where dual vector modal coefficients will be placed
  * @param update range. Modal range over which metric coefficients and tangent vectors will be calculated
  */
-void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array* normFld, const struct gkyl_range *update_range);
+void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array *dualmagFld, struct gkyl_array* normFld, const struct gkyl_range *update_range);
 
 
 /**
@@ -67,7 +67,7 @@ void gkyl_calc_metric_advance(gkyl_calc_metric *up, struct gkyl_range *nrange, s
  * @param bcartFld output field where cartesian compnents of b modal coefficients will be placed
  * @param update range. Modal range over which metric coefficients and tangent vectors will be calculated
  */
-void gkyl_calc_metric_advance_rz(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, struct gkyl_array *dphidtheta_nodal, struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array *normFld, struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range);
+void gkyl_calc_metric_advance_rz(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, struct gkyl_array *dphidtheta_nodal, struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array *dualmagFld, struct gkyl_array *normFld, struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range);
 
 /**
  * Use finite differences to calculate metric coefficients and jacobian at nodes
@@ -87,7 +87,7 @@ void gkyl_calc_metric_advance_rz(gkyl_calc_metric *up, struct gkyl_range *nrange
  * @param bcartFld output field where cartesian compnents of b modal coefficients will be placed
  * @param update range. Modal range over which metric coefficients and tangent vectors will be calculated
  */
-void gkyl_calc_metric_advance_mirror(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array *normFld, struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range);
+void gkyl_calc_metric_advance_mirror(gkyl_calc_metric *up, struct gkyl_range *nrange, struct gkyl_array *mc2p_nodal_fd, struct gkyl_array *bmag_nodal, double *dzc, struct gkyl_array *gFld, struct gkyl_array *tanvecFld, struct gkyl_array *dualFld, struct gkyl_array *dualmagFld, struct gkyl_array *normFld, struct gkyl_array *jFld, struct gkyl_array* bcartFld, const struct gkyl_range *update_range);
 
 /**
  * Calculate cartesian components of bhat

--- a/zero/gkyl_gk_geometry.h
+++ b/zero/gkyl_gk_geometry.h
@@ -33,6 +33,8 @@ struct gk_geometry {
                            // Cartesian components of tangent Vectors stored in order e_1, e_2, e_3
   struct gkyl_array* dzdx; // 9 components.
                            // Cartesian components of dual vectors stroed in order e^1, e^2, e^3
+  struct gkyl_array* dualmag; // 3 components
+                              // norms of the dual vectors : sqrt(e^i.e^i)
   struct gkyl_array* normals; // 9 components
                               // Cartesian components of normal vectors in order n^1,, n^2, n^3
   struct gkyl_array* jacobgeo; // 1 component. Configuration space jacobian J


### PR DESCRIPTION
Add the magnitude of the duals to gk_geometry. @manauref plans to use these to address issue #538.

The unit test has been tested with valgrind on perlmutter and shows no memeory leaks. rt_gk_sheath_1x2v_p1 also shows no memory leaks.