### PR TITLE
Restructure write functions

### DIFF
--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -476,7 +476,7 @@ gk_species_calc_L2norm_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks
 }
 
 static void
-gk_species_calc_L2norm_static(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+gk_species_calc_L2norm_static(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
 {
   // do nothing
 }

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -241,6 +241,282 @@ gk_species_copy_range_static(struct gkyl_array *out,
 }
 
 static void
+gk_species_write_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  struct timespec wst = gkyl_wall_clock();
+  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+      .frame = frame,
+      .stime = tm,
+      .poly_order = app->poly_order,
+      .basis_type = app->basis.id
+    }
+  );
+  const char *fmt = "%s-%s_%d.gkyl";
+  int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
+  char fileNm[sz+1]; // ensures no buffer overflow
+  snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);
+  
+  // copy data from device to host before writing it out
+  if (app->use_gpu) {
+    gkyl_array_copy(gks->f_host, gks->f);
+  }
+  struct timespec wtm = gkyl_wall_clock();
+  gkyl_comm_array_write(gks->comm, &gks->grid, &gks->local, mt, gks->f_host, fileNm);
+  app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+  app->stat.nio += 1;
+    
+  gk_array_meta_release(mt);  
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+static void
+gk_species_write_static(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  // do nothing
+}
+
+static void
+gk_species_write_mom_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  struct timespec wst = gkyl_wall_clock();
+  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+      .frame = frame,
+      .stime = tm,
+      .poly_order = app->poly_order,
+      .basis_type = app->confBasis.id
+    }
+  );
+  for (int m=0; m<gks->info.num_diag_moments; ++m) {
+    gk_species_moment_calc(&gks->moms[m], gks->local, app->local, gks->f);
+    app->stat.nmom += 1;
+    
+    const char *fmt = "%s-%s_%s_%d.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+      gks->info.diag_moments[m], frame);
+    char fileNm[sz+1]; // ensures no buffer overflow
+    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+      gks->info.diag_moments[m], frame);
+    
+    // Rescale moment by inverse of Jacobian if not already re-scaled 
+    if (!gks->moms[m].is_bimaxwellian_moms && !gks->moms[m].is_maxwellian_moms) {
+      gkyl_dg_div_op_range(gks->moms[m].mem_geo, app->confBasis, 
+        0, gks->moms[m].marr, 0, gks->moms[m].marr, 0, 
+        app->gk_geom->jacobgeo, &app->local);  
+    }    
+      
+    if (app->use_gpu) {
+      gkyl_array_copy(gks->moms[m].marr_host, gks->moms[m].marr);
+    }
+    struct timespec wtm = gkyl_wall_clock();
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
+      gks->moms[m].marr_host, fileNm);
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 1;
+  }
+  if (app->enforce_positivity) {
+    // We placed the change in f from the positivity shift in fnew.
+    gk_species_moment_calc(&gks->ps_moms, gks->local, app->local, gks->fnew);
+    app->stat.nmom += 1;
+    const char *fmt = "%s-%s_positivity_shift_FourMoments_%d.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
+    char fileNm[sz+1]; // ensures no buffer overflow
+    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);
+    
+    // Rescale moment by inverse of Jacobian.
+    gkyl_dg_div_op_range(gks->ps_moms.mem_geo, app->confBasis, 
+      0, gks->ps_moms.marr, 0, gks->ps_moms.marr, 0, 
+      app->gk_geom->jacobgeo, &app->local);  
+    if (app->use_gpu) {
+      gkyl_array_copy(gks->ps_moms.marr_host, gks->ps_moms.marr);
+    }
+    struct timespec wtm = gkyl_wall_clock();
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
+      gks->ps_moms.marr_host, fileNm);
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 1;
+  }
+  gk_array_meta_release(mt);   
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+static void
+gk_species_write_mom_static(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  // do nothing
+}
+
+static void
+gk_species_calc_integrated_mom_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  struct timespec wst = gkyl_wall_clock();
+  int vdim = app->vdim;
+  double avals_global[2+vdim];
+  
+  gk_species_moment_calc(&gks->integ_moms, gks->local, app->local, gks->f); 
+  // Reduce (sum) over whole domain, append to diagnostics.
+  gkyl_array_reduce_range(gks->red_integ_diag, gks->integ_moms.marr, GKYL_SUM, &app->local);
+  gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 2+vdim, 
+    gks->red_integ_diag, gks->red_integ_diag_global);
+  if (app->use_gpu) {
+    gkyl_cu_memcpy(avals_global, gks->red_integ_diag_global, sizeof(double[2+vdim]), GKYL_CU_MEMCPY_D2H);
+  }
+  else {
+    memcpy(avals_global, gks->red_integ_diag_global, sizeof(double[2+vdim]));
+  }
+  gkyl_dynvec_append(gks->integ_diag, tm, avals_global);
+  
+  if (app->enforce_positivity) {
+    // The change in f from the positivity shift is in fnew.
+    gk_species_moment_calc(&gks->integ_moms, gks->local, app->local, gks->fnew); 
+    // Reduce (sum) over whole domain, append to diagnostics.
+    gkyl_array_reduce_range(gks->red_integ_diag, gks->integ_moms.marr, GKYL_SUM, &app->local);
+    gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 2+vdim, 
+      gks->red_integ_diag, gks->red_integ_diag_global);
+    if (app->use_gpu) {
+      gkyl_cu_memcpy(avals_global, gks->red_integ_diag_global, sizeof(double[2+vdim]), GKYL_CU_MEMCPY_D2H);
+    }
+    else {
+      memcpy(avals_global, gks->red_integ_diag_global, sizeof(double[2+vdim]));
+      }
+    gkyl_dynvec_append(gks->ps_integ_diag, tm, avals_global);
+  }
+  
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+static void
+gk_species_calc_integrated_mom_static(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  // do nothing
+}
+
+static void
+gk_species_write_integrated_mom_dynamic(gkyl_gyrokinetic_app *app, struct gk_species *gks)
+{
+  struct timespec wst = gkyl_wall_clock();
+  int rank;
+  gkyl_comm_get_rank(app->comm, &rank);
+  
+  if (rank == 0) {
+    // Write integrated diagnostic moments.
+    const char *fmt = "%s-%s_%s.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "integrated_moms");
+    char fileNm[sz+1]; // ensures no buffer overflow
+    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "integrated_moms");
+    
+    struct timespec wtm = gkyl_wall_clock();
+    if (gks->is_first_integ_write_call) {
+      gkyl_dynvec_write(gks->integ_diag, fileNm);
+      gks->is_first_integ_write_call = false;
+    }
+    else {
+      gkyl_dynvec_awrite(gks->integ_diag, fileNm);
+    }
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 1;
+  }
+  gkyl_dynvec_clear(gks->integ_diag);
+  
+  if (app->enforce_positivity) {
+    if (rank == 0) {
+      // Write integrated diagnostic moments.
+      const char *fmt = "%s-%s_positivity_shift_%s.gkyl";
+      int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "integrated_moms");
+      char fileNm[sz+1]; // ensures no buffer overflow
+      snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "integrated_moms");
+      
+      struct timespec wtm = gkyl_wall_clock();
+      if (gks->is_first_ps_integ_write_call) {
+	gkyl_dynvec_write(gks->ps_integ_diag, fileNm);
+	gks->is_first_ps_integ_write_call = false;
+      }
+      else {
+	gkyl_dynvec_awrite(gks->ps_integ_diag, fileNm);
+      }
+      app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+      app->stat.nio += 1;
+    }
+    gkyl_dynvec_clear(gks->ps_integ_diag);
+  }
+  
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+static void
+gk_species_write_integrated_mom_static(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  // do nothing
+}
+
+static void
+gk_species_calc_L2norm_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  struct timespec wst = gkyl_wall_clock();
+
+  gkyl_array_integrate_advance(gks->integ_wfsq_op, gks->f, (2.0*M_PI)/gks->info.mass,
+    app->jacobtot_inv_weak, &gks->local, &app->local, gks->L2norm_local);
+  gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 1, gks->L2norm_local, gks->L2norm_global);
+
+  double L2norm_global[] = {0.0};
+  if (app->use_gpu) {
+    gkyl_cu_memcpy(L2norm_global, gks->L2norm_global, sizeof(double), GKYL_CU_MEMCPY_D2H);
+  }
+  else { 
+    memcpy(L2norm_global, gks->L2norm_global, sizeof(double));
+  }
+  
+  gkyl_dynvec_append(gks->L2norm, tm, L2norm_global);  
+
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+static void
+gk_species_calc_L2norm_static(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  // do nothing
+}
+
+static void
+gk_species_write_L2norm_dynamic(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  struct timespec wst = gkyl_wall_clock();
+
+  int rank;
+  gkyl_comm_get_rank(app->comm, &rank);
+
+  if (rank == 0) {
+    // Write the L2 norm.
+    const char *fmt = "%s-%s_%s.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "L2norm");
+    char fileNm[sz+1]; // ensures no buffer overflow
+    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "L2norm");
+
+    struct timespec wtm = gkyl_wall_clock();
+    if (gks->is_first_L2norm_write_call) {
+      gkyl_dynvec_write(gks->L2norm, fileNm);
+      gks->is_first_L2norm_write_call = false;
+    }
+    else {
+      gkyl_dynvec_awrite(gks->L2norm, fileNm);
+    }
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 1;
+  }
+  gkyl_dynvec_clear(gks->L2norm);
+}
+
+static void
+gk_species_write_L2norm_static(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  // do nothing
+}
+
+static void
 gk_species_release_dynamic(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
 {
     // release various arrays and species objects
@@ -652,6 +928,12 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
   gks->step_f_func = gk_species_step_f_dynamic;
   gks->combine_func = gk_species_combine_dynamic;
   gks->copy_func = gk_species_copy_range_dynamic;
+  gks->write_func = gk_species_write_dynamic;
+  gks->write_mom_func = gk_species_write_mom_dynamic;
+  gks->calc_integrated_mom_func = gk_species_calc_integrated_mom_dynamic;
+  gks->write_integrated_mom_func = gk_species_write_integrated_mom_dynamic;
+  gks->calc_L2norm_func = gk_species_calc_L2norm_dynamic;
+  gks->write_L2norm_func = gk_species_write_L2norm_dynamic;
 }
 
 // initialize static species object
@@ -669,6 +951,12 @@ gk_species_new_static(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *a
   gks->step_f_func = gk_species_step_f_static;
   gks->combine_func = gk_species_combine_static;
   gks->copy_func = gk_species_copy_range_static;
+  gks->write_func = gk_species_write_static;
+  gks->write_mom_func = gk_species_write_mom_static;
+  gks->calc_integrated_mom_func = gk_species_calc_integrated_mom_static;
+  gks->write_integrated_mom_func = gk_species_write_integrated_mom_static;
+  gks->calc_L2norm_func = gk_species_calc_L2norm_static;
+  gks->write_L2norm_func = gk_species_write_L2norm_static;
 }
 
 // End static function definitions.
@@ -1157,6 +1445,51 @@ gk_species_tm(gkyl_gyrokinetic_app *app)
       gkyl_dg_updater_gyrokinetic_get_tm(app->species[i].slvr);
     app->stat.species_rhs_tm += tm.gyrokinetic_tm;
   }
+}
+
+// write functions
+void
+gk_species_write(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  if (frame == 0) {
+    gk_species_write_dynamic(app, gks, tm, frame);
+  }
+  else
+    gks->write_func(app, gks, tm, frame);
+}
+
+void
+gk_species_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  if (frame == 0) {
+    gk_species_write_mom_dynamic(app, gks, tm, frame);
+  }
+  else
+    gks->write_mom_func(app, gks, tm, frame);
+}
+
+void
+gk_species_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  gks->calc_integrated_mom_func(app, gks, tm);
+}
+
+void
+gk_species_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  gks->write_integrated_mom_func(app, gks);
+}
+
+void
+gk_species_calc_L2norm(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  gks->calc_L2norm_func(app, gks, tm);
+}
+
+void
+gk_species_write_L2norm(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  gks->write_L2norm_func(app, gks);
 }
 
 // release resources for species

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -686,17 +686,6 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
       }
     }
   }
-
-  struct gkyl_dg_gyrokinetic_auxfields aux_inp = { .alpha_surf = gks->alpha_surf, 
-    .sgn_alpha_surf = gks->sgn_alpha_surf, .const_sgn_alpha = gks->const_sgn_alpha, 
-    .phi = gks->phi, .apar = gks->apar, .apardot = gks->apardot };
-  // Create collisionless solver.
-  gks->slvr = gkyl_dg_updater_gyrokinetic_new(&gks->grid, &app->confBasis, &app->basis, 
-    &app->local, &gks->local, is_zero_flux, gks->info.charge, gks->info.mass,
-    gks->gkmodel_id, app->gk_geom, gks->vel_map, &aux_inp, app->use_gpu);
-
-  // Acquire equation object.
-  gks->eqn_gyrokinetic = gkyl_dg_updater_gyrokinetic_acquire_eqn(gks->slvr);
   
   // Determine collision type and initialize it.
   gks->lbo = (struct gk_lbo_collisions) { };

--- a/apps/gk_species_lbo.c
+++ b/apps/gk_species_lbo.c
@@ -285,6 +285,69 @@ gk_species_lbo_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *species,
   app->stat.species_coll_tm += gkyl_time_diff_now_sec(wst);
 }
 
+void
+gk_species_lbo_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  if (gks->lbo.collision_id == GKYL_LBO_COLLISIONS && gks->lbo.write_diagnostics) {
+    struct timespec wst = gkyl_wall_clock();
+
+    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+        .frame = frame,
+        .stime = tm,
+        .poly_order = app->poly_order,
+        .basis_type = app->confBasis.id
+      }
+    );
+
+    // Construct the file handles for collision frequency and primitive moments
+    const char *fmt_prim = "%s-%s_prim_moms_%d.gkyl";
+    int sz_prim = gkyl_calc_strlen(fmt_prim, app->name, gks->info.name, frame);
+    char fileNm_prim[sz_prim+1]; // ensures no buffer overflow
+    snprintf(fileNm_prim, sizeof fileNm_prim, fmt_prim, app->name, gks->info.name, frame);
+
+    // Compute primitive moments
+    const struct gkyl_array *fin[app->num_species];
+    gk_species_lbo_moms(app, gks, &gks->lbo, gks->f);
+
+    // copy data from device to host before writing it out
+    if (app->use_gpu) {  
+      gkyl_array_copy(gks->lbo.prim_moms_host, gks->lbo.prim_moms);
+    }
+
+    struct timespec wtm = gkyl_wall_clock();
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.prim_moms_host, fileNm_prim);
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 1;
+
+    // Uncomment the following to write out nu_sum and nu_prim_moms
+    /*const char *fmt = "%s-%s_nu_sum_%d.gkyl";
+    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
+    char fileNm[sz+1]; // ensures no buffer overflow
+    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);
+    
+    const char *fmt_nu_prim = "%s-%s_nu_prim_moms_%d.gkyl";
+    int sz_nu_prim = gkyl_calc_strlen(fmt_nu_prim, app->name, gks->info.name, frame);
+    char fileNm_nu_prim[sz_nu_prim+1]; // ensures no buffer overflow
+    snprintf(fileNm_nu_prim, sizeof fileNm_nu_prim, fmt_nu_prim, app->name, gks->info.name, frame);
+    
+    if (gks->lbo.num_cross_collisions)
+      gk_species_lbo_cross_moms(app, gk_s, &gks->lbo, gks->f);
+    
+    // copy data from device to host before writing it out
+    if (app->use_gpu) {
+      gkyl_array_copy(gks->lbo.nu_sum_host, gks->lbo.nu_sum);
+      gkyl_array_copy(gks->lbo.nu_prim_moms_host, gks->lbo.nu_prim_moms);
+    }
+    
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.nu_sum_host, fileNm);
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.nu_prim_moms_host, fileNm_nu_prim);*/
+
+    gk_array_meta_release(mt); 
+    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+    app->stat.ndiag += 1;
+  }
+}
+
 void 
 gk_species_lbo_release(const struct gkyl_gyrokinetic_app *app, const struct gk_lbo_collisions *lbo)
 {

--- a/apps/gk_species_radiation.c
+++ b/apps/gk_species_radiation.c
@@ -315,6 +315,197 @@ gk_species_radiation_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *spe
   app->stat.species_coll_tm += gkyl_time_diff_now_sec(wst);
 }
 
+// write functions
+void
+gk_species_radiation_write_drag(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  if (gks->rad.radiation_id == GKYL_GK_RADIATION) {
+    struct timespec wst = gkyl_wall_clock();
+    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+        .frame = frame,
+        .stime = tm,
+        .poly_order = app->poly_order,
+        .basis_type = app->basis.id      
+      }
+    );
+
+    // Construct the file handles for vparallel and mu drag
+    const char *fmt_nvnu_surf = "%s-%s_radiation_nvnu_surf_%d.gkyl";
+    int sz_nvnu_surf = gkyl_calc_strlen(fmt_nvnu_surf, app->name, gks->info.name, frame);
+    char fileNm_nvnu_surf[sz_nvnu_surf+1]; // ensures no buffer overflow
+    snprintf(fileNm_nvnu_surf, sizeof fileNm_nvnu_surf, fmt_nvnu_surf, app->name, gks->info.name, frame);
+
+    const char *fmt_nvnu = "%s-%s_radiation_nvnu_%d.gkyl";
+    int sz_nvnu = gkyl_calc_strlen(fmt_nvnu, app->name, gks->info.name, frame);
+    char fileNm_nvnu[sz_nvnu+1]; // ensures no buffer overflow
+    snprintf(fileNm_nvnu, sizeof fileNm_nvnu, fmt_nvnu, app->name, gks->info.name, frame);
+
+    const char *fmt_nvsqnu_surf = "%s-%s_radiation_nvsqnu_surf_%d.gkyl";
+    int sz_nvsqnu_surf = gkyl_calc_strlen(fmt_nvsqnu_surf, app->name, gks->info.name, frame);
+    char fileNm_nvsqnu_surf[sz_nvsqnu_surf+1]; // ensures no buffer overflow
+    snprintf(fileNm_nvsqnu_surf, sizeof fileNm_nvsqnu_surf, fmt_nvsqnu_surf, app->name, gks->info.name, frame);
+
+    const char *fmt_nvsqnu = "%s-%s_radiation_nvsqnu_%d.gkyl";
+    int sz_nvsqnu = gkyl_calc_strlen(fmt_nvsqnu, app->name, gks->info.name, frame);
+    char fileNm_nvsqnu[sz_nvsqnu+1]; // ensures no buffer overflow
+    snprintf(fileNm_nvsqnu, sizeof fileNm_nvsqnu, fmt_nvsqnu, app->name, gks->info.name, frame);
+
+    // Compute radiation drag coefficients
+    const struct gkyl_array *fin_neut[app->num_neut_species];
+    const struct gkyl_array *fin[app->num_species];
+    for (int i=0; i<app->num_species; ++i) 
+      fin[i] = app->species[i].f;
+    for (int i=0; i<app->num_neut_species; ++i)
+      fin_neut[i] = app->neut_species[i].f;
+
+    gk_species_radiation_moms(app, gks, &gks->rad, fin, fin_neut);
+
+    // copy data from device to host before writing it out
+    if (app->use_gpu) {
+      gkyl_array_copy(gks->rad.nvnu_surf_host, gks->rad.nvnu_surf);
+      gkyl_array_copy(gks->rad.nvnu_host, gks->rad.nvnu);
+      gkyl_array_copy(gks->rad.nvsqnu_surf_host, gks->rad.nvsqnu_surf);
+      gkyl_array_copy(gks->rad.nvsqnu_host, gks->rad.nvsqnu);
+    }
+
+    struct timespec wtm = gkyl_wall_clock();
+    gkyl_comm_array_write(gks->comm, &gks->grid, &gks->local, mt, gks->rad.nvnu_surf_host, fileNm_nvnu_surf);
+    gkyl_comm_array_write(gks->comm, &gks->grid, &gks->local, mt, gks->rad.nvnu_host, fileNm_nvnu);
+    gkyl_comm_array_write(gks->comm, &gks->grid, &gks->local, mt, gks->rad.nvsqnu_surf_host, fileNm_nvsqnu_surf);
+    gkyl_comm_array_write(gks->comm, &gks->grid, &gks->local, mt, gks->rad.nvsqnu_host, fileNm_nvsqnu);
+    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+    app->stat.nio += 4;
+
+    gk_array_meta_release(mt);   
+    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+    app->stat.ndiag += 1;
+  }
+}
+
+void
+gk_species_radiation_write_emissivity(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame)
+{
+  if (gks->rad.radiation_id == GKYL_GK_RADIATION) {
+    struct timespec wst = gkyl_wall_clock();
+    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+        .frame = frame,
+        .stime = tm,
+        .poly_order = app->poly_order,
+        .basis_type = app->confBasis.id
+      }
+    );
+    
+    const struct gkyl_array *fin_neut[app->num_neut_species];
+    const struct gkyl_array *fin[app->num_species];
+    for (int i=0; i<app->num_species; ++i) 
+      fin[i] = app->species[i].f;
+    for (int i=0; i<app->num_neut_species; ++i)
+      fin_neut[i] = app->neut_species[i].f;
+
+    gk_species_radiation_emissivity(app, gks, &gks->rad, fin, fin_neut);
+    for (int i=0; i<gks->rad.num_cross_collisions; i++) {
+      // copy data from device to host before writing it out
+      if (app->use_gpu) {
+        gkyl_array_copy(gks->rad.emissivity_host[i], gks->rad.emissivity[i]);
+      }
+      // Construct the file handles for vparallel and mu drag
+      const char *fmt_emissivity = "%s-%s_radiation_emissivity_%s_%d.gkyl";  
+      if (gks->rad.is_neut_species[i]) {
+        int sz_emissivity = gkyl_calc_strlen(fmt_emissivity, app->name, gks->info.name,
+          app->neut_species[gks->rad.collide_with_idx[i]].info.name, frame);
+        char fileNm_emissivity[sz_emissivity+1]; // ensures no buffer overflow
+        snprintf(fileNm_emissivity, sizeof fileNm_emissivity, fmt_emissivity, app->name,
+          gks->info.name, app->neut_species[gks->rad.collide_with_idx[i]].info.name, frame);
+        struct timespec wtm = gkyl_wall_clock();
+        gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->rad.emissivity_host[i], fileNm_emissivity);
+        app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+      } else {
+        int sz_emissivity = gkyl_calc_strlen(fmt_emissivity, app->name, gks->info.name,
+          app->species[gks->rad.collide_with_idx[i]].info.name, frame);
+        char fileNm_emissivity[sz_emissivity+1]; // ensures no buffer overflow
+        snprintf(fileNm_emissivity, sizeof fileNm_emissivity, fmt_emissivity, app->name,
+          gks->info.name, app->species[gks->rad.collide_with_idx[i]].info.name, frame);
+        struct timespec wtm = gkyl_wall_clock();
+        gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->rad.emissivity_host[i], fileNm_emissivity);
+        app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+      }  
+      app->stat.nio += 1;
+    }
+
+    gk_array_meta_release(mt);   
+    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+    app->stat.ndiag += 1;
+  }
+}
+
+void
+gk_species_radiation_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm)
+{
+  if (gks->rad.radiation_id == GKYL_GK_RADIATION) {
+    struct timespec wst = gkyl_wall_clock();
+
+    int vdim = app->vdim;
+    double avals_global[2+vdim];
+
+    // Compute radiation drag coefficients
+    const struct gkyl_array *fin_neut[app->num_neut_species];
+    const struct gkyl_array *fin[app->num_species];
+    for (int i=0; i<app->num_species; ++i) 
+      fin[i] = app->species[i].f;
+    for (int i=0; i<app->num_neut_species; ++i)
+      fin_neut[i] = app->neut_species[i].f;
+    gk_species_radiation_moms(app, gks, &gks->rad, fin, fin_neut);
+    gk_species_radiation_integrated_moms(app, gks, &gks->rad, fin, fin_neut);
+  
+    // reduce to compute sum over whole domain, append to diagnostics
+    gkyl_array_reduce_range(gks->rad.red_integ_diag, gks->rad.integ_moms.marr, GKYL_SUM, &app->local);
+    gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 2+vdim, 
+      gks->rad.red_integ_diag, gks->rad.red_integ_diag_global);
+    if (app->use_gpu) {
+      gkyl_cu_memcpy(avals_global, gks->rad.red_integ_diag_global, sizeof(double[2+vdim]), GKYL_CU_MEMCPY_D2H);
+    }
+    else {
+      memcpy(avals_global, gks->rad.red_integ_diag_global, sizeof(double[2+vdim]));
+    }
+    gkyl_dynvec_append(gks->rad.integ_diag, tm, avals_global);
+
+    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+    app->stat.ndiag += 1;
+  }
+}
+
+void
+gk_species_radiation_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks)
+{
+  if (gks->rad.radiation_id == GKYL_GK_RADIATION) {
+    struct timespec wst = gkyl_wall_clock();
+    // Write from rank 0
+    int rank;
+    gkyl_comm_get_rank(app->comm, &rank);
+    if (rank == 0) {
+      // write out integrated diagnostic moments
+      const char *fmt = "%s-%s_radiation_%s.gkyl";
+      int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "integrated_moms");
+      char fileNm[sz+1]; // ensures no buffer overflow
+      snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "integrated_moms");
+
+      struct timespec wtm = gkyl_wall_clock();
+      if (gks->rad.is_first_integ_write_call) {
+        gkyl_dynvec_write(gks->rad.integ_diag, fileNm);
+        gks->rad.is_first_integ_write_call = false;
+      }
+      else {
+        gkyl_dynvec_awrite(gks->rad.integ_diag, fileNm);
+      }
+      app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+      app->stat.nio += 1;
+    }
+    gkyl_dynvec_clear(gks->rad.integ_diag);
+    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+    app->stat.ndiag += 1;
+  }
+}
+  
 void 
 gk_species_radiation_release(const struct gkyl_gyrokinetic_app *app, const struct gk_rad_drag *rad)
 {

--- a/apps/gk_species_react.c
+++ b/apps/gk_species_react.c
@@ -416,6 +416,133 @@ gk_species_react_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *s,
   app->stat.species_coll_tm += gkyl_time_diff_now_sec(wst);
 }
 
+// write functions
+void
+gk_species_react_write_iz(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame)
+{
+  struct timespec wst = gkyl_wall_clock();
+  
+  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+      .frame = frame,
+      .stime = tm,
+      .poly_order = app->poly_order,
+      .basis_type = app->confBasis.id
+    }
+  );
+
+  // Compute reaction rate
+  const struct gkyl_array *fin[app->num_species];
+  const struct gkyl_array *fin_neut[app->num_neut_species];
+  for (int i=0; i<app->num_species; ++i) 
+    fin[i] = app->species[i].f;
+  for (int i=0; i<app->num_neut_species; ++i)
+    fin_neut[i] = app->neut_species[i].f;
+  gk_species_react_cross_moms(app, gks, gkr, gks->f, fin, fin_neut);
+
+  const char *fmt = "%s-%s_%s_%s_iz_react_%d.gkyl";
+  int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].ion_nm, gkr->react_type[ridx].donor_nm, frame);
+  char fileNm[sz+1]; // ensures no buffer overflow
+  snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].ion_nm, gkr->react_type[ridx].donor_nm, frame);
+  
+  if (app->use_gpu) {
+    gkyl_array_copy(gkr->coeff_react_host[ridx], gkr->coeff_react[ridx]);
+  }
+  struct timespec wtm = gkyl_wall_clock();
+  gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+  app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+  app->stat.nio += 1;
+
+  gk_array_meta_release(mt); 
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
+void
+gk_species_react_write_recomb(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame)
+{
+  struct timespec wst = gkyl_wall_clock();
+  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+      .frame = frame,
+      .stime = tm,
+      .poly_order = app->poly_order,
+      .basis_type = app->confBasis.id
+    }
+  );
+
+  // Compute reaction rate
+  const struct gkyl_array *fin[app->num_species];
+  const struct gkyl_array *fin_neut[app->num_neut_species];
+  for (int i=0; i<app->num_species; ++i) 
+    fin[i] = app->species[i].f;
+  for (int i=0; i<app->num_neut_species; ++i) 
+    fin_neut[i] = app->neut_species[i].f;  
+  gk_species_react_cross_moms(app, gks, gkr, gks->f, fin, fin_neut);
+
+  const char *fmt = "%s-%s_%s_%s_recomb_react_%d.gkyl";
+  int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].ion_nm, gkr->react_type[ridx].recvr_nm, frame);
+  char fileNm[sz+1]; // ensures no buffer overflow
+  snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].ion_nm, gkr->react_type[ridx].recvr_nm, frame);
+  
+  if (app->use_gpu) {
+    gkyl_array_copy(gkr->coeff_react_host[ridx], gkr->coeff_react[ridx]);
+  }
+  struct timespec wtm = gkyl_wall_clock();
+  gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+  app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+  app->stat.nio += 1;
+
+  gk_array_meta_release(mt); 
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1; 
+}
+
+void gk_species_react_write_cx(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame)
+{
+  struct timespec wst = gkyl_wall_clock();
+  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+      .frame = frame,
+      .stime = tm,
+      .poly_order = app->poly_order,
+      .basis_type = app->confBasis.id
+    }
+  );
+
+  // Compute reaction rate
+  const struct gkyl_array *fin[app->num_species];
+  const struct gkyl_array *fin_neut[app->num_neut_species];
+  for (int i=0; i<app->num_species; ++i) 
+    fin[i] = app->species[i].f;
+  for (int i=0; i<app->num_neut_species; ++i) 
+    fin_neut[i] = app->neut_species[i].f;  
+  gk_species_react_cross_moms(app, gks, gkr, gks->f, fin, fin_neut);
+
+  const char *fmt = "%s-%s_%s_cx_react_%d.gkyl";
+  int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].partner_nm, frame);
+  char fileNm[sz+1]; // ensures no buffer overflow
+  snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+    gkr->react_type[ridx].partner_nm, frame);
+  
+  if (app->use_gpu) {
+    gkyl_array_copy(gkr->coeff_react_host[ridx], gkr->coeff_react[ridx]);
+  }
+  struct timespec wtm = gkyl_wall_clock();
+  gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+  app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+  app->stat.nio += 1;
+
+  gk_array_meta_release(mt); 
+  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+  app->stat.ndiag += 1;
+}
+
 void 
 gk_species_react_release(const struct gkyl_gyrokinetic_app *app, const struct gk_react *react)
 {

--- a/apps/gk_species_react.c
+++ b/apps/gk_species_react.c
@@ -421,68 +421,70 @@ void
 gk_species_react_write(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
   int ridx, double tm, int frame)
 {
-  struct timespec wst = gkyl_wall_clock();
-  struct timespec wtm; 
-  struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
-      .frame = frame,
-      .stime = tm,
-      .poly_order = app->poly_order,
-      .basis_type = app->confBasis.id
+  if (gkr->type_self[ridx] == GKYL_SELF_ION) {
+    struct timespec wst = gkyl_wall_clock();
+    struct timespec wtm; 
+    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
+        .frame = frame,
+        .stime = tm,
+        .poly_order = app->poly_order,
+        .basis_type = app->confBasis.id
+      }
+    );
+
+    // Compute reaction rate
+    const struct gkyl_array *fin[app->num_species];
+    const struct gkyl_array *fin_neut[app->num_neut_species];
+    for (int i=0; i<app->num_species; ++i) 
+      fin[i] = app->species[i].f;
+    for (int i=0; i<app->num_neut_species; ++i)
+      fin_neut[i] = app->neut_species[i].f;
+    gk_species_react_cross_moms(app, gks, gkr, fin, fin_neut);
+    
+    if (app->use_gpu) {
+      gkyl_array_copy(gkr->coeff_react_host[ridx], gkr->coeff_react[ridx]);
     }
-  );
-
-  // Compute reaction rate
-  const struct gkyl_array *fin[app->num_species];
-  const struct gkyl_array *fin_neut[app->num_neut_species];
-  for (int i=0; i<app->num_species; ++i) 
-    fin[i] = app->species[i].f;
-  for (int i=0; i<app->num_neut_species; ++i)
-    fin_neut[i] = app->neut_species[i].f;
-  gk_species_react_cross_moms(app, gks, gkr, fin, fin_neut);
-
-  if (app->use_gpu) {
-    gkyl_array_copy(gkr->coeff_react_host[ridx], gkr->coeff_react[ridx]);
-  }
-
-  if (gkr->react_id[ridx] == GKYL_REACT_IZ) {
-    const char *fmt = "%s-%s_%s_%s_iz_react_%d.gkyl";
-    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].donor_nm, frame);
-    char fileNm[sz+1]; // ensures no buffer overflow
-    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].donor_nm, frame);
+    
+    if (gkr->react_id[ridx] == GKYL_REACT_IZ) {
+      const char *fmt = "%s-%s_%s_%s_iz_react_%d.gkyl";
+      int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+        gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].donor_nm, frame);
+      char fileNm[sz+1]; // ensures no buffer overflow
+      snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+        gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].donor_nm, frame);
   
-    wtm = gkyl_wall_clock();
-    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
-  }
-  if (gkr->react_id[ridx] == GKYL_REACT_RECOMB) {
-    const char *fmt = "%s-%s_%s_%s_recomb_react_%d.gkyl";
-    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].recvr_nm, frame);
-    char fileNm[sz+1]; // ensures no buffer overflow
-    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].recvr_nm, frame);
+      wtm = gkyl_wall_clock();
+      gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+    }
+   if (gkr->react_id[ridx] == GKYL_REACT_RECOMB) {
+     const char *fmt = "%s-%s_%s_%s_recomb_react_%d.gkyl";
+     int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+       gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].recvr_nm, frame);
+     char fileNm[sz+1]; // ensures no buffer overflow
+     snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+       gkr->react_type[ridx].elc_nm, gkr->react_type[ridx].recvr_nm, frame);
   
-    wtm = gkyl_wall_clock();
-    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+     wtm = gkyl_wall_clock();
+     gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+   }
+   if (gkr->react_id[ridx] == GKYL_REACT_CX) {
+     const char *fmt = "%s-%s_%s_cx_react_%d.gkyl";
+     int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
+       gkr->react_type[ridx].partner_nm, frame);
+     char fileNm[sz+1]; // ensures no buffer overflow
+     snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
+       gkr->react_type[ridx].partner_nm, frame);
+     
+     wtm = gkyl_wall_clock();
+     gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
+   }
+   app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
+   app->stat.nio += 1;
+   
+   gk_array_meta_release(mt); 
+   app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
+   app->stat.ndiag += 1;
   }
-  if (gkr->react_id[ridx] == GKYL_REACT_CX) {
-    const char *fmt = "%s-%s_%s_cx_react_%d.gkyl";
-    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].partner_nm, frame);
-    char fileNm[sz+1]; // ensures no buffer overflow
-    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
-      gkr->react_type[ridx].partner_nm, frame);
-
-    wtm = gkyl_wall_clock();
-    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gkr->coeff_react_host[ridx], fileNm);
-  }
-  app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-  app->stat.nio += 1;
-
-  gk_array_meta_release(mt); 
-  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-  app->stat.ndiag += 1;
 }
 
 void 

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -158,16 +158,17 @@ struct gkyl_gyrokinetic_react_type {
   double elc_mass; // mass of electron in reaction
   double partner_mass; // mass of neutral in cx reaction
   double vt_sq_ion_min;
-  double vt_sq_partner_min; 
+  double vt_sq_partner_min;
 };
 
-// Parameters for species radiation
+// Parameters for species reaction
 struct gkyl_gyrokinetic_react {
   int num_react; // number of reactions
   // 3 types of reactions supported currently
   // Ionization, Charge exchange, and Recombination
   // GKYL_MAX_SPECIES number of reactions supported per species (8 different reactions)
   struct gkyl_gyrokinetic_react_type react_type[GKYL_MAX_REACT];
+  bool write_diagnostics; // used to write diagnostics from neutral species
 };
 
 struct gkyl_gyrokinetic_ic_import {

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -589,6 +589,12 @@ struct gk_species {
     const struct gkyl_range *rng);
   void (*copy_func)(struct gkyl_array *out, const struct gkyl_array *inp,
     const struct gkyl_range *range);
+  void (*write_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+  void (*write_mom_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+  void (*calc_integrated_mom_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+  void (*write_integrated_mom_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks);
+  void (*calc_L2norm_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+  void (*write_L2norm_func)(gkyl_gyrokinetic_app* app, struct gk_species *gks);
 
   double *omega_cfl; // Maximum Omega_CFL in this MPI process.
   double *m0_max; // Maximum number density in this MPI process.
@@ -1430,6 +1436,60 @@ void gk_species_coll_tm(gkyl_gyrokinetic_app *app);
  * @param app App object to update stat timers
  */
 void gk_species_tm(gkyl_gyrokinetic_app *app);
+
+/**
+ * Species write function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ * @param tm simulation time
+ * @param frame simulation frame
+ */
+void gk_species_write(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Species moment write function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ * @param tm simulation time
+ * @param frame simulation frame
+ */
+void gk_species_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Species calc integrated moment function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ * @param tm simulation time
+ */
+void gk_species_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+
+/**
+ * Species write integrated moment function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ */
+void gk_species_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks);
+
+/**
+ * Species calc L2norm function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ * @param tm simulation time
+ */
+void gk_species_calc_L2norm(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+
+/**
+ * Species write L2norm function.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Species object
+ */
+void gk_species_write_L2norm(gkyl_gyrokinetic_app* app, struct gk_species *gks);
 
 /**
  * Delete resources used in species.

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1703,6 +1703,44 @@ void gk_neut_species_source_rhs(gkyl_gyrokinetic_app *app, const struct gk_neut_
   struct gk_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
+ * Write neutral source diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Pointer to species
+ * @param tm Time for source diagnostic
+ * @param frame Output frame
+ */
+void gk_neut_species_source_write(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+
+/**
+ * Write neutral source moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Pointer to species
+ * @param tm Time for source diagnostic
+ * @param frame Output frame
+ */
+void gk_neut_species_source_write_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+
+/**
+ * Calc neutral source integrated moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Pointer to species
+ * @param tm Time for source diagnostic
+ */
+void gk_neut_species_source_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm);
+
+/**
+ * Write neutral source integrated moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Pointer to species
+ * @param tm Time for source diagnostic
+ */
+void gk_neut_species_source_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns);
+
+/**
  * Release Neutral species source object.
  *
  * @param app gyrokinetic app object

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -687,6 +687,10 @@ struct gk_neut_species {
     const struct gkyl_range *rng);
   void (*copy_func)(struct gkyl_array *out, const struct gkyl_array *inp,
     const struct gkyl_range *range);
+  void (*write_func)(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+  void (*write_mom_func)(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+  void (*calc_integrated_mom_func)(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm);
+  void (*write_integrated_mom_func)(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns);
 };
 
 // field data
@@ -1586,43 +1590,6 @@ void gk_neut_species_react_rhs(gkyl_gyrokinetic_app *app,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
- * Scale and accumulate for forward euler method.
- *
- * @param species Pointer to neutral species
- * @param out Output array
- * @param dt Timestep
- * @param inp Input array
- */
-void gk_neut_species_step_f(struct gk_neut_species *species, struct gkyl_array* out, double dt,
-  const struct gkyl_array* inp);
-
-/**
- * Combine for rk3 method.
- *
- * @param species Pointer to species
- * @param out Output array
- * @param c1 Scaling factor
- * @param arr1 Input array
- * @param c2 Scaling factor
- * @param arr2 Input array
- * @param rng Range
- */
-void gk_neut_species_combine(struct gk_neut_species *species, struct gkyl_array *out, double c1,
-  const struct gkyl_array *arr1, double c2, const struct gkyl_array *arr2,
-  const struct gkyl_range *rng);
-
-/**
- * Copy for rk3 method.
- *
- * @param species Pointer to species
- * @param out Output array
- * @param inp Input array
- * @param range Range
- */
-void gk_neut_species_copy_range(struct gk_neut_species *species, struct gkyl_array *out,
-  const struct gkyl_array *inp, const struct gkyl_range *range);
-
-/**
  * Release neutral species react object.
  *
  * @param app gyrokinetic app object
@@ -1751,6 +1718,80 @@ void gk_neut_species_apply_bc(gkyl_gyrokinetic_app *app, const struct gk_neut_sp
  * @param app App object to update stat timers
  */
 void gk_neut_species_tm(gkyl_gyrokinetic_app *app);
+
+/**
+ * Scale and accumulate for forward euler method.
+ *
+ * @param species Pointer to neutral species
+ * @param out Output array
+ * @param dt Timestep
+ * @param inp Input array
+ */
+void gk_neut_species_step_f(struct gk_neut_species *species, struct gkyl_array* out, double dt,
+  const struct gkyl_array* inp);
+
+/**
+ * Combine for rk3 method.
+ *
+ * @param species Pointer to species
+ * @param out Output array
+ * @param c1 Scaling factor
+ * @param arr1 Input array
+ * @param c2 Scaling factor
+ * @param arr2 Input array
+ * @param rng Range
+ */
+void gk_neut_species_combine(struct gk_neut_species *species, struct gkyl_array *out, double c1,
+  const struct gkyl_array *arr1, double c2, const struct gkyl_array *arr2,
+  const struct gkyl_range *rng);
+
+/**
+ * Copy for rk3 method.
+ *
+ * @param species Pointer to species
+ * @param out Output array
+ * @param inp Input array
+ * @param range Range
+ */
+void gk_neut_species_copy_range(struct gk_neut_species *species, struct gkyl_array *out,
+  const struct gkyl_array *inp, const struct gkyl_range *range);
+
+/**
+ * Species write function.
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Neutral species object
+ * @param tm simulation time
+ * @param frame simulation frame
+ */
+void gk_neut_species_write(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+
+/**
+ * Species moment write function.
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Neutral species object
+ * @param tm simulation time
+ * @param frame simulation frame
+ */
+void gk_neut_species_write_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm, int frame);
+
+/**
+ * Species calc integrated moment function.
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Neutral species object
+ * @param tm simulation time
+ */
+void gk_neut_species_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, double tm);
+
+/**
+ * Species write integrated moment function.
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Neutral species object
+ */
+void gk_neut_species_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns);
 
 /**
  * Delete resources used in neutral species.

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1090,6 +1090,16 @@ void gk_species_lbo_rhs(gkyl_gyrokinetic_app *app,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
+ * Write moments from LBO object.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Simulation time
+ * @parame frame Simulation output frame
+ */
+void gk_species_lbo_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
  * Release species LBO object.
  *
  * @param app gyrokinetic app object
@@ -1158,6 +1168,14 @@ void gk_species_bgk_rhs(gkyl_gyrokinetic_app *app,
   const struct gk_species *species,
   struct gk_bgk_collisions *bgk,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
+
+/**
+ * Release species BGK object.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ */
+void gk_species_bgk_write_max_corr_status(gkyl_gyrokinetic_app* app, struct gk_species *gks);
 
 /**
  * Release species BGK object.

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1019,6 +1019,43 @@ void gk_species_radiation_rhs(gkyl_gyrokinetic_app *app,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
+ * Write species radiation drag.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_species_radiation_write_drag(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Write species radiation emissivity.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_species_radiation_write_emissivity(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Calculate species radiation integrated moments.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Simulation time
+ */
+void gk_species_radiation_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+
+/**
+ * Write species radiation integrated moments.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ */
+void gk_species_radiation_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks);
+
+/**
  * Release species radiation drag object.
  *
  * @param app gyrokinetic app object

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -327,6 +327,7 @@ struct gk_boundary_fluxes {
 struct gk_react {
   int num_react; // number of reactions
   bool all_gk; // boolean for if reactions are only between gyrokinetic species
+  bool write_diagnostics; // Whether to write diagnostics out.
   struct gkyl_gyrokinetic_react_type react_type[GKYL_MAX_REACT]; // input struct for type of reactions
 
   struct gkyl_array *f_react; // distribution function array which holds update for each reaction
@@ -1258,9 +1259,8 @@ void gk_species_react_cross_init(struct gkyl_gyrokinetic_app *app, struct gk_spe
  * @param fin_neut Input neutral distribution functions (size: num_neut_species)
  */
 void gk_species_react_cross_moms(gkyl_gyrokinetic_app *app,
-  const struct gk_species *species,
-  struct gk_react *react,
-  const struct gkyl_array *f_self, const struct gkyl_array *fin[], const struct gkyl_array *fin_neut[]);
+  const struct gk_species *species, struct gk_react *react,
+  const struct gkyl_array *fin[], const struct gkyl_array *fin_neut[]);
 
 /**
  * Compute RHS from reactions 
@@ -1277,7 +1277,7 @@ void gk_species_react_rhs(gkyl_gyrokinetic_app *app,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
- * Write ionization reaction rate.
+ * Write reaction rate.
  *
  * @param app gyrokinetic app object
  * @param gks Pointer to species
@@ -1286,33 +1286,7 @@ void gk_species_react_rhs(gkyl_gyrokinetic_app *app,
  * @param tm Simulation time
  * @param frame Simulation output frame
  */
-void gk_species_react_write_iz(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
-  int ridx, double tm, int frame);
-
-/**
- * Write recombination reaction rate.
- *
- * @param app gyrokinetic app object
- * @param gks Pointer to species
- * @param gkr Pointer to react object
- * @param ridx Index for reaction species
- * @param tm Simulation time
- * @param frame Simulation output frame
- */
-void gk_species_react_write_recomb(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
-  int ridx, double tm, int frame);
-
-/**
- * Write CX reaction rate.
- *
- * @param app gyrokinetic app object
- * @param gks Pointer to species
- * @param gkr Pointer to react object
- * @param ridx Index for reaction species
- * @param tm Simulation time
- * @param frame Simulation output frame
- */
-void gk_species_react_write_cx(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+void gk_species_react_write(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
   int ridx, double tm, int frame);
 
 /**
@@ -1720,6 +1694,20 @@ void gk_neut_species_react_cross_moms(gkyl_gyrokinetic_app *app,
 void gk_neut_species_react_rhs(gkyl_gyrokinetic_app *app,
   const struct gk_neut_species *s, struct gk_react *react,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
+
+/**
+ * Write neutral reaction rate.
+ *
+ * @param app gyrokinetic app object
+ * @param gkns Pointer to neutral species
+ * @param gkr Pointer to react object
+ * @param ridx Index for reaction species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_neut_species_react_write(gkyl_gyrokinetic_app* app, struct gk_neut_species *gkns, struct gk_react *gkr,
+  int ridx, double tm, int frame);
+
 
 /**
  * Release neutral species react object.

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1277,6 +1277,45 @@ void gk_species_react_rhs(gkyl_gyrokinetic_app *app,
   const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
+ * Write ionization reaction rate.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param gkr Pointer to react object
+ * @param ridx Index for reaction species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_species_react_write_iz(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame);
+
+/**
+ * Write recombination reaction rate.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param gkr Pointer to react object
+ * @param ridx Index for reaction species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_species_react_write_recomb(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame);
+
+/**
+ * Write CX reaction rate.
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param gkr Pointer to react object
+ * @param ridx Index for reaction species
+ * @param tm Simulation time
+ * @param frame Simulation output frame
+ */
+void gk_species_react_write_cx(gkyl_gyrokinetic_app* app, struct gk_species *gks, struct gk_react *gkr,
+  int ridx, double tm, int frame);
+
+/**
  * Release species react object.
  *
  * @param app gyrokinetic app object

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1332,6 +1332,44 @@ void gk_species_source_rhs(gkyl_gyrokinetic_app *app, const struct gk_species *s
   struct gk_source *src, const struct gkyl_array *fin, struct gkyl_array *rhs);
 
 /**
+ * Write source diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Time for source diagnostic
+ * @param frame Output frame
+ */
+void gk_species_source_write(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Write source moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Time for source diagnostic
+ * @param frame Output frame
+ */
+void gk_species_source_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm, int frame);
+
+/**
+ * Calc source integrated moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Time for source diagnostic
+ */
+void gk_species_source_calc_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, double tm);
+
+/**
+ * Write source integrated moment diagnostics
+ *
+ * @param app gyrokinetic app object
+ * @param gks Pointer to species
+ * @param tm Time for source diagnostic
+ */
+void gk_species_source_write_integrated_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks);
+
+/**
  * Release species source object.
  *
  * @param app gyrokinetic app object

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -939,37 +939,8 @@ gkyl_gyrokinetic_app_write_field_energy(gkyl_gyrokinetic_app* app)
 void
 gkyl_gyrokinetic_app_write_species(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
 {
-  struct gk_species *gk_s = &app->species[sidx];
-
-  if (!gk_s->info.is_static || frame == 0) {
-    struct timespec wst = gkyl_wall_clock();
-    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
-        .frame = frame,
-        .stime = tm,
-        .poly_order = app->poly_order,
-        .basis_type = app->basis.id
-      }
-    );
-
-    const char *fmt = "%s-%s_%d.gkyl";
-    int sz = gkyl_calc_strlen(fmt, app->name, gk_s->info.name, frame);
-    char fileNm[sz+1]; // ensures no buffer overflow
-    snprintf(fileNm, sizeof fileNm, fmt, app->name, gk_s->info.name, frame);
-
-    // copy data from device to host before writing it out
-    if (app->use_gpu) {
-      gkyl_array_copy(gk_s->f_host, gk_s->f);
-    }
-
-    struct timespec wtm = gkyl_wall_clock();
-    gkyl_comm_array_write(gk_s->comm, &gk_s->grid, &gk_s->local, mt, gk_s->f_host, fileNm);
-    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-    app->stat.nio += 1;
-    
-    gk_array_meta_release(mt);  
-    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-    app->stat.ndiag += 1;
-  }
+  struct gk_species *gks = &app->species[sidx];
+  gk_species_write(app, gks, tm, frame);
 }
 
 void
@@ -1012,75 +983,7 @@ void
 gkyl_gyrokinetic_app_write_species_mom(gkyl_gyrokinetic_app* app, int sidx, double tm, int frame)
 {
   struct gk_species *gks = &app->species[sidx];
-
-  if (!gks->info.is_static || frame == 0) {
-    struct timespec wst = gkyl_wall_clock();
-    struct gkyl_msgpack_data *mt = gk_array_meta_new( (struct gyrokinetic_output_meta) {
-        .frame = frame,
-        .stime = tm,
-        .poly_order = app->poly_order,
-        .basis_type = app->confBasis.id
-      }
-    );
-
-    for (int m=0; m<gks->info.num_diag_moments; ++m) {
-      gk_species_moment_calc(&gks->moms[m], gks->local, app->local, gks->f);
-      app->stat.nmom += 1;
-
-      const char *fmt = "%s-%s_%s_%d.gkyl";
-      int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name,
-        gks->info.diag_moments[m], frame);
-      char fileNm[sz+1]; // ensures no buffer overflow
-      snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name,
-        gks->info.diag_moments[m], frame);
-
-      // Rescale moment by inverse of Jacobian if not already re-scaled 
-      if (!gks->moms[m].is_bimaxwellian_moms && !gks->moms[m].is_maxwellian_moms) {
-	gkyl_dg_div_op_range(gks->moms[m].mem_geo, app->confBasis, 
-          0, gks->moms[m].marr, 0, gks->moms[m].marr, 0, 
-          app->gk_geom->jacobgeo, &app->local);  
-      }    
-      
-      if (app->use_gpu) {
-	gkyl_array_copy(gks->moms[m].marr_host, gks->moms[m].marr);
-      }
-
-      struct timespec wtm = gkyl_wall_clock();
-      gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
-        gks->moms[m].marr_host, fileNm);
-      app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-      app->stat.nio += 1;
-    }
-
-    if (app->enforce_positivity) {
-      // We placed the change in f from the positivity shift in fnew.
-      gk_species_moment_calc(&gks->ps_moms, gks->local, app->local, gks->fnew);
-      app->stat.nmom += 1;
-
-      const char *fmt = "%s-%s_positivity_shift_FourMoments_%d.gkyl";
-      int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
-      char fileNm[sz+1]; // ensures no buffer overflow
-      snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);
-
-      // Rescale moment by inverse of Jacobian.
-      gkyl_dg_div_op_range(gks->ps_moms.mem_geo, app->confBasis, 
-        0, gks->ps_moms.marr, 0, gks->ps_moms.marr, 0, 
-        app->gk_geom->jacobgeo, &app->local);  
-
-      if (app->use_gpu) {
-	gkyl_array_copy(gks->ps_moms.marr_host, gks->ps_moms.marr);
-      }
-
-     struct timespec wtm = gkyl_wall_clock();
-     gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
-       gks->ps_moms.marr_host, fileNm);
-     app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-     app->stat.nio += 1;
-    }
-    gk_array_meta_release(mt);   
-    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-    app->stat.ndiag += 1;
-  }
+  gk_species_write_mom(app, gks, tm, frame);
 }
 
 void
@@ -1134,44 +1037,8 @@ gkyl_gyrokinetic_app_write_neut_species_mom(gkyl_gyrokinetic_app* app, int sidx,
 void
 gkyl_gyrokinetic_app_calc_species_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
 {
-  struct gk_species *gk_s = &app->species[sidx];
-  if (!gk_s->info.is_static) {
-    struct timespec wst = gkyl_wall_clock();
-    int vdim = app->vdim;
-    double avals_global[2+vdim];
-    
-    gk_species_moment_calc(&gk_s->integ_moms, gk_s->local, app->local, gk_s->f); 
-    // Reduce (sum) over whole domain, append to diagnostics.
-    gkyl_array_reduce_range(gk_s->red_integ_diag, gk_s->integ_moms.marr, GKYL_SUM, &app->local);
-    gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 2+vdim, 
-      gk_s->red_integ_diag, gk_s->red_integ_diag_global);
-    if (app->use_gpu) {
-      gkyl_cu_memcpy(avals_global, gk_s->red_integ_diag_global, sizeof(double[2+vdim]), GKYL_CU_MEMCPY_D2H);
-    }
-    else {
-      memcpy(avals_global, gk_s->red_integ_diag_global, sizeof(double[2+vdim]));
-    }
-    gkyl_dynvec_append(gk_s->integ_diag, tm, avals_global);
-    
-    if (app->enforce_positivity) {
-      // The change in f from the positivity shift is in fnew.
-      gk_species_moment_calc(&gk_s->integ_moms, gk_s->local, app->local, gk_s->fnew); 
-      // Reduce (sum) over whole domain, append to diagnostics.
-      gkyl_array_reduce_range(gk_s->red_integ_diag, gk_s->integ_moms.marr, GKYL_SUM, &app->local);
-      gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 2+vdim, 
-			  gk_s->red_integ_diag, gk_s->red_integ_diag_global);
-      if (app->use_gpu) {
-	gkyl_cu_memcpy(avals_global, gk_s->red_integ_diag_global, sizeof(double[2+vdim]), GKYL_CU_MEMCPY_D2H);
-      }
-      else {
-	memcpy(avals_global, gk_s->red_integ_diag_global, sizeof(double[2+vdim]));
-      }
-      gkyl_dynvec_append(gk_s->ps_integ_diag, tm, avals_global);
-    }
-    
-    app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-    app->stat.ndiag += 1;
-  }
+  struct gk_species *gks = &app->species[sidx];
+  gk_species_calc_integrated_mom(app, gks, tm);
 }
 
 void
@@ -1203,115 +1070,10 @@ gkyl_gyrokinetic_app_calc_neut_species_integrated_mom(gkyl_gyrokinetic_app* app,
 }
 
 void
-gkyl_gyrokinetic_app_calc_species_L2norm(gkyl_gyrokinetic_app *app, int sidx, double tm)
-{
-  struct timespec wst = gkyl_wall_clock();
-
-  struct gk_species *gk_s = &app->species[sidx];
-
-  gkyl_array_integrate_advance(gk_s->integ_wfsq_op, gk_s->f, (2.0*M_PI)/gk_s->info.mass,
-    app->jacobtot_inv_weak, &gk_s->local, &app->local, gk_s->L2norm_local);
-  gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_SUM, 1, gk_s->L2norm_local, gk_s->L2norm_global);
-
-  double L2norm_global[] = {0.0};
-  if (app->use_gpu) {
-    gkyl_cu_memcpy(L2norm_global, gk_s->L2norm_global, sizeof(double), GKYL_CU_MEMCPY_D2H);
-  }
-  else { 
-    memcpy(L2norm_global, gk_s->L2norm_global, sizeof(double));
-  }
-  
-  gkyl_dynvec_append(gk_s->L2norm, tm, L2norm_global);  
-
-  app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-  app->stat.ndiag += 1;
-}
-
-void
 gkyl_gyrokinetic_app_write_species_integrated_mom(gkyl_gyrokinetic_app *app, int sidx)
 {
   struct gk_species *gks = &app->species[sidx];
-
-  if (!gks->info.is_static) {
-     struct timespec wst = gkyl_wall_clock();
-     int rank;
-     gkyl_comm_get_rank(app->comm, &rank);
-     
-     if (rank == 0) {
-       // Write integrated diagnostic moments.
-       const char *fmt = "%s-%s_%s.gkyl";
-       int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "integrated_moms");
-       char fileNm[sz+1]; // ensures no buffer overflow
-       snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "integrated_moms");
-
-       struct timespec wtm = gkyl_wall_clock();
-       if (gks->is_first_integ_write_call) {
-	 gkyl_dynvec_write(gks->integ_diag, fileNm);
-	 gks->is_first_integ_write_call = false;
-       }
-       else {
-	 gkyl_dynvec_awrite(gks->integ_diag, fileNm);
-       }
-       app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-       app->stat.nio += 1;
-     }
-     gkyl_dynvec_clear(gks->integ_diag);
-
-     if (app->enforce_positivity) {
-       if (rank == 0) {
-	 // Write integrated diagnostic moments.
-	 const char *fmt = "%s-%s_positivity_shift_%s.gkyl";
-	 int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "integrated_moms");
-	 char fileNm[sz+1]; // ensures no buffer overflow
-	 snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "integrated_moms");
-
-	 struct timespec wtm = gkyl_wall_clock();
-	 if (gks->is_first_ps_integ_write_call) {
-	   gkyl_dynvec_write(gks->ps_integ_diag, fileNm);
-	   gks->is_first_ps_integ_write_call = false;
-	 }
-	 else {
-	   gkyl_dynvec_awrite(gks->ps_integ_diag, fileNm);
-	 }
-	 app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-	 app->stat.nio += 1;
-       }
-       gkyl_dynvec_clear(gks->ps_integ_diag);
-     }
-     
-     app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
-     app->stat.ndiag += 1;
-  }
-}
-
-void
-gkyl_gyrokinetic_app_write_species_L2norm(gkyl_gyrokinetic_app *app, int sidx)
-{
-  struct timespec wst = gkyl_wall_clock();
-  struct gk_species *gks = &app->species[sidx];
-
-  int rank;
-  gkyl_comm_get_rank(app->comm, &rank);
-
-  if (rank == 0) {
-    // Write the L2 norm.
-    const char *fmt = "%s-%s_%s.gkyl";
-    int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, "L2norm");
-    char fileNm[sz+1]; // ensures no buffer overflow
-    snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, "L2norm");
-
-    struct timespec wtm = gkyl_wall_clock();
-    if (gks->is_first_L2norm_write_call) {
-      gkyl_dynvec_write(gks->L2norm, fileNm);
-      gks->is_first_L2norm_write_call = false;
-    }
-    else {
-      gkyl_dynvec_awrite(gks->L2norm, fileNm);
-    }
-    app->stat.io_tm += gkyl_time_diff_now_sec(wtm);
-    app->stat.nio += 1;
-  }
-  gkyl_dynvec_clear(gks->L2norm);
+  gk_species_write_integrated_mom(app, gks);
 }
 
 void
@@ -1347,6 +1109,20 @@ gkyl_gyrokinetic_app_write_neut_species_integrated_mom(gkyl_gyrokinetic_app *app
     app->stat.diag_tm += gkyl_time_diff_now_sec(wst);
     app->stat.ndiag += 1;
   }
+}
+
+void
+gkyl_gyrokinetic_app_calc_species_L2norm(gkyl_gyrokinetic_app *app, int sidx, double tm)
+{
+  struct gk_species *gks = &app->species[sidx];
+  gk_species_calc_L2norm(app, gks, tm);
+}
+
+void
+gkyl_gyrokinetic_app_write_species_L2norm(gkyl_gyrokinetic_app *app, int sidx)
+{
+  struct gk_species *gks = &app->species[sidx];
+  gk_species_write_L2norm(app, gks);
 }
 
 //

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -1115,52 +1115,30 @@ gkyl_gyrokinetic_app_write_species_rad_integrated_mom(gkyl_gyrokinetic_app *app,
 }
 
 //
-// ............. Ionization outputs ............... //
+// ............. Neutral reaction outputs ............... //
 // 
 void
-gkyl_gyrokinetic_app_write_species_iz_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
+gkyl_gyrokinetic_app_write_species_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
 {
   struct gk_species *gks = &app->species[sidx];
   struct gk_react *gkr = &gks->react;
-  gk_species_react_write_iz(app, gks, gkr, ridx, tm, frame);
+  gk_species_react_write(app, gks, gkr, ridx, tm, frame);
 }
 
 void
-gkyl_gyrokinetic_app_write_species_iz_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
+gkyl_gyrokinetic_app_write_species_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
 {
   struct gk_species *gks = &app->species[sidx];
   struct gk_react *gkr = &gks->react_neut;
-  gk_species_react_write_iz(app, gks, gkr, ridx, tm, frame);
-}
-
-//
-// ............. Recombination outputs ............... //
-// 
-void
-gkyl_gyrokinetic_app_write_species_recomb_react(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
-{
-  struct gk_species *gks = &app->species[sidx];
-  struct gk_react *gkr = &gks->react;
-  gk_species_react_write_recomb(app, gks, gkr, ridx, tm, frame);
+  gk_species_react_write(app, gks, gkr, ridx, tm, frame);
 }
 
 void
-gkyl_gyrokinetic_app_write_species_recomb_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
+gkyl_gyrokinetic_app_write_neut_species_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
 {
-  struct gk_species *gks = &app->species[sidx];
-  struct gk_react *gkr = &gks->react_neut;
-  gk_species_react_write_recomb(app, gks, gkr, ridx, tm, frame);
-}
-
-//
-// ............. Charge exchange outputs ............... //
-// 
-void
-gkyl_gyrokinetic_app_write_species_cx_react_neut(gkyl_gyrokinetic_app* app, int sidx, int ridx, double tm, int frame)
-{
-  struct gk_species *gks = &app->species[sidx];
-  struct gk_react *gkr = &gks->react_neut;
-  gk_species_react_write_cx(app, gks, gkr, ridx, tm, frame);
+  struct gk_neut_species *gkns = &app->neut_species[sidx];
+  struct gk_react *gkr = &gkns->react_neut;
+  gk_neut_species_react_write(app, gkns, gkr, ridx, tm, frame);
 }
 
 //
@@ -1195,29 +1173,15 @@ gkyl_gyrokinetic_app_write_species_conf(gkyl_gyrokinetic_app* app, int sidx, dou
 
   gkyl_gyrokinetic_app_write_species_rad_emissivity(app, sidx, tm, frame);
 
-  struct gk_species *gk_s = &app->species[sidx];
-  for (int j=0; j<gk_s->react.num_react; ++j) {
-    if ((gk_s->react.react_id[j] == GKYL_REACT_IZ) 
-      && (gk_s->react.type_self[j] == GKYL_SELF_ELC)) {
-      gkyl_gyrokinetic_app_write_species_iz_react(app, sidx, j, tm, frame);
-    }
-    if ((gk_s->react.react_id[j] == GKYL_REACT_RECOMB) 
-      && (gk_s->react.type_self[j] == GKYL_SELF_ELC)) {
-      gkyl_gyrokinetic_app_write_species_recomb_react(app, sidx, j, tm, frame);
+  struct gk_species *gks = &app->species[sidx];
+  for (int j=0; j<gks->react.num_react; ++j) {
+    if (gks->react.type_self[j] == GKYL_SELF_ION) {
+      gkyl_gyrokinetic_app_write_species_react(app, sidx, j, tm, frame);
     }
   }
-  for (int j=0; j<gk_s->react_neut.num_react; ++j) {
-    if ((gk_s->react_neut.react_id[j] == GKYL_REACT_IZ) 
-      && (gk_s->react_neut.type_self[j] == GKYL_SELF_ELC)) {
-      gkyl_gyrokinetic_app_write_species_iz_react_neut(app, sidx, j, tm, frame);
-    }
-    if ((gk_s->react_neut.react_id[j] == GKYL_REACT_RECOMB) 
-      && (gk_s->react_neut.type_self[j] == GKYL_SELF_ELC)) {
-      gkyl_gyrokinetic_app_write_species_recomb_react_neut(app, sidx, j, tm, frame);
-    }
-    if ((gk_s->react_neut.react_id[j] == GKYL_REACT_CX)
-      && (gk_s->react_neut.type_self[j] == GKYL_SELF_ION)) {
-      gkyl_gyrokinetic_app_write_species_cx_react_neut(app, sidx, j, tm, frame);
+  for (int j=0; j<gks->react_neut.num_react; ++j) {
+    if (gks->react_neut.type_self[j] == GKYL_SELF_ION) {
+      gkyl_gyrokinetic_app_write_species_react_neut(app, sidx, j, tm, frame);
     }
   }
 }
@@ -1228,6 +1192,11 @@ gkyl_gyrokinetic_app_write_neut_species_conf(gkyl_gyrokinetic_app* app, int sidx
   gkyl_gyrokinetic_app_write_neut_species_mom(app, sidx, tm, frame);
 
   gkyl_gyrokinetic_app_write_neut_species_source_mom(app, sidx, tm, frame);
+
+  struct gk_neut_species *gkns = &app->neut_species[sidx];
+  for (int j=0; j<gkns->react_neut.num_react; ++j) {
+    gkyl_gyrokinetic_app_write_neut_species_react_neut(app, sidx, j, tm, frame);
+  }
 }
 
 //
@@ -1373,11 +1342,11 @@ gyrokinetic_rhs(gkyl_gyrokinetic_app* app, double tcurr, double dt,
     // Compute reaction rates (e.g., ionization, recombination, or charge exchange).
     if (gk_s->react.num_react) {
       gk_species_react_cross_moms(app, &app->species[i], 
-        &gk_s->react, fin[i], fin, fin_neut);
+        &gk_s->react, fin, fin_neut);
     }
     if (gk_s->react_neut.num_react) {
       gk_species_react_cross_moms(app, &app->species[i], 
-        &gk_s->react_neut, fin[i], fin, fin_neut);
+        &gk_s->react_neut, fin, fin_neut);
     }
     // Compute necessary drag coefficients for radiation operator.
     if (gk_s->rad.radiation_id == GKYL_GK_RADIATION) {

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -1175,14 +1175,10 @@ gkyl_gyrokinetic_app_write_species_conf(gkyl_gyrokinetic_app* app, int sidx, dou
 
   struct gk_species *gks = &app->species[sidx];
   for (int j=0; j<gks->react.num_react; ++j) {
-    if (gks->react.type_self[j] == GKYL_SELF_ION) {
-      gkyl_gyrokinetic_app_write_species_react(app, sidx, j, tm, frame);
-    }
+    gkyl_gyrokinetic_app_write_species_react(app, sidx, j, tm, frame);
   }
   for (int j=0; j<gks->react_neut.num_react; ++j) {
-    if (gks->react_neut.type_self[j] == GKYL_SELF_ION) {
-      gkyl_gyrokinetic_app_write_species_react_neut(app, sidx, j, tm, frame);
-    }
+    gkyl_gyrokinetic_app_write_species_react_neut(app, sidx, j, tm, frame);
   }
 }
 

--- a/regression/rt_gk_static_3x2v_p1.c
+++ b/regression/rt_gk_static_3x2v_p1.c
@@ -534,14 +534,7 @@ main(int argc, char **argv)
   // Field.
   struct gkyl_gyrokinetic_field field = {
     .fem_parbc = GKYL_FEM_PARPROJ_NONE,
-    .poisson_bcs = {
-      .lo_type = { GKYL_POISSON_DIRICHLET, GKYL_POISSON_PERIODIC },
-      .up_type = { GKYL_POISSON_DIRICHLET, GKYL_POISSON_PERIODIC },
-      .lo_value = { 0.0 }, .up_value = { 0.0 }
-      //.lo_type = { GKYL_POISSON_PERIODIC, GKYL_POISSON_PERIODIC },
-      //.up_type = { GKYL_POISSON_PERIODIC, GKYL_POISSON_PERIODIC },
-      ////.lo_value = { 0.0 }, .up_value = { 0.0 }
-    },
+    .is_static = true,
   };
 
   // GK app.
@@ -554,8 +547,6 @@ main(int argc, char **argv)
     .cells = { cells_x[0], cells_x[1], cells_x[2] },
     .poly_order = 1,
     .basis_type = app_args.basis_type,
-
-    .skip_field = true,
 
     .geometry = {
       .geometry_id = GKYL_MAPC2P,

--- a/regression/rt_gk_static_3x2v_p1.c
+++ b/regression/rt_gk_static_3x2v_p1.c
@@ -492,6 +492,7 @@ main(int argc, char **argv)
     },
 
     .react_neut = {
+      .write_diagnostics = true,
       .num_react = 3,
       .react_type = {
         { .react_id = GKYL_REACT_CX,


### PR DESCRIPTION
Write functions now live in their respective objects, i.e. species, lbo, radiation, react.  This corresponds to DR https://github.com/ammarhakim/gkylzero/issues/581. 

The write functions for the `react` objects were also simplified, removing all the if statements for the different reactions in `gyrokinetic.c`. 