### PR TITLE
Fix GPU part of fem_parproj

### DIFF
--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -85,7 +85,7 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
     }
     if (app->cdim == 1) {
       // Need to set weight to kperpsq*polarizationWeight for use in potential smoothing.
-      f->weight = mkarr(false, app->confBasis.num_basis, app->global_ext.volume); // fem_parproj expects weight on host
+      f->weight = mkarr(app->use_gpu, app->confBasis.num_basis, app->global_ext.volume);
  
       // Gather jacobgeo for smoothing in z.
       struct gkyl_array *jacobgeo_global = mkarr(app->use_gpu, app->confBasis.num_basis, app->global_ext.volume);
@@ -103,7 +103,7 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
         double q_s = f->info.electron_charge;
         double T_s = f->info.electron_temp;
         double quasineut_contr = q_s*n_s0*q_s/T_s;
-        struct gkyl_array *weight_adiab = mkarr(false, app->confBasis.num_basis, app->global_ext.volume); // fem_parproj expects weight on host
+        struct gkyl_array *weight_adiab = mkarr(app->use_gpu, app->confBasis.num_basis, app->global_ext.volume);
         gkyl_array_copy(weight_adiab, jacobgeo_global);
         gkyl_array_scale(weight_adiab, quasineut_contr);
         gkyl_array_accumulate(f->weight, 1., weight_adiab);

--- a/unit/ctest_fem_parproj.c
+++ b/unit/ctest_fem_parproj.c
@@ -1270,6 +1270,7 @@ void gpu_test_3x_p2_nonperiodic() {test_3x(2, false, true);}
 void gpu_test_3x_p2_periodic() {test_3x(2, true, true);}
 
 void gpu_test_2x_p1_dirichlet() {test_2x_dirichlet(1, true);}
+void gpu_test_2x_p1_weighted() {test_2x_weighted(1, false, true);}
 #endif
 
 
@@ -1298,6 +1299,7 @@ TEST_LIST = {
   { "gpu_test_3x_p2_nonperiodic", gpu_test_3x_p2_nonperiodic },
   { "gpu_test_3x_p2_periodic", gpu_test_3x_p2_periodic },
   { "gpu_test_2x_p1_dirichlet", gpu_test_2x_p1_dirichlet},
+  { "gpu_test_2x_p1_weighted", gpu_test_2x_p1_weighted},
 #endif
   { NULL, NULL },
 };

--- a/zero/fem_parproj.c
+++ b/zero/fem_parproj.c
@@ -35,7 +35,13 @@ gkyl_fem_parproj_new(const struct gkyl_range *solve_range,
   }
 
   bool has_weight_lhs = false;
-  if (weight_left) has_weight_lhs = true;
+  struct gkyl_array *weight_left_ho;
+  if (weight_left) {
+    has_weight_lhs = true;
+    weight_left_ho = use_gpu? gkyl_array_new(GKYL_DOUBLE, weight_left->ncomp, weight_left->size)
+                            : gkyl_array_acquire(weight_left);
+    gkyl_array_copy(weight_left_ho, weight_left);
+  }
 
   up->globalidx = gkyl_malloc(sizeof(long[up->num_basis]));
 
@@ -139,7 +145,7 @@ gkyl_fem_parproj_new(const struct gkyl_range *solve_range,
         for (size_t d=0; d<up->pardir; d++) idx1[d] = up->perp_iter2d.idx[d];
         idx1[up->pardir] = up->par_iter1d.idx[0];
         long linidx = gkyl_range_idx(up->solve_range, idx1);
-        wgt_p = gkyl_array_cfetch(weight_left, linidx);
+        wgt_p = gkyl_array_cfetch(weight_left_ho, linidx);
       }
 
       int keri = up->par_iter1d.idx[0] == up->parnum_cells? 1 : 0;
@@ -162,6 +168,9 @@ gkyl_fem_parproj_new(const struct gkyl_range *solve_range,
   for (size_t i=0; i<prob_range.volume; i++)
     gkyl_mat_triples_release(tri[i]);
   gkyl_free(tri);
+
+  if (weight_left)
+    gkyl_array_release(weight_left_ho);
 
   return up;
 }

--- a/zero/fem_parproj.c
+++ b/zero/fem_parproj.c
@@ -80,7 +80,7 @@ gkyl_fem_parproj_new(const struct gkyl_range *solve_range,
 
 #ifdef GKYL_HAVE_CUDA
   if (up->use_gpu)
-    fem_parproj_choose_kernels_cu(basis, up->isperiodic, up->isdirichlet, up->kernels_cu);
+    fem_parproj_choose_kernels_cu(basis, up->has_weight_rhs, up->isperiodic, up->isdirichlet, up->kernels_cu);
 #endif
 
   // We support two cases:

--- a/zero/fem_parproj_cu.cu
+++ b/zero/fem_parproj_cu.cu
@@ -12,7 +12,7 @@ extern "C" {
 // cudaMemcpyFromSymbol.
 __global__ static void
 fem_parproj_set_cu_ker_ptrs(struct gkyl_fem_parproj_kernels* kers, enum gkyl_basis_type b_type,
-  int dim, int poly_order, bool isperiodic, bool isdirichlet)
+  int dim, int poly_order, bool isperiodic, bool isweighted, bool isdirichlet)
 {
   // Set l2g kernels.
   int bckey_periodic = isperiodic? 0 : 1;
@@ -33,7 +33,7 @@ fem_parproj_set_cu_ker_ptrs(struct gkyl_fem_parproj_kernels* kers, enum gkyl_bas
   const srcstencil_kern_list *srcstencil_kernels;
   switch (b_type) {
     case GKYL_BASIS_MODAL_SERENDIPITY:
-      srcstencil_kernels = ser_srcstencil_list;
+      srcstencil_kernels = isweighted? ser_srcstencil_list_weighted : ser_srcstencil_list_noweight;
       break;
     default:
       assert(false);
@@ -54,10 +54,21 @@ fem_parproj_set_cu_ker_ptrs(struct gkyl_fem_parproj_kernels* kers, enum gkyl_bas
 
 }
 
-__global__ void
-gkyl_fem_parproj_set_rhs_kernel(double *rhs_global, const struct gkyl_array *rhsin, const struct gkyl_array *phibc, struct gkyl_range range, struct gkyl_range range_ext, struct gkyl_range perp_range2d, struct gkyl_range par_range1d, struct gkyl_fem_parproj_kernels *kers, long numnodes_global)
+void
+fem_parproj_choose_kernels_cu(const struct gkyl_basis *basis, bool has_weight_rhs,
+  bool isperiodic, bool isdirichlet, struct gkyl_fem_parproj_kernels *kers)
 {
-  int idx[GKYL_MAX_CDIM], skin_idx[GKYL_MAX_CDIM];
+  fem_parproj_set_cu_ker_ptrs<<<1,1>>>(kers, basis->b_type, basis->ndim,
+    basis->poly_order, isperiodic, has_weight_rhs, isdirichlet);
+}
+
+__global__ void
+gkyl_fem_parproj_set_rhs_kernel(double *rhs_global, const struct gkyl_array *rhsin,
+  const struct gkyl_array *weight, const struct gkyl_array *phibc,
+  struct gkyl_range range, struct gkyl_range perp_range2d, struct gkyl_range par_range1d,
+  struct gkyl_fem_parproj_kernels *kers, long numnodes_global)
+{
+  int idx[GKYL_MAX_CDIM];
   long globalidx[32];
   int parnum_cells = range.upper[range.ndim-1]-range.lower[range.ndim-1]+1;
 
@@ -70,18 +81,15 @@ gkyl_fem_parproj_set_rhs_kernel(double *rhs_global, const struct gkyl_array *rhs
     // since update_range is a subrange
     gkyl_sub_range_inv_idx(&range, linc1, idx);
 
-    int idx1d[] = {idx[range.ndim-1]};
-
     // convert back to a linear index on the super-range (with ghost cells)
     // linc will have jumps in it to jump over ghost cells
     long linidx = gkyl_range_idx(&range, idx);
+
+    const double *wgt_p = weight? (const double *) gkyl_array_cfetch(weight, linidx) : NULL;
+    const double *phibc_p = phibc? (const double *) gkyl_array_cfetch(phibc, linidx) : NULL;
     const double *rhsin_p = (const double*) gkyl_array_cfetch(rhsin, linidx);
 
-    for (int d=0; d<range.ndim-1; d++) skin_idx[d] = idx[d];
-    skin_idx[range.ndim-1] = idx1d[0] == parnum_cells? idx1d[0] : idx1d[0];
-    linidx = gkyl_range_idx(&range_ext, skin_idx);
-    const double *phibc_p = phibc? (const double *) gkyl_array_cfetch(phibc, linidx) : NULL;
-
+    int idx1d[] = {idx[range.ndim-1]};
     long paridx = gkyl_range_idx(&par_range1d, idx1d);
     int keri = idx1d[0] == parnum_cells? 1 : 0;
     kers->l2g[keri](parnum_cells, paridx, globalidx);
@@ -94,12 +102,27 @@ gkyl_fem_parproj_set_rhs_kernel(double *rhs_global, const struct gkyl_array *rhs
     // Apply the RHS source stencil. It's mostly the mass matrix times a
     // modal-to-nodal operator times the source, modified by BCs in skin cells.
     keri = idx_to_inloup_ker(parnum_cells, idx1d[0]);
-    kers->srcker[keri](rhsin_p, phibc_p, perpProbOff, globalidx, rhs_global);
+    kers->srcker[keri](wgt_p, rhsin_p, phibc_p, perpProbOff, globalidx, rhs_global);
   }
 }
 
+void
+gkyl_fem_parproj_set_rhs_cu(gkyl_fem_parproj *up, const struct gkyl_array *rhsin, const struct gkyl_array *phibc)
+{
+  gkyl_culinsolver_clear_rhs(up->prob_cu, 0);
+  double *rhs_cu = gkyl_culinsolver_get_rhs_ptr(up->prob_cu, 0);
+
+  const struct gkyl_array *phibc_cu = phibc? phibc->on_dev : NULL;
+  const struct gkyl_array *wgt_cu = up->has_weight_rhs? up->weight_rhs->on_dev : NULL;
+
+  gkyl_fem_parproj_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(rhs_cu, rhsin->on_dev, wgt_cu, phibc_cu,
+    *up->solve_range, up->perp_range2d, up->par_range1d, up->kernels_cu, up->numnodes_global);
+}
+
 __global__ void
-gkyl_fem_parproj_get_sol_kernel(struct gkyl_array *phiout, const double *x_global, struct gkyl_range range, struct gkyl_range perp_range2d, struct gkyl_range par_range1d, struct gkyl_fem_parproj_kernels *kers, long numnodes_global)
+gkyl_fem_parproj_get_sol_kernel(struct gkyl_array *phiout, const double *x_global, struct gkyl_range range,
+  struct gkyl_range perp_range2d, struct gkyl_range par_range1d, struct gkyl_fem_parproj_kernels *kers,
+  long numnodes_global)
 {
   int idx[GKYL_MAX_DIM];
   long globalidx[32];
@@ -136,25 +159,11 @@ gkyl_fem_parproj_get_sol_kernel(struct gkyl_array *phiout, const double *x_globa
 }
 
 void
-fem_parproj_choose_kernels_cu(const struct gkyl_basis *basis, bool isperiodic, bool isdirichlet, struct gkyl_fem_parproj_kernels *kers)
-{
-  fem_parproj_set_cu_ker_ptrs<<<1,1>>>(kers, basis->b_type, basis->ndim, basis->poly_order, isperiodic, isdirichlet);
-}
-
-void
-gkyl_fem_parproj_set_rhs_cu(gkyl_fem_parproj *up, const struct gkyl_array *rhsin, const struct gkyl_array *phibc)
-{
-  gkyl_culinsolver_clear_rhs(up->prob_cu, 0);
-  double *rhs_cu = gkyl_culinsolver_get_rhs_ptr(up->prob_cu, 0);
-  const struct gkyl_array *phibc_cu = phibc? phibc->on_dev : NULL;
-  gkyl_fem_parproj_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(rhs_cu, rhsin->on_dev, phibc_cu, *up->solve_range, *up->solve_range_ext, up->perp_range2d, up->par_range1d, up->kernels_cu, up->numnodes_global);
-}
-
-void
 gkyl_fem_parproj_solve_cu(gkyl_fem_parproj *up, struct gkyl_array *phiout)
 {
   gkyl_culinsolver_solve(up->prob_cu);
   double *x_cu = gkyl_culinsolver_get_sol_ptr(up->prob_cu, 0);
 
-  gkyl_fem_parproj_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev, x_cu, *up->solve_range, up->perp_range2d, up->par_range1d, up->kernels_cu, up->numnodes_global);
+  gkyl_fem_parproj_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev, x_cu,
+    *up->solve_range, up->perp_range2d, up->par_range1d, up->kernels_cu, up->numnodes_global);
 }

--- a/zero/fem_poisson_perp_cu.cu
+++ b/zero/fem_poisson_perp_cu.cu
@@ -142,7 +142,9 @@ gkyl_fem_poisson_perp_set_rhs_cu(gkyl_fem_poisson_perp *up, struct gkyl_array *r
   gkyl_culinsolver_clear_rhs(up->prob_cu, 0);
   double *rhs_cu = gkyl_culinsolver_get_rhs_ptr(up->prob_cu, 0);
 
-  gkyl_fem_poisson_perp_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(up->epsilon->on_dev, up->dx_cu, rhs_cu, rhsin->on_dev, *up->solve_range, up->par_range1d, up->bcvals_cu, up->kernels_cu, up->numnodes_global);
+  gkyl_fem_poisson_perp_set_rhs_kernel<<<rhsin->nblocks, rhsin->nthreads>>>(up->epsilon->on_dev,
+    up->dx_cu, rhs_cu, rhsin->on_dev, *up->solve_range, up->par_range1d, up->bcvals_cu,
+    up->kernels_cu, up->numnodes_global);
 }
 
 __global__ void
@@ -186,5 +188,6 @@ gkyl_fem_poisson_perp_solve_cu(struct gkyl_fem_poisson_perp *up, struct gkyl_arr
   gkyl_culinsolver_solve(up->prob_cu);
   double *x_cu = gkyl_culinsolver_get_sol_ptr(up->prob_cu, 0);
 
-  gkyl_fem_poisson_perp_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev, x_cu, *up->solve_range, up->par_range1d, up->kernels_cu, up->numnodes_global);
+  gkyl_fem_poisson_perp_get_sol_kernel<<<phiout->nblocks, phiout->nthreads>>>(phiout->on_dev,
+    x_cu, *up->solve_range, up->par_range1d, up->kernels_cu, up->numnodes_global);
 }

--- a/zero/gkyl_fem_parproj_priv.h
+++ b/zero/gkyl_fem_parproj_priv.h
@@ -399,7 +399,8 @@ struct gkyl_fem_parproj {
 #define CK(lst,dim,bc,poly_order,loc) lst[dim-1].list[bc].list[poly_order-1].kernels[loc]
 
 void
-fem_parproj_choose_kernels_cu(const struct gkyl_basis* basis, bool isperiodic, bool isdirichlet, struct gkyl_fem_parproj_kernels *kers);
+fem_parproj_choose_kernels_cu(const struct gkyl_basis* basis, bool isweighted,
+  bool isperiodic, bool isdirichlet, struct gkyl_fem_parproj_kernels *kers);
 
 GKYL_CU_D
 static void


### PR DESCRIPTION
PR #570 had incomplete code in that some changes were missing in the fem_parproj CUDA file, and that the updater still assumed the weight should reside on the host. We fix that here.

The code compiles again, unit tests pass, and several regression tests with various field models run and return expected results on GPU.