### PR TITLE
Fix Valgrind Errors in Reduce Bmag

### DIFF
--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -193,10 +193,10 @@ gkyl_gk_geometry_reduce_bmag(struct gk_geometry* up, enum gkyl_array_op op)
     }
   }
 
-  return b_m;
-
   gkyl_array_release(nodes);
   gkyl_array_release(bmag_ho);
+
+  return b_m;
 }
 
 void


### PR DESCRIPTION
Fix issue where reduce_bmag function returned before releasing temporary arrays.
![image](https://github.com/user-attachments/assets/b3835d27-e5fe-47d0-99c8-11bce3319c87)
