### PR TITLE
Fixing bflux seg fault in static species after new boundary flux features were added

### DIFF
--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -1069,7 +1069,6 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
   }
 
   // Create boundary flux diagnostics if requested.
-  gks->bflux_diag = (struct gk_boundary_fluxes) { };
   gk_species_bflux_init(app, gks, &gks->bflux_diag, true);
 
   if (app->enforce_positivity) {
@@ -1568,7 +1567,9 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   // Initialize boundary fluxes for emission BCs or Boltzmann elc.
   gks->bflux_solver = (struct gk_boundary_fluxes) { };
   gk_species_bflux_init(app, gks, &gks->bflux_solver, false);
-
+  gks->bflux_diag = (struct gk_boundary_fluxes) { };
+  gk_species_bflux_init(app, gks, &gks->bflux_diag, false);
+  
   // Initialize a Maxwellian/LTE (local thermodynamic equilibrium) projection routine
   // Projection routine optionally corrects all the Maxwellian/LTE moments
   // This routine is utilized by both reactions and BGK collisions

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -1068,9 +1068,6 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
     }
   }
 
-  // Create boundary flux diagnostics if requested.
-  gk_species_bflux_init(app, gks, &gks->bflux_diag, true);
-
   if (app->enforce_positivity) {
     // Positivity enforcing by shifting f (ps=positivity shift).
     gks->ps_delta_m0 = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
@@ -1122,8 +1119,6 @@ gk_species_new_static(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *a
   // Allocate distribution function arrays.
   gks->f1 = gks->f;
   gks->fnew = gks->f;
-
-  gk_species_bflux_init(app, gks, &gks->bflux_diag, false);
   
   // Set function pointers.
   gks->rhs_func = gk_species_rhs_static;
@@ -1569,8 +1564,9 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   // Initialize boundary fluxes for emission BCs or Boltzmann elc.
   gks->bflux_solver = (struct gk_boundary_fluxes) { };
   gk_species_bflux_init(app, gks, &gks->bflux_solver, false);
+  // Create boundary flux diagnostics if requested.
   gks->bflux_diag = (struct gk_boundary_fluxes) { };
-  
+  gk_species_bflux_init(app, gks, &gks->bflux_solver, !gks->info.is_static);
   
   // Initialize a Maxwellian/LTE (local thermodynamic equilibrium) projection routine
   // Projection routine optionally corrects all the Maxwellian/LTE moments

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -1123,6 +1123,8 @@ gk_species_new_static(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *a
   gks->f1 = gks->f;
   gks->fnew = gks->f;
 
+  gk_species_bflux_init(app, gks, &gks->bflux_diag, false);
+  
   // Set function pointers.
   gks->rhs_func = gk_species_rhs_static;
   gks->rhs_implicit_func = gk_species_rhs_implicit_static;
@@ -1568,7 +1570,7 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   gks->bflux_solver = (struct gk_boundary_fluxes) { };
   gk_species_bflux_init(app, gks, &gks->bflux_solver, false);
   gks->bflux_diag = (struct gk_boundary_fluxes) { };
-  gk_species_bflux_init(app, gks, &gks->bflux_diag, false);
+  
   
   // Initialize a Maxwellian/LTE (local thermodynamic equilibrium) projection routine
   // Projection routine optionally corrects all the Maxwellian/LTE moments

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -750,9 +750,6 @@ gk_species_release_dynamic(const gkyl_gyrokinetic_app* app, const struct gk_spec
     gkyl_free(s->L2norm_global);
   }
 
-  // Free boundary flux diagnostics memory.
-  gk_species_bflux_release(app, &s->bflux_diag);
-
   if (s->info.time_rate_diagnostics) {
     // Free df/dt diagnostics memory.
     gkyl_array_release(s->fdot_mom_old);
@@ -1566,7 +1563,7 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   gk_species_bflux_init(app, gks, &gks->bflux_solver, false);
   // Create boundary flux diagnostics if requested.
   gks->bflux_diag = (struct gk_boundary_fluxes) { };
-  gk_species_bflux_init(app, gks, &gks->bflux_solver, !gks->info.is_static);
+  gk_species_bflux_init(app, gks, &gks->bflux_diag, !gks->info.is_static);
   
   // Initialize a Maxwellian/LTE (local thermodynamic equilibrium) projection routine
   // Projection routine optionally corrects all the Maxwellian/LTE moments
@@ -1864,8 +1861,11 @@ gk_species_release(const gkyl_gyrokinetic_app* app, const struct gk_species *s)
 
   gk_species_source_release(app, &s->src);
 
+  // Free boundary flux solver memory.
   gk_species_bflux_release(app, &s->bflux_solver);
-
+  // Free boundary flux diagnostics memory.
+  gk_species_bflux_release(app, &s->bflux_diag);
+  
   gk_species_lte_release(app, &s->lte);
 
   gkyl_array_release(s->m0_gyroavg);

--- a/apps/gk_species_bflux.c
+++ b/apps/gk_species_bflux.c
@@ -415,8 +415,9 @@ gk_species_bflux_init(struct gkyl_gyrokinetic_app *app, struct gk_species *gk_s,
       bflux->bflux_calc_integrated_mom_func = gk_species_bflux_append_integrated_mom;
       bflux->bflux_calc_voltime_int_mom_func = gk_species_bflux_calc_voltime_integrated_mom_dynamic;
     }
-    else
+    else {
       bflux->bflux_calc_integrated_mom_func = gk_species_bflux_calc_integrated_mom_dynamic;
+    }
     bflux->bflux_write_integrated_mom_func = gk_species_bflux_write_integrated_mom_dynamic;
 
     // Object computing moments of the boundary flux.


### PR DESCRIPTION
The bflux integrated moment function for static species wasn't initialized leading to a seg fault when the following was called in gyrokinetic.c: 
```
void
gkyl_gyrokinetic_app_calc_species_boundary_flux_integrated_mom(gkyl_gyrokinetic_app* app, int sidx, double tm)
{
  struct gk_species *gks = &app->species[sidx];
  gk_species_bflux_calc_integrated_mom(app, gks, &gks->bflux_diag, tm);
}
```
Now fixed and rt_gk_static test runs.