### PR TITLE
Fix a small bug introduced in the phase basis PR in the MB app.

### DIFF
--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -808,7 +808,7 @@ and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot
     for (int d=0; d<cdim; d++) {
       for (int e=0; e<2; e++) {
         mbapp->jf_rescale_charged[d*2+e] = gkyl_rescale_ghost_jacf_new(d,e,&sbapp0->basis,
-          &sbapp0->basis, mbapp->use_gpu);
+          &sbapp0->species[0].basis, mbapp->use_gpu);
         if ((mbapp->num_neut_species > 0) && (!sbapp0->neut_species[0].info.is_static)) {
           mbapp->jf_rescale_neut[d*2+e] = gkyl_rescale_ghost_jacf_new(d,e,&sbapp0->basis,
             &sbapp0->neut_species[0].basis, mbapp->use_gpu);


### PR DESCRIPTION
When the phase basis was moved out of the app into the species, the jf rescaler in the MB app for neutral species was updated correctly. However, the second basis argument for the charged species jf rescaler needed to be modified as well. This PR updates the charged jf rescaler accordingly.

