### PR TITLE
Updated mkdeps to build LuaJIT by default

### DIFF
--- a/machines/mkdeps.della-cpu.sh
+++ b/machines/mkdeps.della-cpu.sh
@@ -2,4 +2,4 @@ module load intel/2021.1.2
 module load openmpi/intel-2021.1/4.1.0 
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --build-luajit=yes --prefix=$PREFIX

--- a/machines/mkdeps.della-gpu.sh
+++ b/machines/mkdeps.della-gpu.sh
@@ -2,4 +2,4 @@ module load cudatoolkit/12.0
 module load openmpi/cuda-11.1/gcc/4.1.1
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --build-luajit=yes --prefix=$PREFIX

--- a/machines/mkdeps.macos.sh
+++ b/machines/mkdeps.macos.sh
@@ -1,3 +1,3 @@
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=no --build-superlu=yes --prefix=$PREFIX
+./mkdeps.sh --build-openblas=no --build-superlu=yes --build-luajit=yes --prefix=$PREFIX

--- a/machines/mkdeps.perlmutter.cpu.sh
+++ b/machines/mkdeps.perlmutter.cpu.sh
@@ -1,4 +1,4 @@
 module unload darshan
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes  --prefix=$PREFIX
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --build-luajit=yes --prefix=$PREFIX

--- a/machines/mkdeps.perlmutter.gpu.sh
+++ b/machines/mkdeps.perlmutter.gpu.sh
@@ -15,4 +15,4 @@ module load nccl/2.18.3-cu12
 : "${PREFIX:=$HOME/gkylsoft}"
 
 cd install-deps
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-openmpi=no MPICC=mpicc  MPICXX=mpicxx
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-openmpi=no --build-luajit=yes MPICC=mpicc  MPICXX=mpicxx

--- a/machines/mkdeps.satori.sh
+++ b/machines/mkdeps.satori.sh
@@ -1,2 +1,2 @@
 cd install-deps
-./mkdeps.sh --build-openblas=yes --build-superlu=yes
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --build-luajit=yes

--- a/machines/mkdeps.stellar-amd.sh
+++ b/machines/mkdeps.stellar-amd.sh
@@ -2,4 +2,4 @@ module load cudatoolkit/12.4
 module load openmpi/cuda-11.1/gcc/4.1.1
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-cudss=yes
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-cudss=yes --build-luajit=yes

--- a/machines/mkdeps.stellar-intel.sh
+++ b/machines/mkdeps.stellar-intel.sh
@@ -2,4 +2,4 @@ module load intel/2021.1.2
 module load openmpi/intel-2021.1/4.1.2 
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-luajit=yes

--- a/machines/mkdeps.traverse.sh
+++ b/machines/mkdeps.traverse.sh
@@ -4,4 +4,4 @@ module load openmpi/cuda-11.7/nvhpc-22.5/4.1.4/64
 
 cd install-deps
 : "${PREFIX:=$HOME/gkylsoft}"
-./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX
+./mkdeps.sh --build-openblas=yes --build-superlu=yes --prefix=$PREFIX --build-luajit=yes


### PR DESCRIPTION
Thanks @JunoRavin and @Antoinehoff for pointing out that the recent configuration file updates to use Lua by default didn't also come with a corresponding change to the mkdeps files to build LuaJIT by default.

Eventually, we will want to modify the way that the Lua wrappers work to ensure that we can build using _only_ vanilla Lua 5.1 (right now this _almost_ works, but fails for some slightly obscure reason due to the way that we're packaging equation objects. It's likely an easy fix), in which case we will need to revisit this default building of LuaJIT. But for now this should work.