### PR TITLE
Fix a small oversight in the position map usage in the unit tests

### DIFF
--- a/regression/rt_gk_wham_nonuniformx_1x2v_p1_numeric.c
+++ b/regression/rt_gk_wham_nonuniformx_1x2v_p1_numeric.c
@@ -449,7 +449,7 @@ create_ctx(void)
   double mu_max_elc = me * pow(3. * vte, 2.) / (2. * B_p);
   double vpar_max_ion = 20 * vti;
   double mu_max_ion = mi * pow(3. * vti, 2.) / (2. * B_p);
-  int Nz = 128;
+  int Nz = 64;
   int Nvpar = 32; // Number of cells in the paralell velocity direction 96
   int Nmu = 32;  // Number of cells in the mu direction 192
   int poly_order = 1;

--- a/unit/ctest_position_map.c
+++ b/unit/ctest_position_map.c
@@ -91,13 +91,13 @@ test_position_map_init_1x()
   struct gkyl_position_map *pos_map = gkyl_position_map_new(pos_map_inp,
     grid, localRange, localRange_ext, localRange, localRange_ext, basis);
 
-  TEST_ASSERT(pos_map->to_optimize == 0);
-  TEST_ASSERT(pos_map->grid.ndim == 1);
-  TEST_ASSERT(pos_map->local.ndim == 1);
-  TEST_ASSERT(pos_map->local_ext.ndim == 1);
-  TEST_ASSERT(pos_map->basis.ndim == 1);
-  TEST_ASSERT(pos_map->basis.poly_order == 1);
-  TEST_ASSERT(pos_map->flags == 0);
+  TEST_CHECK(pos_map->to_optimize == 0);
+  TEST_CHECK(pos_map->grid.ndim == 1);
+  TEST_CHECK(pos_map->local.ndim == 1);
+  TEST_CHECK(pos_map->local_ext.ndim == 1);
+  TEST_CHECK(pos_map->basis.ndim == 1);
+  TEST_CHECK(pos_map->basis.poly_order == 1);
+  TEST_CHECK(pos_map->flags == 0);
 
   gkyl_position_map_release(pos_map);
 }
@@ -127,26 +127,26 @@ test_position_map_init_1x_null()
   struct gkyl_position_map *pos_map = gkyl_position_map_new(pos_map_inp, \
     grid, localRange, localRange_ext, localRange, localRange_ext, basis);
 
-  TEST_ASSERT(pos_map->id == GKYL_PMAP_USER_INPUT);
+  TEST_CHECK(pos_map->id == GKYL_PMAP_USER_INPUT);
   for (double i = 0; i < 1; i = i+0.1){
     double x[1] = {i};
     double y[1];
     pos_map->maps[0](0.0, x, y, pos_map->ctxs[0]);
-    TEST_ASSERT(y[0] == x[0]);
+    TEST_CHECK(y[0] == x[0]);
 
     pos_map->maps[1](0.0, x, y, pos_map->ctxs[1]);
-    TEST_ASSERT(y[0] == x[0]);
+    TEST_CHECK(y[0] == x[0]);
 
     pos_map->maps[2](0.0, x, y, pos_map->ctxs[2]);
-    TEST_ASSERT(y[0] == x[0]);
+    TEST_CHECK(y[0] == x[0]);
   }
-  TEST_ASSERT(pos_map->to_optimize == 0);
-  TEST_ASSERT(pos_map->grid.ndim == 1);
-  TEST_ASSERT(pos_map->local.ndim == 1);
-  TEST_ASSERT(pos_map->local_ext.ndim == 1);
-  TEST_ASSERT(pos_map->basis.ndim == 1);
-  TEST_ASSERT(pos_map->basis.poly_order == 1);
-  TEST_ASSERT(pos_map->flags == 0);
+  TEST_CHECK(pos_map->to_optimize == 0);
+  TEST_CHECK(pos_map->grid.ndim == 1);
+  TEST_CHECK(pos_map->local.ndim == 1);
+  TEST_CHECK(pos_map->local_ext.ndim == 1);
+  TEST_CHECK(pos_map->basis.ndim == 1);
+  TEST_CHECK(pos_map->basis.poly_order == 1);
+  TEST_CHECK(pos_map->flags == 0);
 
   gkyl_position_map_release(pos_map);
 }
@@ -178,13 +178,13 @@ test_position_map_init_2x()
   struct gkyl_position_map *pos_map = gkyl_position_map_new(pos_map_inp, \
     grid, localRange, localRange_ext, localRange, localRange_ext, basis);
 
-  TEST_ASSERT(pos_map->to_optimize == 0);
-  TEST_ASSERT(pos_map->grid.ndim == 2);
-  TEST_ASSERT(pos_map->local.ndim == 2);
-  TEST_ASSERT(pos_map->local_ext.ndim == 2);
-  TEST_ASSERT(pos_map->basis.ndim == 2);
-  TEST_ASSERT(pos_map->basis.poly_order == 1);
-  TEST_ASSERT(pos_map->flags == 0);
+  TEST_CHECK(pos_map->to_optimize == 0);
+  TEST_CHECK(pos_map->grid.ndim == 2);
+  TEST_CHECK(pos_map->local.ndim == 2);
+  TEST_CHECK(pos_map->local_ext.ndim == 2);
+  TEST_CHECK(pos_map->basis.ndim == 2);
+  TEST_CHECK(pos_map->basis.poly_order == 1);
+  TEST_CHECK(pos_map->flags == 0);
 
   gkyl_position_map_release(pos_map);
 }
@@ -216,13 +216,13 @@ test_position_map_init_3x()
   struct gkyl_position_map *pos_map = gkyl_position_map_new(pos_map_inp, \
     grid, localRange, localRange_ext, localRange, localRange_ext, basis);
 
-  TEST_ASSERT(pos_map->to_optimize == 0);
-  TEST_ASSERT(pos_map->grid.ndim == 3);
-  TEST_ASSERT(pos_map->local.ndim == 3);
-  TEST_ASSERT(pos_map->local_ext.ndim == 3);
-  TEST_ASSERT(pos_map->basis.ndim == 3);
-  TEST_ASSERT(pos_map->basis.poly_order == 1);
-  TEST_ASSERT(pos_map->flags == 0);
+  TEST_CHECK(pos_map->to_optimize == 0);
+  TEST_CHECK(pos_map->grid.ndim == 3);
+  TEST_CHECK(pos_map->local.ndim == 3);
+  TEST_CHECK(pos_map->local_ext.ndim == 3);
+  TEST_CHECK(pos_map->basis.ndim == 3);
+  TEST_CHECK(pos_map->basis.poly_order == 1);
+  TEST_CHECK(pos_map->flags == 0);
 
   gkyl_position_map_release(pos_map);
 }
@@ -382,15 +382,15 @@ test_position_polynomial_map_optimize_1x()
 
   gkyl_position_map_optimize(pos_map);
 
-  TEST_ASSERT(pos_map->to_optimize == true);
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_throat, 1.565796, 1e-6) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->Bmag_throat, 1.093613, 1e-6) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->psi, 0.5, 1e-6) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->alpha, 0.0, 1e-6) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->map_strength, 1.0, 1e-6) );
-  TEST_ASSERT( pos_map->constB_ctx->map_order_center == 2 );
-  TEST_ASSERT( pos_map->constB_ctx->map_order_expander == 3 );
-  TEST_ASSERT( pos_map->constB_ctx->N_theta_boundaries == 65 );
+  TEST_CHECK(pos_map->to_optimize == true);
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_throat, 1.565796, 1e-6) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->Bmag_throat, 1.093613, 1e-6) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->psi, 0.5, 1e-6) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->alpha, 0.0, 1e-6) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->map_strength, 1.0, 1e-6) );
+  TEST_CHECK( pos_map->constB_ctx->map_order_center == 2 );
+  TEST_CHECK( pos_map->constB_ctx->map_order_expander == 3 );
+  TEST_CHECK( pos_map->constB_ctx->N_theta_boundaries == 65 );
 
   gkyl_position_map_release(pos_map);
   gkyl_array_release(bmag_global);
@@ -453,12 +453,12 @@ test_position_map_numeric_optimize_1x()
 
   double theta_extrema_analytic[5] = {lower[0], lower[0]/2, 0.0, upper[0]/2, upper[0]};
 
-  TEST_ASSERT( pos_map->constB_ctx->num_extrema == 5 );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_extrema[0], theta_extrema_analytic[0], 1e-15) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_extrema[1], theta_extrema_analytic[1], 1e-15) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_extrema[2], theta_extrema_analytic[2], 1e-15) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_extrema[3], theta_extrema_analytic[3], 1e-15) );
-  TEST_ASSERT( gkyl_compare(pos_map->constB_ctx->theta_extrema[4], theta_extrema_analytic[4], 1e-15) );
+  TEST_CHECK( pos_map->constB_ctx->num_extrema == 5 );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_extrema[0], theta_extrema_analytic[0], 1e-15) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_extrema[1], theta_extrema_analytic[1], 1e-15) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_extrema[2], theta_extrema_analytic[2], 1e-15) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_extrema[3], theta_extrema_analytic[3], 1e-15) );
+  TEST_CHECK( gkyl_compare(pos_map->constB_ctx->theta_extrema[4], theta_extrema_analytic[4], 1e-15) );
 
   gkyl_position_map_release(pos_map);
   gkyl_array_release(bmag_global);
@@ -522,7 +522,7 @@ test_position_map_numeric_calculate_1x()
 
   double theta_map = 1.0;
   pos_map->maps[2](0.0, &theta_map, &theta_map, pos_map->ctxs[2]);
-  TEST_ASSERT( gkyl_compare(theta_map, 1.503465, 1e-5) );
+  TEST_CHECK( gkyl_compare(theta_map, 1.503465, 1e-5) );
 
   gkyl_position_map_release(pos_map);
   gkyl_array_release(bmag_global);

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -262,27 +262,38 @@ gkyl_gk_geometry_mapc2p_new(struct gkyl_gk_geometry_inp *geometry_inp)
 {
   struct gk_geometry* gk_geom_3d;
   struct gk_geometry* gk_geom;
-  // First construct the uniform 3d geometry
-  gk_geom_3d = gk_geometry_mapc2p_init(geometry_inp);
-  // The conversion array computational to field aligned is still computed
-  // in uniform geometry, so we need to deflate it
-  if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
-      geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
-    // Must deflate the 3Duniform geometry in order for the allgather to work
-    if(geometry_inp->grid.ndim < 3)
-      gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
-    else
-      gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
 
-    geometry_inp->position_map->to_optimize = true;
-    gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
-    &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
 
-    gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
-    gkyl_gk_geometry_release(gk_geom); // release 3d geometry
-
-    // Construct the non-uniform grid
+  if (geometry_inp->position_map == 0){
+    geometry_inp->position_map = gkyl_position_map_new((struct gkyl_position_map_inp) {}, \
+      geometry_inp->grid, geometry_inp->local, geometry_inp->local_ext, geometry_inp->local, \
+      geometry_inp->local_ext, geometry_inp->basis);
     gk_geom_3d = gk_geometry_mapc2p_init(geometry_inp);
+    gkyl_position_map_release(geometry_inp->position_map);
+  }
+  else {
+    // First construct the uniform 3d geometry
+    gk_geom_3d = gk_geometry_mapc2p_init(geometry_inp);
+    // The conversion array computational to field aligned is still computed
+    // in uniform geometry, so we need to deflate it
+    if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
+        geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
+      // Must deflate the 3Duniform geometry in order for the allgather to work
+      if(geometry_inp->grid.ndim < 3)
+        gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
+      else
+        gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
+
+      geometry_inp->position_map->to_optimize = true;
+      gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
+      &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
+
+      gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
+      gkyl_gk_geometry_release(gk_geom); // release 3d geometry
+
+      // Construct the non-uniform grid
+      gk_geom_3d = gk_geometry_mapc2p_init(geometry_inp);
+    }
   }
   return gk_geom_3d;
 }

--- a/zero/gk_geometry_mirror.c
+++ b/zero/gk_geometry_mirror.c
@@ -130,7 +130,6 @@ gkyl_gk_geometry_mirror_new(struct gkyl_gk_geometry_inp *geometry_inp)
   struct gk_geometry* gk_geom_3d;
   struct gk_geometry* gk_geom;
 
-
   if (geometry_inp->position_map == 0){
     geometry_inp->position_map = gkyl_position_map_new((struct gkyl_position_map_inp) {}, \
       geometry_inp->grid, geometry_inp->local, geometry_inp->local_ext, geometry_inp->local, \
@@ -141,11 +140,10 @@ gkyl_gk_geometry_mirror_new(struct gkyl_gk_geometry_inp *geometry_inp)
   else {
     // First construct the uniform 3d geometry
     gk_geom_3d = gk_geometry_mirror_init(geometry_inp);
-    // The conversion array computational to field aligned is still computed
-    // in uniform geometry, so we need to deflate it
     if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
         geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
-      // Must deflate the 3Duniform geometry in order for the allgather to work
+      // The array mc2nu is computed using the uniform geometry, so we need to deflate it
+      // Must deflate the 3D uniform geometry in order for the allgather to work
       if(geometry_inp->grid.ndim < 3)
         gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
       else

--- a/zero/gk_geometry_mirror.c
+++ b/zero/gk_geometry_mirror.c
@@ -129,27 +129,38 @@ gkyl_gk_geometry_mirror_new(struct gkyl_gk_geometry_inp *geometry_inp)
 {
   struct gk_geometry* gk_geom_3d;
   struct gk_geometry* gk_geom;
-  // First construct the uniform 3d geometry
-  gk_geom_3d = gk_geometry_mirror_init(geometry_inp);
-  // The conversion array computational to field aligned is still computed
-  // in uniform geometry, so we need to deflate it
-  if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
-      geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
-    // Must deflate the 3Duniform geometry in order for the allgather to work
-    if(geometry_inp->grid.ndim < 3)
-      gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
-    else
-      gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
 
-    geometry_inp->position_map->to_optimize = true;
-    gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
-    &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
 
-    gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
-    gkyl_gk_geometry_release(gk_geom); // release 3d geometry
-
-    // Construct the non-uniform grid
+  if (geometry_inp->position_map == 0){
+    geometry_inp->position_map = gkyl_position_map_new((struct gkyl_position_map_inp) {}, \
+      geometry_inp->grid, geometry_inp->local, geometry_inp->local_ext, geometry_inp->local, \
+      geometry_inp->local_ext, geometry_inp->basis);
     gk_geom_3d = gk_geometry_mirror_init(geometry_inp);
+    gkyl_position_map_release(geometry_inp->position_map);
+  }
+  else {
+    // First construct the uniform 3d geometry
+    gk_geom_3d = gk_geometry_mirror_init(geometry_inp);
+    // The conversion array computational to field aligned is still computed
+    // in uniform geometry, so we need to deflate it
+    if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
+        geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
+      // Must deflate the 3Duniform geometry in order for the allgather to work
+      if(geometry_inp->grid.ndim < 3)
+        gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
+      else
+        gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
+
+      geometry_inp->position_map->to_optimize = true;
+      gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
+      &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
+
+      gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
+      gkyl_gk_geometry_release(gk_geom); // release 3d geometry
+
+      // Construct the non-uniform grid
+      gk_geom_3d = gk_geometry_mirror_init(geometry_inp);
+    }
   }
   return gk_geom_3d;
 }

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -137,11 +137,10 @@ gkyl_gk_geometry_tok_new(struct gkyl_gk_geometry_inp *geometry_inp)
   else {
     // First construct the uniform 3d geometry
     gk_geom_3d = gk_geometry_tok_init(geometry_inp);
-    // The conversion array computational to field aligned is still computed
-    // in uniform geometry, so we need to deflate it
     if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
         geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
-      // Must deflate the 3Duniform geometry in order for the allgather to work
+      // The array mc2nu is computed using the uniform geometry, so we need to deflate it
+      // Must deflate the 3D uniform geometry in order for the allgather to work
       if(geometry_inp->grid.ndim < 3)
         gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
       else

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -126,27 +126,37 @@ gkyl_gk_geometry_tok_new(struct gkyl_gk_geometry_inp *geometry_inp)
 {
   struct gk_geometry* gk_geom_3d;
   struct gk_geometry* gk_geom;
-  // First construct the uniform 3d geometry
-  gk_geom_3d = gk_geometry_tok_init(geometry_inp);
-  // The conversion array computational to field aligned is still computed
-  // in uniform geometry, so we need to deflate it
-  if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
-      geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
-    // Must deflate the 3Duniform geometry in order for the allgather to work
-    if(geometry_inp->grid.ndim < 3)
-      gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
-    else
-      gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
 
-    geometry_inp->position_map->to_optimize = true;
-    gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
-    &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
-
-    gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
-    gkyl_gk_geometry_release(gk_geom); // release 3d geometry
-
-    // Construct the non-uniform grid
+  if (geometry_inp->position_map == 0){
+    geometry_inp->position_map = gkyl_position_map_new((struct gkyl_position_map_inp) {}, \
+      geometry_inp->grid, geometry_inp->local, geometry_inp->local_ext, geometry_inp->local, \
+      geometry_inp->local_ext, geometry_inp->basis);
     gk_geom_3d = gk_geometry_tok_init(geometry_inp);
+    gkyl_position_map_release(geometry_inp->position_map);
+  }
+  else {
+    // First construct the uniform 3d geometry
+    gk_geom_3d = gk_geometry_tok_init(geometry_inp);
+    // The conversion array computational to field aligned is still computed
+    // in uniform geometry, so we need to deflate it
+    if (geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL || \
+        geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
+      // Must deflate the 3Duniform geometry in order for the allgather to work
+      if(geometry_inp->grid.ndim < 3)
+        gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
+      else
+        gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);
+
+      geometry_inp->position_map->to_optimize = true;
+      gkyl_comm_array_allgather_host(geometry_inp->comm, &geometry_inp->local, \
+      &geometry_inp->global, gk_geom->bmag, (struct gkyl_array*) geometry_inp->position_map->bmag_ctx->bmag);
+
+      gkyl_gk_geometry_release(gk_geom_3d); // release temporary 3d geometry
+      gkyl_gk_geometry_release(gk_geom); // release 3d geometry
+
+      // Construct the non-uniform grid
+      gk_geom_3d = gk_geometry_tok_init(geometry_inp);
+    }
   }
   return gk_geom_3d;
 }

--- a/zero/gkyl_position_map_priv.h
+++ b/zero/gkyl_position_map_priv.h
@@ -314,18 +314,16 @@ find_B_field_extrema(struct gkyl_position_map *gpm)
   double theta_extrema[16];
   double bmag_extrema[16];
 
+  theta_extrema[0] = theta_lo;
+  xp[Z_IDX] = theta_lo;
+  gkyl_calc_bmag_global(0.0, xp, &bmag_extrema[0], bmag_ctx);
+  extrema++;
+
   for (int i = 0; i <= npts; i++){
     double theta = theta_lo + i * theta_dxi;
     xp[Z_IDX] = theta;
     gkyl_calc_bmag_global(0.0, xp, &bmag_vals[i], bmag_ctx);
     dbmag_vals[i] = calc_bmag_global_derivative(theta, gpm);
-    if (i == 0 || i == npts)
-    {
-      theta_extrema[extrema] = theta;
-      bmag_extrema[extrema] = bmag_vals[i];
-      extrema++;
-      continue;
-    }
 
     // Minima
     if (dbmag_vals[i] > 0 && dbmag_vals[i-1] < 0){
@@ -359,6 +357,12 @@ find_B_field_extrema(struct gkyl_position_map *gpm)
       }
     }
   }
+
+  theta_extrema[extrema] = theta_hi;
+  xp[Z_IDX] = theta_hi;
+  gkyl_calc_bmag_global(0.0, xp, &bmag_extrema[extrema], bmag_ctx);
+  extrema++;
+
   gpm->constB_ctx->num_extrema = extrema;
   for (int i = 0; i < extrema; i++)
   {

--- a/zero/mirror_geo.c
+++ b/zero/mirror_geo.c
@@ -173,10 +173,6 @@ void gkyl_mirror_geo_calc(struct gk_geometry* up, struct gkyl_range *nrange, dou
     psi_lo = up->grid.lower[PSI_IDX] + (up->local.lower[PSI_IDX] - up->global.lower[PSI_IDX])*up->grid.dx[PSI_IDX],
     alpha_lo = up->grid.lower[AL_IDX] + (up->local.lower[AL_IDX] - up->global.lower[AL_IDX])*up->grid.dx[AL_IDX];
 
-  double theta_up = inp->cgrid.upper[TH_IDX],
-    psi_up = inp->cgrid.upper[PSI_IDX],
-    alpha_up = inp->cgrid.upper[AL_IDX];
-
   double dx_fact = up->basis.poly_order == 1 ? 1 : 0.5;
   dtheta *= dx_fact; dpsi *= dx_fact; dalpha *= dx_fact;
 
@@ -207,13 +203,13 @@ void gkyl_mirror_geo_calc(struct gk_geometry* up, struct gkyl_range *nrange, dou
     .geo = geo
   };
 
-  position_map->constB_ctx->alpha_max = alpha_up;
-  position_map->constB_ctx->alpha_min = alpha_lo;
-  position_map->constB_ctx->psi_max = psi_up;
-  position_map->constB_ctx->psi_min = psi_lo;
-  position_map->constB_ctx->theta_max = theta_up;
-  position_map->constB_ctx->theta_min = theta_lo;
-  position_map->constB_ctx->N_theta_boundaries = nrange->upper[TH_IDX] - nrange->lower[TH_IDX] + 1;
+  position_map->constB_ctx->psi_max   = up->grid.upper[PSI_IDX];
+  position_map->constB_ctx->psi_min   = up->grid.lower[PSI_IDX];
+  position_map->constB_ctx->alpha_max = up->grid.upper[AL_IDX];
+  position_map->constB_ctx->alpha_min = up->grid.lower[AL_IDX];
+  position_map->constB_ctx->theta_max = up->grid.upper[TH_IDX];
+  position_map->constB_ctx->theta_min = up->grid.lower[TH_IDX];
+  position_map->constB_ctx->N_theta_boundaries = up->global.upper[TH_IDX] - up->global.lower[TH_IDX];
   gkyl_position_map_optimize(position_map);
 
   int cidx[3] = { 0 };

--- a/zero/tok_geo.c
+++ b/zero/tok_geo.c
@@ -386,10 +386,6 @@ void gkyl_tok_geo_calc(struct gk_geometry* up, struct gkyl_range *nrange, double
   double theta_lo = up->grid.lower[TH_IDX] + (up->local.lower[TH_IDX] - up->global.lower[TH_IDX])*up->grid.dx[TH_IDX],
     psi_lo = up->grid.lower[PSI_IDX] + (up->local.lower[PSI_IDX] - up->global.lower[PSI_IDX])*up->grid.dx[PSI_IDX],
     alpha_lo = up->grid.lower[AL_IDX] + (up->local.lower[AL_IDX] - up->global.lower[AL_IDX])*up->grid.dx[AL_IDX];
-
-  double theta_up = inp->cgrid.upper[TH_IDX],
-    psi_up = inp->cgrid.upper[PSI_IDX],
-    alpha_up = inp->cgrid.upper[AL_IDX];
     
   double dx_fact = up->basis.poly_order == 1.0/up->basis.poly_order;
   dtheta *= dx_fact; dpsi *= dx_fact; dalpha *= dx_fact;
@@ -429,13 +425,13 @@ void gkyl_tok_geo_calc(struct gk_geometry* up, struct gkyl_range *nrange, double
     .geo = geo
   };
 
-  position_map->constB_ctx->alpha_max = alpha_up;
-  position_map->constB_ctx->alpha_min = alpha_lo;
-  position_map->constB_ctx->psi_max = psi_up;
-  position_map->constB_ctx->psi_min = psi_lo;
-  position_map->constB_ctx->theta_max = theta_up;
-  position_map->constB_ctx->theta_min = theta_lo;
-  position_map->constB_ctx->N_theta_boundaries = nrange->upper[TH_IDX] - nrange->lower[TH_IDX] + 1;
+  position_map->constB_ctx->psi_max   = up->grid.upper[PSI_IDX];
+  position_map->constB_ctx->psi_min   = up->grid.lower[PSI_IDX];
+  position_map->constB_ctx->alpha_max = up->grid.upper[AL_IDX];
+  position_map->constB_ctx->alpha_min = up->grid.lower[AL_IDX];
+  position_map->constB_ctx->theta_max = up->grid.upper[TH_IDX];
+  position_map->constB_ctx->theta_min = up->grid.lower[TH_IDX];
+  position_map->constB_ctx->N_theta_boundaries = up->global.upper[TH_IDX] - up->global.lower[TH_IDX];
   gkyl_position_map_optimize(position_map);
 
   int cidx[3] = { 0 };


### PR DESCRIPTION
Consider the case where the position map is not provided as an input to the geometry generation. This often happens in a unit test for the geometry modules. The geometry needs to call the position map functions, even if they are identity maps. For this, a temporary position map must be created and destroyed. 