### PR TITLE
Quick fix of a compatibility issue in ctest_array_average with array_integrate updater

### DIFF
--- a/unit/ctest_array_average.c
+++ b/unit/ctest_array_average.c
@@ -36,7 +36,7 @@ double solution_array_integrate(struct gkyl_rect_grid grid, struct gkyl_basis ba
 
   struct gkyl_array_integrate* arr_integ = gkyl_array_integrate_new(&grid, &basis, 1, GKYL_ARRAY_INTEGRATE_OP_NONE, use_gpu);
 
-  gkyl_array_integrate_advance(arr_integ, fin, 1.0, fin, &local, avgf_ref);
+  gkyl_array_integrate_advance(arr_integ, fin, 1.0, fin, &local, &local, avgf_ref);
 
   gkyl_array_integrate_release(arr_integ);
 


### PR DESCRIPTION
One small change on the ctest for array_average where we used a >2months old call of the array_integrate_advance routine.