### PR TITLE
The adiabatic coupling array needs to be initialized to 0 

### DIFF
--- a/zero/dg_calc_canonical_pb_fluid_vars.c
+++ b/zero/dg_calc_canonical_pb_fluid_vars.c
@@ -30,6 +30,7 @@ gkyl_dg_calc_canonical_pb_fluid_vars_new(const struct gkyl_rect_grid *conf_grid,
   up->alpha = 0.0;
   up->is_modified = 0; 
 
+  up->adiabatic_coupling_phi_n = 0;
   if (wv_eqn->type == GKYL_EQN_CAN_PB_HASEGAWA_MIMA) {
     up->canonical_pb_fluid_source = choose_canonical_pb_fluid_hasegawa_mima_source_kern(conf_basis->b_type, cdim, poly_order);
   }

--- a/zero/dg_calc_canonical_pb_fluid_vars_cu.cu
+++ b/zero/dg_calc_canonical_pb_fluid_vars_cu.cu
@@ -212,6 +212,7 @@ gkyl_dg_calc_canonical_pb_fluid_vars_cu_dev_new(const struct gkyl_rect_grid *con
   up->alpha = 0.0;
   up->is_modified = 0; 
 
+  up->adiabatic_coupling_phi_n = 0;
   if (wv_eqn->type == GKYL_EQN_CAN_PB_HASEGAWA_WAKATANI) {
     up->alpha = gkyl_wv_can_pb_hasegawa_wakatani_alpha(wv_eqn); 
     up->is_modified = gkyl_wv_can_pb_hasegawa_wakatani_is_modified(wv_eqn); 


### PR DESCRIPTION
so that the logic that I copied from other DG equations works correctly for not indexing an unallocated array. I was accidentally being saved by certain compilers being okay with this while others were not.