### PR TITLE
Bug fix: Boltzmann electron sheath values were half

### DIFF
--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -546,7 +546,6 @@ gk_field_calc_ambi_pot_sheath_vals(gkyl_gyrokinetic_app *app, struct gk_field *f
     gkyl_comm_array_bcast(app->comm, field->sheath_vals[2*index_parallel]  , field->sheath_vals[2*index_parallel], 0);
     gkyl_comm_array_bcast(app->comm, field->sheath_vals[2*index_parallel+1], field->sheath_vals[2*index_parallel+1], comm_sz[0]-1);
     gkyl_array_accumulate(field->sheath_vals[2*index_parallel], 1., field->sheath_vals[2*index_parallel+1]);
-    gkyl_array_scale(field->sheath_vals[2*index_parallel], 0.5);
   } 
 }
 

--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -222,6 +222,10 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
     polarization_weight = 1.0; 
     f->ambi_pot = gkyl_ambi_bolt_potential_new(&app->grid, &app->basis, 
       f->info.electron_mass, f->info.electron_charge, f->info.electron_temp, app->use_gpu);
+    // sheath_vals contains both the ion density and the phi_sheath values, which is why it's 2* the size
+    // The first componenets are the ion density and the second are the sheath values.
+    // We have 2 arrays for each cdim direction because first index is the lower sheath and the higher
+    // index is the upper sheath
     for (int j=0; j<app->cdim; ++j) {
       f->sheath_vals[2*j]   = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);
       f->sheath_vals[2*j+1] = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -1071,8 +1071,8 @@ int gk_find_neut_species_idx(const gkyl_gyrokinetic_app *app, const char *nm);
  * @param app gyrokinetic app object
  * @param s Species object 
  * @param sm Species moment object
- * @param is_integrated Whether to compute the volume integrated moment.
  * @param nm Name string indicating moment type
+ * @param is_integrated Whether to compute the volume integrated moment.
  */
 void gk_species_moment_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
   struct gk_species_moment *sm, const char *nm, bool is_integrated);

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -110,12 +110,33 @@ test_ambi_bolt_sheath_calc_1x()
   gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
     &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
 
+  // Serendipity 1x basis is [1/sqrt(2), sqrt(3/2)x].
+  // sheath_vals stores both the ion density and sheath value
+  // Ion density is the first 2 components. Should be 1
+  // Sheath potential is the second part. 
+  // phi_s = Te/e * log(ni (Te/me) / (sqrt(2*pi) gamma_i J dz/2))
+  // phi_s = log(1/(sqrt(2*pi) 0.5 * 1/4))
   double *sheath_lower_c = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
   double *sheath_upper_c = ((double *) gkyl_array_cfetch(sheath_vals[1], 9));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4)), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[3], 0, 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4)), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[3], 0, 1e-12));
+
+  // This operation happens after the sheaths are determined in the app, so we should test this
+  gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
+  gkyl_array_scale(sheath_vals[0], 0.5);
+
+  double *sheath_lower_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[0], sqrt(2)/2, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[1], 0, 1e-12));
+  double *sheath_upper_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 9));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[0], sqrt(2)/2, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[1], 0, 1e-12));
 
   gkyl_ambi_bolt_potential_release(ambi);
   gkyl_proj_on_basis_release(proj_one);

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -14,7 +14,6 @@
 #include <gkyl_ambi_bolt_potential_priv.h>
 #include <gkyl_proj_on_basis.h>
 #include <gkyl_util.h>
-#include <gkyl_null_comm.h>
 
 void eval_one(double t, const double *xn, double* restrict fout, void *ctx)
 {
@@ -128,19 +127,7 @@ test_ambi_bolt_sheath_calc_1x()
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[3], 0, 1e-12));
 
-  int cuts[] = { 1 };
-  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(local.ndim, cuts, &local);
-
-  struct gkyl_comm *comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
-    }
-  );
-
   // This operation happens after the sheaths are determined in the app, so we should test this
-  int comm_sz[1];
-  gkyl_comm_get_size(comm, comm_sz);
-  gkyl_comm_array_bcast(comm, sheath_vals[0], sheath_vals[0], 0);
-  gkyl_comm_array_bcast(comm, sheath_vals[1], sheath_vals[1], comm_sz[0]-1);
   gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
 
   double *sheath_lower_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
@@ -212,17 +199,6 @@ test_ambi_bolt_phi_calc_1x()
   gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
     &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
 
-  int cuts[] = { 1 };
-  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(local.ndim, cuts, &local);
-
-  struct gkyl_comm *comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .decomp = decomp
-    }
-  );
-  int comm_sz[1];
-  gkyl_comm_get_size(comm, comm_sz);
-  gkyl_comm_array_bcast(comm, sheath_vals[0], sheath_vals[0], 0);
-  gkyl_comm_array_bcast(comm, sheath_vals[1], sheath_vals[1], comm_sz[0]-1);
   gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
 
   struct gkyl_array *phi = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -20,6 +20,11 @@ void eval_one(double t, const double *xn, double* restrict fout, void *ctx)
   fout[0] = 1.0;
 }
 
+void eval_hat(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  fout[0] = 2. - fabs(xn[0]);
+}
+
 void
 test_ambi_bolt_init_1x()
 {
@@ -219,9 +224,181 @@ test_ambi_bolt_phi_calc_1x()
   gkyl_proj_on_basis_release(proj_one);
 }
 
+void
+test_ambi_bolt_sheath_calc_1x_hat()
+{
+  int poly_order = 1;
+  double lower[] = {-1.0}, upper[] = {1.0};
+  int cells[] = {8};
+  int cdim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grid.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, cdim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis *basis;
+  basis = gkyl_cart_modal_serendip_new(cdim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  double mass_e = 1.0, charge_e = -1.0, temp_e = 1.0;
+  bool use_gpu = false;
+
+  struct gkyl_ambi_bolt_potential *ambi = gkyl_ambi_bolt_potential_new(&grid, basis, mass_e, charge_e, temp_e, use_gpu);
+
+  struct gkyl_array *sheath_vals[2*cdim];
+  for (int j=0; j<cdim; ++j) {
+    sheath_vals[2*j]   = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    sheath_vals[2*j+1] = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    gkyl_array_clear(sheath_vals[2*j],   0.0);
+    gkyl_array_clear(sheath_vals[2*j+1], 0.0);
+  }
+
+  // Local skin and ghost ranges for configuration space fields.
+  struct gkyl_range lower_skin[cdim], lower_ghost[cdim], upper_skin[cdim], upper_ghost[cdim];
+  for (int dir=0; dir<cdim; ++dir) {
+    gkyl_skin_ghost_ranges(&lower_skin[dir], &lower_ghost[dir], dir, GKYL_LOWER_EDGE, &local_ext, ghost); 
+    gkyl_skin_ghost_ranges(&upper_skin[dir], &upper_ghost[dir], dir, GKYL_UPPER_EDGE, &local_ext, ghost);
+  }
+
+  struct gkyl_array *jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *M0 = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *gamma_i = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_proj_on_basis *proj_one = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_one, NULL); 
+  gkyl_proj_on_basis *proj_hat = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_hat, NULL); 
+
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, jacobgeo_inv);
+  gkyl_proj_on_basis_advance(proj_hat, 0.0, &local_ext, M0);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, gamma_i);
+
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_LOWER_EDGE, 
+    &lower_skin[0], &lower_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[0]);
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
+    &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
+
+  // Serendipity 1x basis is [1/sqrt(2), sqrt(3/2)x].
+  // sheath_vals stores both the ion density and sheath value
+  // Ion density is the first 2 components. Should be 1
+  // Sheath potential is the second part. 
+  // phi_s = Te/e * log(ni (Te/me) / (sqrt(2*pi) gamma_i J dz/2))
+  // phi_s = log(1/(sqrt(2*pi) 0.5 * 1/4))
+  double *sheath_lower_c = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
+  double *sheath_upper_c = ((double *) gkyl_array_cfetch(sheath_vals[1], 9));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[3], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[3], 0, 1e-12));
+
+  // This operation happens after the sheaths are determined in the app, so we should test this
+  gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
+
+  double *sheath_lower_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[3], 0, 1e-12));
+  double *sheath_upper_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 9));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[3], 0, 1e-12));
+
+  gkyl_ambi_bolt_potential_release(ambi);
+  gkyl_proj_on_basis_release(proj_one);
+  gkyl_proj_on_basis_release(proj_hat);
+}
+
+void
+test_ambi_bolt_phi_calc_1x_hat()
+{
+  int poly_order = 1;
+  double lower[] = {-1.0}, upper[] = {1.0};
+  int cells[] = {8};
+  int cdim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grid.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, cdim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis *basis;
+  basis = gkyl_cart_modal_serendip_new(cdim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  double mass_e = 1.0, charge_e = -1.0, temp_e = 1.0;
+  bool use_gpu = false;
+
+  struct gkyl_ambi_bolt_potential *ambi = gkyl_ambi_bolt_potential_new(&grid, basis, mass_e, charge_e, temp_e, use_gpu);
+
+  struct gkyl_array *sheath_vals[2*cdim];
+  for (int j=0; j<cdim; ++j) {
+    sheath_vals[2*j]   = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    sheath_vals[2*j+1] = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    gkyl_array_clear(sheath_vals[2*j],   0.0);
+    gkyl_array_clear(sheath_vals[2*j+1], 0.0);
+  }
+
+  // Local skin and ghost ranges for configuration space fields.
+  struct gkyl_range lower_skin[cdim], lower_ghost[cdim], upper_skin[cdim], upper_ghost[cdim];
+  for (int dir=0; dir<cdim; ++dir) {
+    gkyl_skin_ghost_ranges(&lower_skin[dir], &lower_ghost[dir], dir, GKYL_LOWER_EDGE, &local_ext, ghost); 
+    gkyl_skin_ghost_ranges(&upper_skin[dir], &upper_ghost[dir], dir, GKYL_UPPER_EDGE, &local_ext, ghost);
+  }
+
+  struct gkyl_array *jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *M0 = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *gamma_i = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_proj_on_basis *proj_one = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_one, NULL); 
+  gkyl_proj_on_basis *proj_hat = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_hat, NULL); 
+
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, jacobgeo_inv);
+  gkyl_proj_on_basis_advance(proj_hat, 0.0, &local_ext, M0);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, gamma_i);
+
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_LOWER_EDGE, 
+    &lower_skin[0], &lower_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[0]);
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
+    &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
+
+  gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
+
+  struct gkyl_array *phi = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_ambi_bolt_potential_phi_calc(ambi, &local, &local_ext,
+    jacobgeo_inv, M0, sheath_vals[0], phi);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  double phi_sheath = log(1/(sqrt(2*M_PI)*0.5*1/4));
+  while (gkyl_range_iter_next(&iter)) {
+    double *phi_c = ((double *) gkyl_array_cfetch(phi, iter.idx[0]));
+    double *ni_c  = ((double *) gkyl_array_cfetch(M0, iter.idx[0]));
+    double ni = ni_c[0]/sqrt(2);
+    TEST_CHECK(gkyl_compare_double(phi_c[0]/sqrt(2), phi_sheath + log(ni), 1e-3));
+  }
+
+  gkyl_ambi_bolt_potential_release(ambi);
+  gkyl_proj_on_basis_release(proj_one);
+  gkyl_proj_on_basis_release(proj_hat);
+}
+
 TEST_LIST = {
   { "test_ambi_bolt_init_1x", test_ambi_bolt_init_1x },
   { "test_ambi_bolt_sheath_calc_1x", test_ambi_bolt_sheath_calc_1x },
   { "test_ambi_bolt_phi_calc_1x", test_ambi_bolt_phi_calc_1x },
+  { "test_ambi_bolt_sheath_calc_1x_hat", test_ambi_bolt_sheath_calc_1x_hat },
+  { "test_ambi_bolt_phi_calc_1x_hat", test_ambi_bolt_phi_calc_1x_hat },
   { NULL, NULL },
 };

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -1,0 +1,203 @@
+// Description: Test for the boltzmann electron model for potential
+
+#include <acutest.h>
+
+#include <gkyl_array_ops.h>
+#include <gkyl_range.h>
+#include <gkyl_rect_decomp.h>
+#include <gkyl_rect_grid.h>
+
+#include <gkyl_basis.h>
+#include <gkyl_bc_sheath_gyrokinetic.h>
+#include <gkyl_velocity_map.h>
+#include <gkyl_ambi_bolt_potential.h>
+#include <gkyl_ambi_bolt_potential_priv.h>
+#include <gkyl_proj_on_basis.h>
+#include <gkyl_util.h>
+
+void eval_one(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  fout[0] = 1.0;
+}
+
+void
+test_ambi_bolt_init_1x()
+{
+  int poly_order = 1;
+  double lower[] = {-1.0}, upper[] = {1.0};
+  int cells[] = {8};
+  int cdim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grid.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, cdim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis *basis;
+  basis = gkyl_cart_modal_serendip_new(cdim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  double mass_e = 1.0, charge_e = -1.0, temp_e = 1.0;
+  bool use_gpu = false;
+
+  struct gkyl_ambi_bolt_potential *ambi = gkyl_ambi_bolt_potential_new(&grid, basis, mass_e, charge_e, temp_e, use_gpu);
+
+  TEST_CHECK( ambi->cdim == 1);
+  TEST_CHECK( ambi->num_basis == basis->num_basis);
+  TEST_CHECK( ambi->use_gpu == use_gpu);
+  TEST_CHECK( gkyl_compare_double(ambi->dz, 2./8., 1e-12));
+  TEST_CHECK( gkyl_compare_double(ambi->mass_e, mass_e, 1e-12));
+  TEST_CHECK( gkyl_compare_double(ambi->charge_e, charge_e, 1e-12));
+  TEST_CHECK( gkyl_compare_double(ambi->temp_e, temp_e, 1e-12));
+
+  gkyl_ambi_bolt_potential_release(ambi);
+}
+
+void
+test_ambi_bolt_sheath_calc_1x()
+{
+  int poly_order = 1;
+  double lower[] = {-1.0}, upper[] = {1.0};
+  int cells[] = {8};
+  int cdim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grid.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, cdim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis *basis;
+  basis = gkyl_cart_modal_serendip_new(cdim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  double mass_e = 1.0, charge_e = -1.0, temp_e = 1.0;
+  bool use_gpu = false;
+
+  struct gkyl_ambi_bolt_potential *ambi = gkyl_ambi_bolt_potential_new(&grid, basis, mass_e, charge_e, temp_e, use_gpu);
+
+  struct gkyl_array *sheath_vals[2*cdim];
+  for (int j=0; j<cdim; ++j) {
+    sheath_vals[2*j]   = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    sheath_vals[2*j+1] = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    gkyl_array_clear(sheath_vals[2*j],   0.0);
+    gkyl_array_clear(sheath_vals[2*j+1], 0.0);
+  }
+
+  // Local skin and ghost ranges for configuration space fields.
+  struct gkyl_range lower_skin[cdim], lower_ghost[cdim], upper_skin[cdim], upper_ghost[cdim];
+  for (int dir=0; dir<cdim; ++dir) {
+    gkyl_skin_ghost_ranges(&lower_skin[dir], &lower_ghost[dir], dir, GKYL_LOWER_EDGE, &local_ext, ghost); 
+    gkyl_skin_ghost_ranges(&upper_skin[dir], &upper_ghost[dir], dir, GKYL_UPPER_EDGE, &local_ext, ghost);
+  }
+
+  struct gkyl_array *jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *M0 = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *gamma_i = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_proj_on_basis *proj_one = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_one, NULL);  
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, jacobgeo_inv);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, M0);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, gamma_i);
+
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_LOWER_EDGE, 
+    &lower_skin[0], &lower_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[0]);
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
+    &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
+
+  double *sheath_lower_c = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
+  double *sheath_upper_c = ((double *) gkyl_array_cfetch(sheath_vals[1], 9));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[0], sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[1], 0, 1e-12));
+
+  gkyl_ambi_bolt_potential_release(ambi);
+  gkyl_proj_on_basis_release(proj_one);
+}
+
+void
+test_ambi_bolt_phi_calc_1x()
+{
+  int poly_order = 1;
+  double lower[] = {-1.0}, upper[] = {1.0};
+  int cells[] = {8};
+  int cdim = sizeof(lower)/sizeof(lower[0]);
+
+  // Grid.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, cdim, lower, upper, cells);
+
+  // Basis functions.
+  struct gkyl_basis *basis;
+  basis = gkyl_cart_modal_serendip_new(cdim, poly_order);
+
+  int ghost[] = { 1 };
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  double mass_e = 1.0, charge_e = -1.0, temp_e = 1.0;
+  bool use_gpu = false;
+
+  struct gkyl_ambi_bolt_potential *ambi = gkyl_ambi_bolt_potential_new(&grid, basis, mass_e, charge_e, temp_e, use_gpu);
+
+  struct gkyl_array *sheath_vals[2*cdim];
+  for (int j=0; j<cdim; ++j) {
+    sheath_vals[2*j]   = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    sheath_vals[2*j+1] = gkyl_array_new(GKYL_DOUBLE, 2*basis->num_basis, local_ext.volume);
+    gkyl_array_clear(sheath_vals[2*j],   0.0);
+    gkyl_array_clear(sheath_vals[2*j+1], 0.0);
+  }
+
+  // Local skin and ghost ranges for configuration space fields.
+  struct gkyl_range lower_skin[cdim], lower_ghost[cdim], upper_skin[cdim], upper_ghost[cdim];
+  for (int dir=0; dir<cdim; ++dir) {
+    gkyl_skin_ghost_ranges(&lower_skin[dir], &lower_ghost[dir], dir, GKYL_LOWER_EDGE, &local_ext, ghost); 
+    gkyl_skin_ghost_ranges(&upper_skin[dir], &upper_ghost[dir], dir, GKYL_UPPER_EDGE, &local_ext, ghost);
+  }
+
+  struct gkyl_array *jacobgeo_inv = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *M0 = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+  struct gkyl_array *gamma_i = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_proj_on_basis *proj_one = gkyl_proj_on_basis_new(&grid, basis, poly_order+1, 1, eval_one, NULL);  
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, jacobgeo_inv);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, M0);
+  gkyl_proj_on_basis_advance(proj_one, 0.0, &local_ext, gamma_i);
+
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_LOWER_EDGE, 
+    &lower_skin[0], &lower_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[0]);
+  gkyl_ambi_bolt_potential_sheath_calc(ambi, GKYL_UPPER_EDGE,
+    &upper_skin[0], &upper_ghost[0], jacobgeo_inv, gamma_i, M0, sheath_vals[1]);
+
+  gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
+  gkyl_array_scale(sheath_vals[0], 0.5);
+
+  struct gkyl_array *phi = gkyl_array_new(GKYL_DOUBLE, basis->num_basis, local_ext.volume);
+
+  gkyl_ambi_bolt_potential_phi_calc(ambi, &local, &local_ext,
+    jacobgeo_inv, M0, sheath_vals[0], phi);
+
+  struct gkyl_range_iter iter;
+  gkyl_range_iter_init(&iter, &local);
+  while (gkyl_range_iter_next(&iter)) {
+    double *phi_c = ((double *) gkyl_array_cfetch(phi, iter.idx[0]));
+    TEST_CHECK(gkyl_compare_double(phi_c[0], 1.800857690348724, 1e-12));
+    TEST_CHECK(gkyl_compare_double(phi_c[1], 0.0, 1e-12));
+  }
+
+  gkyl_ambi_bolt_potential_release(ambi);
+  gkyl_proj_on_basis_release(proj_one);
+}
+
+TEST_LIST = {
+  { "test_ambi_bolt_init_1x", test_ambi_bolt_init_1x },
+  { "test_ambi_bolt_sheath_calc_1x", test_ambi_bolt_sheath_calc_1x },
+  { "test_ambi_bolt_phi_calc_1x", test_ambi_bolt_phi_calc_1x },
+  { NULL, NULL },
+};

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -120,23 +120,26 @@ test_ambi_bolt_sheath_calc_1x()
   double *sheath_upper_c = ((double *) gkyl_array_cfetch(sheath_vals[1], 9));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c[1], 0, 1e-12));
-  TEST_CHECK(gkyl_compare_double(sheath_lower_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4)), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c[3], 0, 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[1], 0, 1e-12));
-  TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4)), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[3], 0, 1e-12));
 
   // This operation happens after the sheaths are determined in the app, so we should test this
   gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
-  gkyl_array_scale(sheath_vals[0], 0.5);
 
   double *sheath_lower_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));
-  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[0], sqrt(2)/2, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_lower_c_avg[3], 0, 1e-12));
   double *sheath_upper_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 9));
-  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[0], sqrt(2)/2, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[0], sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[1], 0, 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
+  TEST_CHECK(gkyl_compare_double(sheath_upper_c_avg[3], 0, 1e-12));
 
   gkyl_ambi_bolt_potential_release(ambi);
   gkyl_proj_on_basis_release(proj_one);

--- a/unit/ctest_ambi_bolt_potential.c
+++ b/unit/ctest_ambi_bolt_potential.c
@@ -14,6 +14,7 @@
 #include <gkyl_ambi_bolt_potential_priv.h>
 #include <gkyl_proj_on_basis.h>
 #include <gkyl_util.h>
+#include <gkyl_null_comm.h>
 
 void eval_one(double t, const double *xn, double* restrict fout, void *ctx)
 {
@@ -127,7 +128,19 @@ test_ambi_bolt_sheath_calc_1x()
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[2], log(1/(sqrt(2*M_PI)*0.5*1/4))*sqrt(2), 1e-12));
   TEST_CHECK(gkyl_compare_double(sheath_upper_c[3], 0, 1e-12));
 
+  int cuts[] = { 1 };
+  struct gkyl_rect_decomp *decomp = gkyl_rect_decomp_new_from_cuts(local.ndim, cuts, &local);
+
+  struct gkyl_comm *comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
+      .decomp = decomp
+    }
+  );
+
   // This operation happens after the sheaths are determined in the app, so we should test this
+  int comm_sz[1];
+  gkyl_comm_get_size(comm, comm_sz);
+  gkyl_comm_array_bcast(comm, sheath_vals[0], sheath_vals[0], 0);
+  gkyl_comm_array_bcast(comm, sheath_vals[1], sheath_vals[1], comm_sz[0]-1);
   gkyl_array_accumulate(sheath_vals[0], 1., sheath_vals[1]);
 
   double *sheath_lower_c_avg = ((double *) gkyl_array_cfetch(sheath_vals[0], 0));

--- a/zero/ambi_bolt_potential.c
+++ b/zero/ambi_bolt_potential.c
@@ -8,11 +8,11 @@ gkyl_ambi_bolt_potential_new(const struct gkyl_rect_grid *grid, const struct gky
 {
   struct gkyl_ambi_bolt_potential *up = gkyl_malloc(sizeof(struct gkyl_ambi_bolt_potential));
 
-  up->ndim = basis->ndim;
+  up->cdim = basis->ndim;
   up->num_basis = basis->num_basis;
   up->use_gpu = use_gpu;
 
-  up->dz = grid->dx[up->ndim-1];
+  up->dz = grid->dx[up->cdim-1];
   up->mass_e = mass_e;
   up->charge_e = charge_e;
   up->temp_e = temp_e;
@@ -58,9 +58,9 @@ void gkyl_ambi_bolt_potential_sheath_calc(struct gkyl_ambi_bolt_potential *up, e
   struct gkyl_range_iter iter;
   gkyl_range_iter_init(&iter, ghost_r);
   while (gkyl_range_iter_next(&iter)) {
-    gkyl_copy_int_arr(up->ndim, iter.idx, idx_s);
+    gkyl_copy_int_arr(up->cdim, iter.idx, idx_s);
     // Assume only 1 ghost cell on either side along the field line.
-    idx_s[up->ndim-1] = edge == GKYL_LOWER_EDGE ? iter.idx[up->ndim-1]+1 : iter.idx[up->ndim-1]-1;
+    idx_s[up->cdim-1] = edge == GKYL_LOWER_EDGE ? iter.idx[up->cdim-1]+1 : iter.idx[up->cdim-1]-1;
 
     long ghost_loc = gkyl_range_idx(ghost_r, iter.idx);
     long skin_loc = gkyl_range_idx(skin_r, idx_s);
@@ -92,8 +92,8 @@ void gkyl_ambi_bolt_potential_phi_calc(struct gkyl_ambi_bolt_potential *up,
   while (gkyl_range_iter_next(&iter)) {
     // We assume each MPI rank calls this over the local range and
     // that the sheath values are defined on the lower local ghost range.
-    gkyl_copy_int_arr(up->ndim, iter.idx, idx_g);
-    idx_g[up->ndim-1] = extlocal_r->lower[up->ndim-1];
+    gkyl_copy_int_arr(up->cdim, iter.idx, idx_g);
+    idx_g[up->cdim-1] = extlocal_r->lower[up->cdim-1];
 
     long loc = gkyl_range_idx(local_r, iter.idx);
     long ghost_loc = gkyl_range_idx(extlocal_r, idx_g);

--- a/zero/gkyl_ambi_bolt_potential_priv.h
+++ b/zero/gkyl_ambi_bolt_potential_priv.h
@@ -26,8 +26,8 @@ static const sheath_calc_kern_edge_list ser_sheath_calc_list[] = {
   { .list = {{ambi_bolt_potential_sheath_calc_lower_1x_ser_p1, ambi_bolt_potential_sheath_calc_upper_1x_ser_p1},
              {ambi_bolt_potential_sheath_calc_lower_1x_ser_p2, ambi_bolt_potential_sheath_calc_upper_1x_ser_p2}}, },
   // 2x
-  { .list = {{NULL, NULL},
-             {NULL, NULL}}, },
+  { .list = {{ambi_bolt_potential_sheath_calc_lower_1x_ser_p1, ambi_bolt_potential_sheath_calc_upper_1x_ser_p1},
+             {ambi_bolt_potential_sheath_calc_lower_1x_ser_p2, ambi_bolt_potential_sheath_calc_upper_1x_ser_p2}}, },
 //  // 3x
 //  { .list = {{ambi_bolt_potential_sheath_calc_lower_3x_ser_p1, ambi_bolt_potential_sheath_calc_upper_3x_ser_p1},
 //             {ambi_bolt_potential_sheath_calc_lower_3x_ser_p2, ambi_bolt_potential_sheath_calc_upper_3x_ser_p2}}, },
@@ -39,7 +39,7 @@ static const phi_calc_kern_list ser_phi_calc_list[] = {
   // 1x kernels
   { ambi_bolt_potential_phi_calc_1x_ser_p1, ambi_bolt_potential_phi_calc_1x_ser_p2 },
   // 2x kernels
-  { NULL, NULL },
+  { ambi_bolt_potential_phi_calc_1x_ser_p1, ambi_bolt_potential_phi_calc_1x_ser_p2 },
   // 3x kernels
 //  { ambi_bolt_potential_phi_calc_3x_ser_p1, ambi_bolt_potential_phi_calc_3x_ser_p2 },
 };
@@ -56,7 +56,7 @@ struct gkyl_ambi_bolt_potential_kernels {
 
 // Primary struct in this updater.
 struct gkyl_ambi_bolt_potential {
-  int ndim;
+  int cdim;
   double num_basis;
   bool use_gpu;
   double dz;


### PR DESCRIPTION
# Bug fix

## Summary

Description: In calculating the sheath values for the Boltzmann electron model, there is an apparent average that the app does. The code reads like this. This is exclusive to 1x.

First, sheath_vals[0] calculates the density and sheath potential on the left edge. Then, sheath_vals[1] calculates density and sheath potential on the right edge. The rest of the arrays are zero. We want one array with all these quantities, so they are accumulated (out = out + 1 * inp).

```
gkyl_array_accumulate(field->sheath_vals[0], 1., field->sheath_vals[1]);
gkyl_array_scale(field->sheath_vals[0], 0.5);
```

If all the sheath values were 1, the arrays would look like this:
sheath_vals[0] = {1,0,0, ... , 0,0,0}
sheath_vals[1] = {0,0,0, ... , 0,0,1}

We want a result:
sheath_vals[0] = {1,0,0, ..., 0,0,1}

This scale should not be here because it would effectively average the sheath_vals with zero. This results in a 1/2 factor in the ion density at the sheath and the sheath potential, which should not be there.

Issue link: No issue opened

## Solution

The bug is fixed by removing the gkyl_array_scale. 

This was found through writing a unit test. There was no unit test for the functions in `zero/ambi_bolt_potential.c`. All files in `/zero` should have unit tests.

A unit test is added to ensure we understand how these functions behave. The unit test copies the features in the app directly with a known analytic solution.

Impacted files: app/gk_field.c

## Community Standards

- [x] Documentation has been updated.
- [x] My code follows the project's coding guidelines.

## Testing: _(x (yes), blank (no))_

- [ ] I added a regression test to test for this bug.
- [x] I added a unit test to test this bug.
- [x] Ran `make check` and unit tests all pass.
- [ ] I ran the code through Valgrind, and it is clean.
- [x] I ran a few regression tests to ensure no apparent errors.
- [x] Tested and works on CPU.
- [ ] Tested and works on multi-CPU.
- [ ] Tested and works on GPU.
- [ ] Tested and works on multi-GPU.

## Additional Notes

This is a part of an inclusion of 2x Boltzmann electrons into Gkeyll. I wanted to PR this bug fix separately to make the PRs easy to address. There is some renaming of variables as well, and refactoring is required. It does not impact anything relevant to the 1x work. I want to add 2x unit tests before I PR that side of the project. I think what I implemented here regarding that should mean this works in 2x, but it's not tested. This is a separate bug-related PR and does not mean to be a 2x/3x Boltzmann electrons PR

Here, I run rt_gk_mirror_boltz_elc_1x2v_p1.c before and after the bug. It's interesting that the sheath potential is not doubled. Perhaps this interacts with the density.

![image](https://github.com/user-attachments/assets/95bf6e30-af7a-47d7-abc0-9a2b3b9b157d)

