### PR TITLE
Fix CX updater for CUDA

### DIFF
--- a/regression/rt_gk_static_3x2v_p1.c
+++ b/regression/rt_gk_static_3x2v_p1.c
@@ -535,7 +535,16 @@ main(int argc, char **argv)
   // Field.
   struct gkyl_gyrokinetic_field field = {
     .fem_parbc = GKYL_FEM_PARPROJ_NONE,
+    .zero_init_field = true,
     .is_static = true,
+
+    .poisson_bcs = {
+      .lo_type = { GKYL_POISSON_DIRICHLET, GKYL_POISSON_PERIODIC },
+      .up_type = { GKYL_POISSON_DIRICHLET, GKYL_POISSON_PERIODIC },
+
+      .lo_value = { 0.0 },
+      .up_value = { 0.0 },
+    },
   };
 
   // GK app.

--- a/zero/dg_cx.c
+++ b/zero/dg_cx.c
@@ -55,7 +55,9 @@ gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu)
     up->b = 5.65e-20;
   }
 
-  up->react_rate = choose_kern(b_type, cdim, vdim_vl, poly_order);
+  int tblidx = cv_index[cdim].vdim[vdim_vl]
+  assert(tblidx != -1);
+  up->react_rate = choose_kern(b_type, tblidx, poly_order);
 
   up->flags = 0;
   GKYL_CLEAR_CU_ALLOC(up->flags);

--- a/zero/dg_cx.c
+++ b/zero/dg_cx.c
@@ -55,7 +55,7 @@ gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu)
     up->b = 5.65e-20;
   }
 
-  int tblidx = cv_index[cdim].vdim[vdim_vl]
+  int tblidx = cv_index[cdim].vdim[vdim_vl];
   assert(tblidx != -1);
   up->react_rate = choose_kern(b_type, tblidx, poly_order);
 

--- a/zero/dg_cx.c
+++ b/zero/dg_cx.c
@@ -38,22 +38,8 @@ gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu)
   int vdim_vl = up->pbasis_vl->ndim - cdim;
   enum gkyl_basis_type b_type = up->pbasis_vl->b_type;
 
-  if (up->type_ion == GKYL_ION_H) {
-    up->a = 1.12e-18;
-    up->b = 7.15e-20;
-  }
-  else if (up->type_ion == GKYL_ION_D) {
-    up->a = 1.09e-18;
-    up->b = 7.15e-20;
-  }
-  else if (up->type_ion == GKYL_ION_HE) {
-    up->a = 6.484e-19;
-    up->b = 4.350e-20;
-  } 
-  else if (up->type_ion == GKYL_ION_NE) {
-    up->a = 7.95e-19;
-    up->b = 5.65e-20;
-  }
+  // get parameters for fitting function
+  fit_param(up->type_ion, &up->a, &up->b);
 
   int tblidx = cv_index[cdim].vdim[vdim_vl];
   assert(tblidx != -1);
@@ -92,17 +78,6 @@ void gkyl_dg_cx_coll(const struct gkyl_dg_cx *up,
     
     double cflr = up->react_rate(up->a, up->b, up->vt_sq_ion_min, up->vt_sq_neut_min,
       prim_vars_ion_d, prim_vars_neut_d, upar_b_i_d, coef_cx_d);
-    
-    /* gkyl_range_deflate(&vel_rng, up->phase_rng, rem_dir, conf_iter.idx); */
-    /* gkyl_range_iter_no_split_init(&vel_iter, &vel_rng); */
-    /* // cfl associated with reaction is a *phase space* cfl */
-    /* // Need to loop over velocity space for each configuration space cell */
-    /* // to get total cfl rate in each phase space cell */
-    /* while (gkyl_range_iter_next(&vel_iter)) { */
-    /*   long cfl_idx = gkyl_range_idx(&vel_rng, vel_iter.idx); */
-    /*   double *cflrate_d = gkyl_array_fetch(cflrate, cfl_idx); */
-    /*   cflrate_d[0] += cflr; // frequencies are additive */
-    /* } */
   }
 }
 

--- a/zero/dg_cx.c
+++ b/zero/dg_cx.c
@@ -15,7 +15,7 @@ gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu)
 {
 #ifdef GKYL_HAVE_CUDA
   if(use_gpu) {
-    return gkyl_dg_cx_new_cu(inp);
+    return gkyl_dg_cx_cu_dev_new(inp);
   } 
 #endif  
   gkyl_dg_cx *up = gkyl_malloc(sizeof(struct gkyl_dg_cx));

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -76,23 +76,8 @@ gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp)
   int vdim_vl = up->pbasis_vl->ndim - cdim;
   enum gkyl_basis_type b_type = up->pbasis_vl->b_type;
 
-  if (up->type_ion == GKYL_ION_H) {
-    up->a = 1.12e-18;
-    up->b = 7.15e-20;
-  }
-  else if (up->type_ion == GKYL_ION_D) {
-    up->a = 1.09e-18;
-    up->b = 7.15e-20;
-  }
-  else if (up->type_ion == GKYL_ION_HE) {
-    up->a = 6.484e-19;
-    up->b = 4.350e-20;
-  } 
-  else if (up->type_ion == GKYL_ION_NE) {
-    up->a = 7.95e-19;
-    up->b = 5.65e-20;
-  }
-
+  fit_param(up->type_ion, up->a, up->b);
+  
   up->flags = 0;
   GKYL_SET_CU_ALLOC(up->flags);
 

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -15,9 +15,9 @@ extern "C" {
 // CUDA kernel to set device pointers to kernels.
 __global__ static void
 gkyl_dg_cx_set_cu_dev_ptrs(struct gkyl_dg_cx *up, 
-  enum gkyl_basis_type b_type, int cdim, int vdim, int poly_order)
+  enum gkyl_basis_type b_type, int tblidx, int poly_order)
 {
-  up->react_rate = choose_kern(b_type, cdim, vdim, poly_order);
+  up->react_rate = choose_kern(b_type, tblidx, poly_order);
 };
 
 __global__ static void

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -100,7 +100,6 @@ gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp)
   gkyl_cu_memcpy(up_cu, up, sizeof(gkyl_dg_cx), GKYL_CU_MEMCPY_H2D);
 
   int tblidx = cv_index[cdim].vdim[vdim_vl]
-  assert(tblidx != -1);
   gkyl_dg_cx_set_cu_dev_ptrs<<<1,1>>>(up_cu, b_type, tblidx, poly_order);
 
   // set parent on_dev pointer

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -54,7 +54,7 @@ void gkyl_dg_cx_coll_cu(const struct gkyl_dg_cx *up,
 }
 
 gkyl_dg_cx*
-gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp)
+gkyl_dg_cx_cu_dev_new(struct gkyl_dg_cx_inp *inp)
 {
   gkyl_dg_cx *up = (struct gkyl_dg_cx*) gkyl_malloc(sizeof(*up));
 

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -76,7 +76,7 @@ gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp)
   int vdim_vl = up->pbasis_vl->ndim - cdim;
   enum gkyl_basis_type b_type = up->pbasis_vl->b_type;
 
-  fit_param(up->type_ion, up->a, up->b);
+  fit_param(up->type_ion, &up->a, &up->b);
   
   up->flags = 0;
   GKYL_SET_CU_ALLOC(up->flags);

--- a/zero/dg_cx_cu.cu
+++ b/zero/dg_cx_cu.cu
@@ -99,7 +99,8 @@ gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp)
   struct gkyl_dg_cx *up_cu = (struct gkyl_dg_cx*) gkyl_cu_malloc(sizeof(*up_cu));
   gkyl_cu_memcpy(up_cu, up, sizeof(gkyl_dg_cx), GKYL_CU_MEMCPY_H2D);
 
-  int tblidx = cv_index[cdim].vdim[vdim_vl]
+  int tblidx = cv_index[cdim].vdim[vdim_vl];
+  assert(tblidx != -1);
   gkyl_dg_cx_set_cu_dev_ptrs<<<1,1>>>(up_cu, b_type, tblidx, poly_order);
 
   // set parent on_dev pointer

--- a/zero/gkyl_dg_cx.h
+++ b/zero/gkyl_dg_cx.h
@@ -37,7 +37,7 @@ struct gkyl_dg_cx* gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu);
  * Create new ionization updater type object on NV-GPU: 
  * see new() method above for documentation.
  */
-struct gkyl_dg_cx* gkyl_dg_cx_cu_dev_new(struct gkyl_dg_cx_inp *inp);
+struct gkyl_dg_cx* gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp);
 
 
 /**

--- a/zero/gkyl_dg_cx.h
+++ b/zero/gkyl_dg_cx.h
@@ -37,7 +37,7 @@ struct gkyl_dg_cx* gkyl_dg_cx_new(struct gkyl_dg_cx_inp *inp, bool use_gpu);
  * Create new ionization updater type object on NV-GPU: 
  * see new() method above for documentation.
  */
-struct gkyl_dg_cx* gkyl_dg_cx_new_cu(struct gkyl_dg_cx_inp *inp);
+struct gkyl_dg_cx* gkyl_dg_cx_cu_dev_new(struct gkyl_dg_cx_inp *inp);
 
 
 /**

--- a/zero/gkyl_dg_cx_priv.h
+++ b/zero/gkyl_dg_cx_priv.h
@@ -36,16 +36,9 @@ static const gkyl_cx_react_rate_kern_list ser_cx_react_rate_kernels[] = {
   { NULL, sigma_cx_3x3v_ser_p1, NULL }, // 5
 };
 
-struct gkyl_dg_cx_kernels {
-  dg_cx_react_ratef_t react_rate;
-};
-
 struct gkyl_dg_cx {
   const struct gkyl_rect_grid *grid; // grid object
-  int cdim; // number of configuration space dimensions
-  int vdim_vl;
-  int vdim_gk;
-  int poly_order; // polynomial order of DG basis
+
   struct gkyl_basis *cbasis;
   struct gkyl_basis *pbasis_gk;
   struct gkyl_basis *pbasis_vl;
@@ -63,41 +56,24 @@ struct gkyl_dg_cx {
   enum gkyl_ion_type type_ion;
   enum gkyl_react_self_type type_self;
 
-  bool use_gpu;
+  uint32_t flags;
+  dg_cx_react_ratef_t react_rate; // pointer to reaction rate kernel
+
   struct gkyl_dg_cx *on_dev; // pointer to itself or device data
 
-  struct gkyl_dg_cx_kernels *kernels;
-  //dg_cx_react_ratef_t react_rate; // pointer to reaction rate kernel
 };
 
-void
-dg_cx_choose_kernel_cu(struct gkyl_dg_cx_kernels *kernels,
-  struct gkyl_basis pbasis_vl, struct gkyl_basis cbasis);
-
 GKYL_CU_D
-static void dg_cx_choose_kernel(struct gkyl_dg_cx_kernels *kernels,
-  struct gkyl_basis pbasis_vl, struct gkyl_basis cbasis, bool use_gpu)
+static dg_cx_react_ratef_t
+choose_kern(enum gkyl_basis_type b_type, int tblidx, int poly_order)
 {
-#ifdef GKYL_HAVE_CUDA
-  if (use_gpu) {
-    dg_cx_choose_kernel_cu(kernels, pbasis_vl, cbasis);
-    return;
-  }
-#endif
-
-  enum gkyl_basis_type basis_type = pbasis_vl.b_type;
-  int pdim = pbasis_vl.ndim;
-  int cdim = cbasis.ndim;
-  int vdim = pdim - cdim;
-  int poly_order = pbasis_vl.poly_order;
-
-  switch (basis_type) {
+  switch (b_type) {
     case GKYL_BASIS_MODAL_HYBRID:
     case GKYL_BASIS_MODAL_SERENDIPITY:
-      kernels->react_rate = ser_cx_react_rate_kernels[cv_index[cdim].vdim[vdim]].kernels[poly_order];
+      return ser_cx_react_rate_kernels[tblidx].kernels[poly_order];
       break;
     default:
       assert(false);
-      break;
+      break; 
   }
 }

--- a/zero/gkyl_dg_cx_priv.h
+++ b/zero/gkyl_dg_cx_priv.h
@@ -78,7 +78,8 @@ choose_kern(enum gkyl_basis_type b_type, int tblidx, int poly_order)
   }
 }
 
-GKYL_CU_D void
+GKYL_CU_D
+static void
 fit_param(enum gkyl_ion_type type_ion, double *a, double *b)
 {
   // These values are from E. Meier's PhD Thesis

--- a/zero/gkyl_dg_cx_priv.h
+++ b/zero/gkyl_dg_cx_priv.h
@@ -78,7 +78,6 @@ choose_kern(enum gkyl_basis_type b_type, int tblidx, int poly_order)
   }
 }
 
-GKYL_CU_D
 static void
 fit_param(enum gkyl_ion_type type_ion, double *a, double *b)
 {

--- a/zero/gkyl_dg_cx_priv.h
+++ b/zero/gkyl_dg_cx_priv.h
@@ -77,3 +77,26 @@ choose_kern(enum gkyl_basis_type b_type, int tblidx, int poly_order)
       break; 
   }
 }
+
+GKYL_CU_D void
+fit_param(enum gkyl_ion_type type_ion, double *a, double *b)
+{
+  // These values are from E. Meier's PhD Thesis
+  if (type_ion == GKYL_ION_H) {
+    a[0] = 1.12e-18;
+    b[0] = 7.15e-20;
+  }
+  else if (type_ion == GKYL_ION_D) {
+    a[0] = 1.09e-18;
+    b[0] = 7.15e-20;
+  }
+  else if (type_ion == GKYL_ION_HE) {
+    a[0] = 6.484e-19;
+    b[0] = 4.350e-20;
+  } 
+  else if (type_ion == GKYL_ION_NE) {
+    a[0] = 7.95e-19;
+    b[0] = 5.65e-20;
+  }
+}
+


### PR DESCRIPTION
The CX updater functions and methods of kernel selection are now optimized for CUDA to avoid memory leaks. Structure is now consistent with other cuda updaters in zero directory. Tests with CX are valgrind clean and results are consistent with main branch.