### PR TITLE
Updating g0 machine files to build with Lua by default

### DIFF
--- a/machines/configure.della-cpu.sh
+++ b/machines/configure.della-cpu.sh
@@ -1,4 +1,4 @@
 module load intel/2021.1.2
 module load openmpi/intel-2021.1/4.1.0 
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64;
+./configure CC=cc --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-lua=yes;

--- a/machines/configure.della-gpu.sh
+++ b/machines/configure.della-gpu.sh
@@ -1,4 +1,4 @@
 module load cudatoolkit/12.0
 module load openmpi/cuda-11.1/gcc/4.1.1
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-nccl=yes --nccl-inc=/usr/include --nccl-lib=/usr/lib64;
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-nccl=yes --nccl-inc=/usr/include --nccl-lib=/usr/lib64 --use-lua=yes;

--- a/machines/configure.linux.cpu.sh
+++ b/machines/configure.linux.cpu.sh
@@ -1,3 +1,3 @@
 : "${PREFIX:=$HOME/gkylsoft}"
 : "${MPI_HOME:=$HOME/gkylsoft/openmpi}"
-./configure CC=clang --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib --use-adas=yes --use-lua=yes
+./configure CC=clang --prefix=$PREFIX --use-lua=yes

--- a/machines/configure.linux.cpu.sh
+++ b/machines/configure.linux.cpu.sh
@@ -1,3 +1,3 @@
 : "${PREFIX:=$HOME/gkylsoft}"
 : "${MPI_HOME:=$HOME/gkylsoft/openmpi}"
-./configure CC=clang --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib --use-adas=yes
+./configure CC=clang --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib --use-adas=yes --use-lua=yes

--- a/machines/configure.linux.gpu.sh
+++ b/machines/configure.linux.gpu.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=nvcc --prefix=$PREFIX
+./configure CC=nvcc --prefix=$PREFIX --use-lua=yes

--- a/machines/configure.macos.sh
+++ b/machines/configure.macos.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure --prefix=$PREFIX --use-mpi=yes --use-adas=yes --use-lua=yes
+./configure --prefix=$PREFIX --use-lua=yes

--- a/machines/configure.macos.sh
+++ b/machines/configure.macos.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure --prefix=$PREFIX --use-mpi=yes --use-adas=yes
+./configure --prefix=$PREFIX --use-mpi=yes --use-adas=yes --use-lua=yes

--- a/machines/configure.perlmutter.cpu.sh
+++ b/machines/configure.perlmutter.cpu.sh
@@ -1,5 +1,5 @@
 module unload darshan
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a;
+./configure CC=cc --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-lua=yes;
 
 

--- a/machines/configure.perlmutter.gpu.sh
+++ b/machines/configure.perlmutter.gpu.sh
@@ -14,6 +14,6 @@ module load nccl/2.18.3-cu12
 
 : "${PREFIX:=$HOME/gkylsoft}"
 
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/23.1/math_libs/12.0/lib64 --use-mpi=yes --mpi-inc=$CRAY_MPICH_DIR/include --mpi-lib=$CRAY_MPICH_DIR/lib --use-nccl=yes --nccl-inc=$NCCL_DIR/include --nccl-lib=$NCCL_DIR/lib;
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --cudamath-libdir=/opt/nvidia/hpc_sdk/Linux_x86_64/23.1/math_libs/12.0/lib64 --use-mpi=yes --mpi-inc=$CRAY_MPICH_DIR/include --mpi-lib=$CRAY_MPICH_DIR/lib --use-nccl=yes --nccl-inc=$NCCL_DIR/include --nccl-lib=$NCCL_DIR/lib --use-lua=yes;
 
 

--- a/machines/configure.satori.cpu.sh
+++ b/machines/configure.satori.cpu.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX
+./configure CC=cc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX --use-lua=yes

--- a/machines/configure.satori.gpu.sh
+++ b/machines/configure.satori.gpu.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=nvcc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX
+./configure CC=nvcc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX --use-lua=yes

--- a/machines/configure.stellar-amd.sh
+++ b/machines/configure.stellar-amd.sh
@@ -1,6 +1,6 @@
 module load cudatoolkit/12.4
 module load openmpi/cuda-11.1/gcc/4.1.1
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-nccl=yes --nccl-inc=/usr/include --nccl-lib=/usr/lib64 --use-cudss=yes;
+./configure CC=nvcc ARCH_FLAGS="-march=native" CUDA_ARCH=80 --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-nccl=yes --nccl-inc=/usr/include --nccl-lib=/usr/lib64 --use-cudss=yes --use-lua=yes;
 
 

--- a/machines/configure.stellar-intel.sh
+++ b/machines/configure.stellar-intel.sh
@@ -2,5 +2,5 @@ module load intel/2021.1.2
 module load openmpi/intel-2021.1/4.1.2 
 
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-adas=yes
+./configure CC=cc --prefix=$PREFIX --use-mpi=yes --mpi-inc=$MPI_HOME/include --mpi-lib=$MPI_HOME/lib64 --use-adas=yes --use-lua=yes
 

--- a/machines/configure.traverse.dev.sh
+++ b/machines/configure.traverse.dev.sh
@@ -8,4 +8,4 @@ module load openmpi/cuda-11.7/nvhpc-22.5/4.1.4/64
 : "${PREFIX:=$HOME/gkylsoft}"
 : "${MPI_SOURCE:=/usr/local/openmpi/cuda-11.7/4.1.4/nvhpc225/ppc64le}"
 : "${NCCL_HOME:=$HOROVOD_NCCL_HOME}"
-./configure CC=nvcc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_SOURCE/include --mpi-lib=$MPI_SOURCE/lib64 --use-nccl=yes --nccl-inc=$NCCL_HOME/include --nccl-lib=$NCCL_HOME/lib64;
+./configure CC=nvcc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX --lapack-inc=$PREFIX/OpenBLAS/include --lapack-lib=$PREFIX/OpenBLAS/lib/libopenblas.a --superlu-inc=$PREFIX/superlu/include --superlu-lib=$PREFIX/superlu/lib/libsuperlu.a --use-mpi=yes --mpi-inc=$MPI_SOURCE/include --mpi-lib=$MPI_SOURCE/lib64 --use-nccl=yes --nccl-inc=$NCCL_HOME/include --nccl-lib=$NCCL_HOME/lib64 --use-lua=yes;

--- a/machines/configure.traverse.host.sh
+++ b/machines/configure.traverse.host.sh
@@ -1,2 +1,2 @@
 : "${PREFIX:=$HOME/gkylsoft}"
-./configure CC=cc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX
+./configure CC=cc  ARCH_FLAGS="-mcpu=native" --prefix=$PREFIX --use-lua=yes


### PR DESCRIPTION
Following internal discussions, I've updated the configuration files for all presently supported architectures to run the configuration script with the `--use-lua` flag set to `yes` by default. I also removed the default `--use-mpi=yes` and `--use-adas=yes` flags from the Mac OS and Linux configuration files, since both MPI and ADAS should (in contrast to Lua) be considered optional dependencies for Gkeyll, and so should not be included in the configuration unless we are building on a known machine which definitely has them installed.