### PR TITLE
Mirror geometry cubics fix

### DIFF
--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -490,7 +490,7 @@ create_ctx(void)
   double mu_max_elc = me * pow(3. * vte, 2.) / (2. * B_p);
   double vpar_max_ion = 20 * vti;
   double mu_max_ion = mi * pow(3. * vti, 2.) / (2. * B_p);
-  int Nz = 128;
+  int Nz = 32;
   int Nvpar = 32; // Number of cells in the paralell velocity direction 96
   int Nmu = 32;  // Number of cells in the mu direction 192
   int poly_order = 1;
@@ -797,6 +797,7 @@ int main(int argc, char **argv)
     .rclose = 0.2, // closest R to region of interest
     .zmin = -2.0,  // Z of lower boundary
     .zmax =  2.0,  // Z of upper boundary 
+    .use_cubics = true, // use cubic splines for interpolation
   };
 
   // GK app

--- a/zero/gkyl_mirror_geo_priv.h
+++ b/zero/gkyl_mirror_geo_priv.h
@@ -407,7 +407,7 @@ contour_func(double Z, void *ctx)
   c->ncall += 1;
   double R[4] = { 0 }, dR[4] = { 0 };
   
-  int nr = R_psiZ(c->geo, c->psi, Z, 4, R, dR);
+  int nr = gkyl_mirror_geo_R_psiZ(c->geo, c->psi, Z, 4, R, dR);
   double dRdZ = nr == 1 ? dR[0] : choose_closest(c->last_R, R, dR,nr);
   
   return nr>0 ? sqrt(1+dRdZ*dRdZ) : 0.0;
@@ -420,7 +420,7 @@ phi_contour_func(double Z, void *ctx)
   c->ncall += 1;
   double R[4] = { 0 }, dR[4] = { 0 };
   
-  int nr = R_psiZ(c->geo, c->psi, Z, 4, R, dR);
+  int nr = gkyl_mirror_geo_R_psiZ(c->geo, c->psi, Z, 4, R, dR);
   double dRdZ = nr == 1 ? dR[0] : choose_closest(c->last_R, R, dR, nr);
   double r_curr = nr == 1 ? R[0] : choose_closest(c->last_R, R, R, nr);
 


### PR DESCRIPTION
# Bug fix

Geometry was not being generated correctly with the cubics for the mirror. I fixed it in 2 lines.

## Summary

Description: The field lines need to be traced with the cubic integrator. This was not passed correctly. It was found by comparing it against the tokamak code.

Issue link: No issue. Serendipitous discovery

## Solution

Call gkyl_mirror_geo_R_psiZ instead of R_psiZ

Impacted files: gkyl_mirror_geo_priv.h

## Community Standards

- [ ] Documentation has been updated.
- [x] My code follows the project's coding guidelines.

## Testing: _(x (yes), blank (no))_

- [x] I added a regression test to test for this bug.
- [ ] I added a unit test to test this bug.
- [ ] Ran `make check` and unit tests all pass.
- [ ] I ran the code through Valgrind, and it is clean.
- [x] I ran a few regression tests to ensure no apparent errors.
- [x] Tested and works on CPU.
- [ ] Tested and works on multi-CPU.
- [ ] Tested and works on GPU.
- [ ] Tested and works on multi-GPU.

## Additional Notes

Let's examine this rt_gk_wham_1x2v unit test with the cubics flag. 32 cells in z to make it speedy.

Before fix: SIGABRT

Geometry after fix:

![image](https://github.com/user-attachments/assets/f2718695-eb35-419b-a326-94d46d0062be)
![image](https://github.com/user-attachments/assets/8a21415e-bba1-416d-b221-e2b49ee5dea1)
![image](https://github.com/user-attachments/assets/bf87168e-3010-492d-af3f-aa028b5b79d5)





