### PR TITLE
Gk g0 app host allgather

### DIFF
--- a/unit/mctest_mpi_comm.c
+++ b/unit/mctest_mpi_comm.c
@@ -256,6 +256,137 @@ mpi_n4_allgather_2d()
   gkyl_array_release(arr_global);   
 }
 
+
+static void
+mpi_n2_allgather_1d_host()
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 2) return;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  struct gkyl_range global;
+  gkyl_range_init(&global, 1, (int[]) { 1 }, (int[]) { 10 });
+
+  int cuts[] = { 2 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(global.ndim, cuts, &global);
+  
+  struct gkyl_comm *comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = decomp,
+    }
+  );
+
+  int nghost[] = { 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&decomp->ranges[rank], nghost, &local_ext, &local);
+
+  struct gkyl_array *arr_local = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
+  gkyl_array_clear(arr_local, 200005.0);
+  struct gkyl_array *arr_global = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
+  gkyl_array_clear(arr_global, 0.0);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&local, iter.idx);
+    double  *f = gkyl_array_fetch(arr_local, idx);
+    f[0] = idx+10.0*rank;
+  }
+
+  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local, arr_global);
+
+  struct gkyl_range_iter iter_global;
+  gkyl_range_iter_init(&iter_global, &global);
+  while (gkyl_range_iter_next(&iter_global)) {
+    long idx = gkyl_range_idx(&global, iter_global.idx);
+    double *f = gkyl_array_fetch(arr_global, idx);
+    // first 5 entries are 1-5, second 5 entries are 11-15
+    if (idx < local.volume)
+      TEST_CHECK( idx+1.0 == f[0] );
+    else 
+      TEST_CHECK( idx+6.0 == f[0] );
+  }
+
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_array_release(arr_local);      
+  gkyl_array_release(arr_global); 
+}
+
+static void
+mpi_n4_allgather_2d_host()
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 4) return;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  // create global range
+  int cells[] = { 10, 10 };
+  struct gkyl_range global;
+  gkyl_create_global_range(2, cells, &global);
+
+  int cuts[] = { 2, 2 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(2, cuts, &global);  
+  
+  struct gkyl_comm *comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = decomp,
+    }
+  );
+
+  int nghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&decomp->ranges[rank], nghost, &local_ext, &local);
+
+  struct gkyl_array *arr_local = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
+  gkyl_array_clear(arr_local, 200005.0);
+  struct gkyl_array *arr_global = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
+  gkyl_array_clear(arr_global, 0.0);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&local, iter.idx);
+    double  *f = gkyl_array_fetch(arr_local, idx);
+    f[0] = iter.idx[0] + iter.idx[1]*(rank+1.0) + 10.0*rank;
+  } 
+
+  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local, arr_global);
+
+  struct gkyl_range_iter iter_global;
+  gkyl_range_iter_init(&iter_global, &global);
+  while (gkyl_range_iter_next(&iter_global)) {
+    long idx = gkyl_range_idx(&global, iter_global.idx);
+    double *f = gkyl_array_fetch(arr_global, idx);
+    // check value of {2, 2} decomp organized as 
+    // rank 0 owns {1, 1} to {5, 5}
+    // rank 1 owns {1, 6} to {5, 10} 
+    // rank 2 owns {6, 1} to {10, 5} 
+    // rank 3 owns {6, 6} to {10, 10}
+    double val;
+    if (iter_global.idx[0] <= cells[0]/cuts[0] && iter_global.idx[1] <= cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1];
+    else if (iter_global.idx[0] <= cells[0]/cuts[0] && iter_global.idx[1] > cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1]*2.0 + 10.0;
+    else if (iter_global.idx[0] > cells[0]/cuts[0] && iter_global.idx[1] <= cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1]*3.0 + 20.0;
+    else 
+      val = iter_global.idx[0] + iter_global.idx[1]*4.0 + 30.0;
+    TEST_CHECK( val == f[0] );
+  }
+
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_array_release(arr_local);      
+  gkyl_array_release(arr_global);   
+}
+
 static void
 mpi_n2_sync_1d()
 {
@@ -1443,6 +1574,9 @@ TEST_LIST = {
   
   {"mpi_n2_allgather_1d", mpi_n2_allgather_1d},
   {"mpi_n4_allgather_2d", mpi_n4_allgather_2d},
+
+  {"mpi_n2_allgather_1d_host", mpi_n2_allgather_1d_host},
+  {"mpi_n4_allgather_2d_host", mpi_n4_allgather_2d_host},
   
   {"mpi_n2_sync_1d", mpi_n2_sync_1d},
   {"mpi_n4_sync_2d_no_corner", mpi_n4_sync_2d_no_corner },

--- a/unit/mctest_nccl_comm.c
+++ b/unit/mctest_nccl_comm.c
@@ -229,6 +229,137 @@ nccl_n4_allgather_2d()
   gkyl_array_release(arr_global_ho);
 }
 
+
+void
+nccl_n2_allgather_1d_host()
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 2) return;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  struct gkyl_range global;
+  gkyl_range_init(&global, 1, (int[]) { 1 }, (int[]) { 10 });
+
+  int cuts[] = { 2 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(global.ndim, cuts, &global);
+  
+  struct gkyl_comm *comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = decomp,
+    }
+  );
+
+  int nghost[] = { 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&decomp->ranges[rank], nghost, &local_ext, &local);
+
+  struct gkyl_array *arr_local_ho = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
+  struct gkyl_array *arr_global_ho = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
+  gkyl_array_clear(arr_global, 0.0);
+
+  gkyl_array_clear(arr_local_ho, 200005.0);
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&local, iter.idx);
+    double  *f = gkyl_array_fetch(arr_local_ho, idx);
+    f[0] = idx+10.0*rank;
+  }
+
+  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local_ho, arr_global_ho);
+
+  struct gkyl_range_iter iter_global;
+  gkyl_range_iter_init(&iter_global, &global);
+  while (gkyl_range_iter_next(&iter_global)) {
+    long idx = gkyl_range_idx(&global, iter_global.idx);
+    double *f = gkyl_array_fetch(arr_global_ho, idx);
+    // first 5 entries are 1-5, second 5 entries are 11-15
+    if (idx < local.volume)
+      TEST_CHECK( idx+1.0 == f[0] );
+    else 
+      TEST_CHECK( idx+6.0 == f[0] );
+  }
+
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_array_release(arr_local_ho);      
+  gkyl_array_release(arr_global_ho); 
+}
+
+void
+nccl_n4_allgather_2d_host()
+{
+  int m_sz;
+  MPI_Comm_size(MPI_COMM_WORLD, &m_sz);
+  if (m_sz != 4) return;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  // create global range
+  int cells[] = { 10, 10 };
+  struct gkyl_range global;
+  gkyl_create_global_range(2, cells, &global);
+
+  int cuts[] = { 2, 2 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(2, cuts, &global);  
+  
+  struct gkyl_comm *comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
+      .mpi_comm = MPI_COMM_WORLD,
+      .decomp = decomp,
+    }
+  );
+
+  int nghost[] = { 1, 1 };
+  struct gkyl_range local, local_ext;
+  gkyl_create_ranges(&decomp->ranges[rank], nghost, &local_ext, &local);
+
+  struct gkyl_array *arr_local_ho = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
+  struct gkyl_array *arr_global_ho = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
+  gkyl_array_clear(arr_global, 0.0);
+
+  gkyl_array_clear(arr_local_ho, 200005.0);
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    long idx = gkyl_range_idx(&local, iter.idx);
+    double  *f = gkyl_array_fetch(arr_local_ho, idx);
+    f[0] = iter.idx[0] + iter.idx[1]*(rank+1.0) + 10.0*rank;
+  } 
+
+  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local, arr_global);
+
+  struct gkyl_range_iter iter_global;
+  gkyl_range_iter_init(&iter_global, &global);
+  while (gkyl_range_iter_next(&iter_global)) {
+    long idx = gkyl_range_idx(&global, iter_global.idx);
+    double *f = gkyl_array_fetch(arr_global_ho, idx);
+    // check value of {2, 2} decomp organized as 
+    // rank 0 owns {1, 1} to {5, 5}
+    // rank 1 owns {1, 6} to {5, 10} 
+    // rank 2 owns {6, 1} to {10, 5} 
+    // rank 3 owns {6, 6} to {10, 10}
+    double val;
+    if (iter_global.idx[0] <= cells[0]/cuts[0] && iter_global.idx[1] <= cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1];
+    else if (iter_global.idx[0] <= cells[0]/cuts[0] && iter_global.idx[1] > cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1]*2.0 + 10.0;
+    else if (iter_global.idx[0] > cells[0]/cuts[0] && iter_global.idx[1] <= cells[1]/cuts[1])
+      val = iter_global.idx[0] + iter_global.idx[1]*3.0 + 20.0;
+    else 
+      val = iter_global.idx[0] + iter_global.idx[1]*4.0 + 30.0;
+    TEST_CHECK( val == f[0] );
+  }
+
+  gkyl_rect_decomp_release(decomp);
+  gkyl_comm_release(comm);
+  gkyl_array_release(arr_local_ho);
+  gkyl_array_release(arr_global_ho);
+}
+
 // MF 2024/09/12: disable these for now per 498b7d1569eaa9285ae59581bd22dab124672f7b.
 // void
 // nccl_n2_array_send_irecv_2d()
@@ -1431,6 +1562,8 @@ TEST_LIST = {
   {"nccl_allreduce", nccl_allreduce},
   {"nccl_n2_allgather_1d", nccl_n2_allgather_1d},
   {"nccl_n4_allgather_2d", nccl_n4_allgather_2d},
+  {"nccl_n2_allgather_1d_host", nccl_n2_allgather_1d_host},
+  {"nccl_n4_allgather_2d_host", nccl_n4_allgather_2d_host},
 //  {"nccl_n2_array_send_irecv_2d", nccl_n2_array_send_irecv_2d},
 //  {"nccl_n2_array_isend_irecv_2d", nccl_n2_array_isend_irecv_2d},
   {"nccl_n2_sync_1d", nccl_n2_sync_1d},

--- a/unit/mctest_nccl_comm.c
+++ b/unit/mctest_nccl_comm.c
@@ -258,7 +258,6 @@ nccl_n2_allgather_1d_host()
 
   struct gkyl_array *arr_local_ho = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
   struct gkyl_array *arr_global_ho = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
-  gkyl_array_clear(arr_global, 0.0);
 
   gkyl_array_clear(arr_local_ho, 200005.0);
   struct gkyl_range_iter iter;
@@ -319,7 +318,6 @@ nccl_n4_allgather_2d_host()
 
   struct gkyl_array *arr_local_ho = gkyl_array_new(GKYL_DOUBLE, 1, local_ext.volume);
   struct gkyl_array *arr_global_ho = gkyl_array_new(GKYL_DOUBLE, 1, global.volume);
-  gkyl_array_clear(arr_global, 0.0);
 
   gkyl_array_clear(arr_local_ho, 200005.0);
   struct gkyl_range_iter iter;
@@ -330,7 +328,7 @@ nccl_n4_allgather_2d_host()
     f[0] = iter.idx[0] + iter.idx[1]*(rank+1.0) + 10.0*rank;
   } 
 
-  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local, arr_global);
+  gkyl_comm_array_allgather_host(comm, &local, &global, arr_local_ho, arr_global_ho);
 
   struct gkyl_range_iter iter_global;
   gkyl_range_iter_init(&iter_global, &global);

--- a/zero/comm.c
+++ b/zero/comm.c
@@ -54,6 +54,15 @@ gkyl_comm_array_allgather(struct gkyl_comm *pcomm,
 }
 
 int
+gkyl_comm_array_allgather_host(struct gkyl_comm *pcomm, 
+  const struct gkyl_range *local, const struct gkyl_range *global,
+  const struct gkyl_array *array_local, struct gkyl_array *array_global)
+{
+  struct gkyl_comm_priv *comm = container_of(pcomm, struct gkyl_comm_priv, pub_comm);  
+  return comm->gkyl_array_allgather_host(pcomm, local, global, array_local, array_global);
+}
+
+int
 gkyl_comm_array_bcast(struct gkyl_comm *pcomm, 
   const struct gkyl_array *array_send, struct gkyl_array *array_recv, int root)
 {

--- a/zero/gkyl_comm.h
+++ b/zero/gkyl_comm.h
@@ -78,6 +78,20 @@ int gkyl_comm_array_allgather(struct gkyl_comm *comm,
   const struct gkyl_array *array_local, struct gkyl_array *array_global);
 
 /**
+ * Gather all local data on host into a global array on each process.
+ *
+ * @param comm Communicator
+ * @param local Local range for array
+ * @param global Global range for array
+ * @param array_local Local array
+ * @param array_global Global array
+ * @return error code: 0 for success
+ */
+int gkyl_comm_array_allgather_host(struct gkyl_comm *comm, 
+  const struct gkyl_range *local, const struct gkyl_range *global,
+  const struct gkyl_array *array_local, struct gkyl_array *array_global);
+
+/**
  * Broadcast an array to other processes.
  *
  * @param comm Communicator.

--- a/zero/gkyl_comm_priv.h
+++ b/zero/gkyl_comm_priv.h
@@ -95,6 +95,7 @@ struct gkyl_comm_priv {
   // FOLLOWING NEED A DECOMP 
 
   gkyl_array_allgather_t gkyl_array_allgather; // gather local arrays to global array
+  gkyl_array_allgather_t gkyl_array_allgather_host; // ?? gather local arrays to global array on host
 
   gkyl_array_bcast_t gkyl_array_bcast; // broadcast array to other processes
   gkyl_array_bcast_t gkyl_array_bcast_host; // ?? broadcast host side array to other processes

--- a/zero/mpi_comm.c
+++ b/zero/mpi_comm.c
@@ -774,6 +774,7 @@ mpi_comm_new(const struct gkyl_mpi_comm_inp *inp,
   mpi->priv_comm.gkyl_array_write = array_write;
   mpi->priv_comm.gkyl_array_read = array_read;
   mpi->priv_comm.gkyl_array_allgather = array_allgather;
+  mpi->priv_comm.gkyl_array_allgather_host = array_allgather;
   
   mpi->priv_comm.get_rank = get_rank;
   mpi->priv_comm.get_size = get_size;

--- a/zero/nccl_comm.c
+++ b/zero/nccl_comm.c
@@ -291,6 +291,15 @@ array_allgather(struct gkyl_comm *comm,
 }
 
 static int
+array_allgather_host(struct gkyl_comm *comm,
+  const struct gkyl_range *local, const struct gkyl_range *global, 
+  const struct gkyl_array *array_local, struct gkyl_array *array_global)
+{
+  struct nccl_comm *nccl = container_of(comm, struct nccl_comm, priv_comm.pub_comm);
+  return gkyl_comm_array_allgather_host(nccl->mpi_comm, local, global, array_local, array_global);
+}
+
+static int
 array_bcast(struct gkyl_comm *comm, const struct gkyl_array *asend,
   struct gkyl_array *arecv, int root)
 {
@@ -702,7 +711,7 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
   
   nccl->local_range_offset = gkyl_rect_decomp_calc_offset(nccl->decomp, nccl->rank);
 
-  nccl->priv_comm.gkyl_array_allgather = array_allgather;
+  
   nccl->priv_comm.gkyl_array_sync = array_sync;
   nccl->priv_comm.gkyl_array_per_sync = array_per_sync;
   nccl->priv_comm.gkyl_array_write = array_write;
@@ -721,6 +730,8 @@ nccl_comm_new(const struct gkyl_nccl_comm_inp *inp,
 //  nccl->priv_comm.comm_state_new = comm_state_new;
 //  nccl->priv_comm.comm_state_release = comm_state_release;
 //  nccl->priv_comm.comm_state_wait = comm_state_wait;
+  nccl->priv_comm.gkyl_array_allgather = array_allgather;
+  nccl->priv_comm.gkyl_array_allgather_host = array_allgather_host;
   nccl->priv_comm.gkyl_array_bcast = array_bcast;
   nccl->priv_comm.gkyl_array_bcast_host = array_bcast_host;
   nccl->priv_comm.comm_group_call_start = group_call_start;

--- a/zero/null_comm.c
+++ b/zero/null_comm.c
@@ -351,6 +351,7 @@ gkyl_null_comm_inew(const struct gkyl_null_comm_inp *inp)
   comm->priv_comm.allreduce = allreduce;
   comm->priv_comm.allreduce_host = allreduce_host;
   comm->priv_comm.gkyl_array_allgather = array_allgather;
+  comm->priv_comm.gkyl_array_allgather_host = array_allgather;
   comm->priv_comm.gkyl_array_bcast = array_bcast;
   comm->priv_comm.gkyl_array_bcast_host = array_bcast;
   comm->priv_comm.gkyl_array_sync = array_sync;


### PR DESCRIPTION
Added a host allgather for GPU simulations. This is needed to gather a global representation of Bmag for the non-uniform grids. I added 4 unit tests for this, 2 MPI, 2 NCCL. They all pass on Stellar in 2 and 4 CPUs, and on 2 GPUs. 

The style is copied from the differences between bcast and bcast_host. Almost everything is nearly identical, except for how the unit tests work.