### PR TITLE
Fix bug in GK geo for lower dim cases

### DIFF
--- a/machines/mkdeps.macos.sh
+++ b/machines/mkdeps.macos.sh
@@ -1,3 +1,3 @@
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=no --build-superlu=no --prefix=$PREFIX
+./mkdeps.sh --build-openblas=no --build-superlu=yes --prefix=$PREFIX

--- a/regression/rt_gk_ltx_1x2v_p1.c
+++ b/regression/rt_gk_ltx_1x2v_p1.c
@@ -491,6 +491,7 @@ int main(int argc, char **argv)
     .lower = { -ctx.vpar_max_elc, 0.0},
     .upper = {  ctx.vpar_max_elc, ctx.mu_max_elc}, 
     .cells = { cells_v[0], cells_v[1] },
+
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -502,6 +503,7 @@ int main(int argc, char **argv)
       .ctx_temp = &ctx,
       .temp = temp_elc,      
     },
+
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
       .ctx = &ctx,
@@ -509,6 +511,7 @@ int main(int argc, char **argv)
       .num_cross_collisions = 1,
       .collide_with = { "ion" },
     },
+
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
       .num_sources = 1,
@@ -539,6 +542,7 @@ int main(int argc, char **argv)
     .lower = { -ctx.vpar_max_ion, 0.0},
     .upper = {  ctx.vpar_max_ion, ctx.mu_max_ion}, 
     .cells = { cells_v[0], cells_v[1] },
+
     .polarization_density = ctx.n0,
 
     .projection = {
@@ -550,6 +554,7 @@ int main(int argc, char **argv)
       .ctx_temp = &ctx,
       .temp = temp_ion,      
     },
+
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
       .ctx = &ctx,
@@ -557,6 +562,7 @@ int main(int argc, char **argv)
       .num_cross_collisions = 1,
       .collide_with = { "elc" },
     },
+
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
       .num_sources = 1,

--- a/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
+++ b/regression/rt_gk_ltx_boltz_elc_1x2v_p1.c
@@ -443,7 +443,9 @@ int main(int argc, char **argv)
     .lower = { -ctx.vpar_max_ion, 0.0},
     .upper = {  ctx.vpar_max_ion, ctx.mu_max_ion}, 
     .cells = { cells_v[0], cells_v[1] },
+
     .polarization_density = ctx.n0,
+
     .projection = {
       .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
       .ctx_density = &ctx,
@@ -453,11 +455,13 @@ int main(int argc, char **argv)
       .ctx_temp = &ctx,
       .temp = temp_ion,      
     },
+
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
       .ctx = &ctx,
       .self_nu = evalNuIon,
     },
+
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
       .num_sources = 1,
@@ -471,10 +475,12 @@ int main(int argc, char **argv)
         .temp = temp_ion_src,  
       }, 
     },
+
     .bcx = {
       .lower={.type = GKYL_SPECIES_GK_SHEATH,},
       .upper={.type = GKYL_SPECIES_GK_SHEATH,},
     },
+
     .num_diag_moments = 5,
     .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
   };
@@ -522,7 +528,6 @@ int main(int argc, char **argv)
     },
   };
   
-
   // Create app object.
   gkyl_gyrokinetic_app *app = gkyl_gyrokinetic_app_new(&gk);
 

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -79,11 +79,11 @@ struct gkyl_rect_grid gkyl_gk_geometry_augment_grid(struct gkyl_rect_grid grid, 
     cells[1] = 1;
     cells[2] = grid.cells[0];
 
-    lower[0] = geometry.world[0] - fmin(1e-5, geometry.world[0]*0.1);
+    lower[0] = geometry.world[0] - (geometry.world[0]>1e-14? fmin(1e-5, geometry.world[0]*0.1) : 1e-5);
     lower[1] = geometry.world[1] - 1e-1;
     lower[2] = grid.lower[0];
 
-    upper[0] = geometry.world[0] + fmin(1e-5, geometry.world[0]*0.1);
+    upper[0] = geometry.world[0] + (geometry.world[0]>1e-14? fmin(1e-5, geometry.world[0]*0.1) : 1e-5);
     upper[1] = geometry.world[1] + 1e-1;
     upper[2] = grid.upper[0];
   }


### PR DESCRIPTION
Fix a bug introduced in PR #522 (fyi @akashukla @Maxwell-Rosen ) which didn't consider the case in which the world coords are 0, as they are in the LTX reg tests. 

Also restore the build-superlu=yes in MacOS machine file.