### PR TITLE
Fix mistake in STEP regression test where block type was incorrect. 

### DIFF
--- a/regression/rt_gk_step_out_2x2v_p1.c
+++ b/regression/rt_gk_step_out_2x2v_p1.c
@@ -653,12 +653,14 @@ main(int argc, char **argv)
   };
 
   struct gkyl_tok_geo_grid_inp grid_inp = {
-    .ftype = GKYL_SOL_DN_OUT_MID, // type of geometry
+    .ftype = GKYL_SOL_DN_OUT, // type of geometry
     .rclose = 6.2,                // closest R to region of interest
     .rright = 6.2,                // Closest R to outboard SOL
     .rleft = 2.0,                 // closest R to inboard SOL
     .rmin = 1.1,                  // smallest R in machine
     .rmax = 6.2,                  // largest R in machine
+    .zmin = -6.0,                 // Z of upper plate
+    .zmax = 6.0,                  // Z of lower plate
     .use_cubics = false,          // Whether to use cubic representation of psi(R,Z) for field line tracing
   };
 


### PR DESCRIPTION
Fix an oversight in the step regression test. The block type should not be set to DN_OUT_MID now that we use the global tokamak normalization. Instead it should just be DN_OUT.

Single Block should no longer use separated block types such as OUT, MID, and LO unless someone is trying to do something special. This test was odd from the beginning any way. All other step reg tests use DN_OUT, which this one now matches.