### PR TITLE
The gkyl_gk struct has become too HUGE for storing on the stack!!! So

### DIFF
--- a/apps/gk_species_moment.c
+++ b/apps/gk_species_moment.c
@@ -105,6 +105,7 @@ gk_species_moment_release(const struct gkyl_gyrokinetic_app *app, const struct g
   if (app->use_gpu) {
     gkyl_array_release(sm->marr_host);
   }
+  gkyl_array_release(sm->marr);  
 
   if (sm->is_integrated) {
     gkyl_dg_updater_moment_gyrokinetic_release(sm->mcalc);
@@ -116,7 +117,6 @@ gk_species_moment_release(const struct gkyl_gyrokinetic_app *app, const struct g
     else {
       gkyl_dg_updater_moment_gyrokinetic_release(sm->mcalc);
     }
-    gkyl_array_release(sm->marr);
 
     // Free the weak division memory if not computing integrated moments.
     gkyl_dg_bin_op_mem_release(sm->mem_geo);


### PR DESCRIPTION
The gkyl_gk struct has become too **HUGE** for storing on the stack!!! So we can no longer have C regressions the way we used to. We need to allocat the gkyl_gk struct on the heap, and set it manually. This sucks, but we must do this from now on. I have fixed one regression test regression/rt_gk_d3d_iwl_2x2v_p1.c and fixed a memory leak. This test is now valgrind clean.

@manauref @manauref @akashukla please go over EVERY SINGLE GK test/file and make the same fixes. This is a serious bug. More below.

Basically, the gkyl_gk struct is too big to keep on the stack. **This is a silent failure**. Some sims may seem to run but may randomly fail. Hence, it is very bad as this will happen at random. So we must fix every single input file in the manner I have indicated.