### PR TITLE
Optional ghost currents functionality in 1x Vlasov-Maxwell

### DIFF
--- a/apps/gkyl_vlasov.h
+++ b/apps/gkyl_vlasov.h
@@ -215,6 +215,8 @@ struct gkyl_vlasov_field {
   
   double limiter_fac; // Optional input parameter for adjusting diffusion in slope limiter
   bool limit_em; // Optional input parameter for applying limiters to EM fields
+
+  bool use_ghost_current; // Are we using ghost currents to correct dE/dt = -J in 1x
   
   // boundary conditions
   enum gkyl_field_bc_type bcx[2], bcy[2], bcz[2];

--- a/apps/gkyl_vlasov_priv.h
+++ b/apps/gkyl_vlasov_priv.h
@@ -508,6 +508,10 @@ struct vm_field {
       struct gkyl_array *em_energy; // EM energy components in each cell
       double *em_energy_red; // memory for use in GPU reduction of EM energy
 
+      bool use_ghost_current; // Are we using ghost currents to correct dE/dt = -J in 1x
+      struct gkyl_array *ghost_current; // Array for storying global average of current density
+      double *red_ghost_current; // memory for use in GPU reduction of average of current density
+
       // boundary conditions on lower/upper edges in each direction  
       enum gkyl_field_bc_type lower_bc[3], upper_bc[3];
       // Pointers to updaters that apply BC.

--- a/apps/vlasov_lw.c
+++ b/apps/vlasov_lw.c
@@ -982,6 +982,7 @@ vlasov_field_lw_new(lua_State *L)
   vm_field.elcErrorSpeedFactor = glua_tbl_get_number(L, "elcErrorSpeedFactor", 0.0);
   vm_field.mgnErrorSpeedFactor = glua_tbl_get_number(L, "mgnErrorSpeedFactor", 0.0);
   vm_field.limit_em = glua_tbl_get_bool(L, "limitField", false);
+  vm_field.use_ghost_current = glua_tbl_get_bool(L, "useGhostCurrent", false);
 
   bool evolve = glua_tbl_get_bool(L, "evolve", true);
   vm_field.is_static = !evolve;

--- a/apps/vm_field.c
+++ b/apps/vm_field.c
@@ -137,6 +137,19 @@ vm_field_new(struct gkyl_vm *vm, struct gkyl_vlasov_app *app)
     }
   }
 
+  f->use_ghost_current = false;
+  if (f->info.use_ghost_current) {
+    if (app->cdim != 1 && app->num_periodic_dir != 1) {
+      // Ghost currents do not make sense with cdim > 1 or non-periodic boundary conditions.
+      assert(false);
+    }
+    f->use_ghost_current = true; 
+    f->ghost_current = mkarr(app->use_gpu, 1, app->local_ext.volume);
+    if (app->use_gpu) {
+      f->red_ghost_current = gkyl_cu_malloc(sizeof(double[1]));
+    } 
+  }
+
   // allocate buffer for applying BCs 
   long buff_sz = 0;
   // compute buffer size needed
@@ -244,6 +257,25 @@ vm_field_accumulate_current(gkyl_vlasov_app *app,
 
     vm_species_moment_calc(&s->m1i, s->local, app->local, fin[i]);
     gkyl_array_accumulate_range(emout, -qbyeps, s->m1i.marr, &app->local);
+
+    if (app->field->use_ghost_current) {
+      double avals_ghost_current[1], avals_ghost_current_global[1]; 
+      // First set the scalar ghost current array to the cell average 
+      // current/(epsilon0*nx) where nx is the number of x cells. 
+      gkyl_array_set_range(app->field->ghost_current, qbyeps/app->grid.cells[0], s->m1i.marr, &app->local); 
+      // Integrate the current over the whole domain to find the globally averaged ghost current. 
+      if (app->use_gpu) {
+        gkyl_array_reduce_range(app->field->red_ghost_current, app->field->ghost_current, GKYL_SUM, &app->local);
+        gkyl_cu_memcpy(avals_ghost_current, app->field->red_ghost_current, sizeof(double[1]), GKYL_CU_MEMCPY_D2H);
+      }
+      else { 
+        gkyl_array_reduce_range(avals_ghost_current, app->field->ghost_current, GKYL_SUM, &app->local);
+      }
+      gkyl_comm_allreduce_host(app->comm, GKYL_DOUBLE, GKYL_SUM, 1, avals_ghost_current, avals_ghost_current_global);
+      // Set the scalar ghost current array to the global average current and accumulate to the electric field. 
+      gkyl_array_clear(app->field->ghost_current, avals_ghost_current_global[0]);
+      gkyl_array_accumulate_range(emout, 1.0, app->field->ghost_current, &app->local);   
+    }    
   } 
   // Accumulate applied current to electric field terms
   // *Only* accumulate applied currents if num_fluid_species = 0 and there is no fluid-EM coupling.
@@ -415,6 +447,14 @@ vm_field_release(const gkyl_vlasov_app* app, struct vm_field *f)
   else {
     gkyl_free(f->omegaCfl_ptr);
   }
+
+  if (f->use_ghost_current) {
+    gkyl_array_release(f->ghost_current); 
+    if (app->use_gpu) {
+      gkyl_cu_free(f->red_ghost_current); 
+    }
+  }
+
   // Copy BCs are allocated by default. Need to free.
   for (int d=0; d<app->cdim; ++d) {
     gkyl_bc_basic_release(f->bc_lo[d]);

--- a/regression/lua/rt_vlasov_buneman_1x1v_p2.lua
+++ b/regression/lua/rt_vlasov_buneman_1x1v_p2.lua
@@ -1,0 +1,171 @@
+-- Buneman instability with the Vlasov-Maxwell system of equations. 
+-- Input parameters match the initial conditions found in entry JE33 of Ammar's Simulation Journal 
+-- (https://ammar-hakim.org/sj/je/je33/je33-buneman.html)
+-- As discussed in JE33, solving for the Buneman instability with the Vlasov-Maxwell system
+-- requires the introduction of "ghost" currents which cancel the net current in the system
+-- so that Ampere's Law dE/dt = -J/epsilon0 is equivalent to solving a Poisson equation 
+-- with periodic boundary conditions. 
+local Vlasov = G0.Vlasov
+
+-- Mathematical constants (dimensionless).
+pi = math.pi
+
+-- Physical constants (using normalized code units).
+epsilon0 = 1.0 -- Permittivity of free space.
+mass_elc = 1.0 -- Electron mass.
+mass_ion = 25.0 -- Ion mass. 
+charge_elc = -1.0 -- Electron charge.
+charge_ion = 1.0 -- Ion charge. 
+
+n0 = 1.0 -- Reference number density.
+Vx_drift_elc = 0.159 -- Electron drift velocity.
+Vx_drift_ion = 0.0 -- Ion drift velocity
+vte = 0.02 -- Electron thermal velocity.
+vti = 0.001 -- Ion thermal velocity. 
+
+alpha = 1.0e-6 -- Applied perturbation amplitude.
+
+-- Derived physical quantities (using normalized code units).
+Te = vte^2*mass_elc -- Electron temperature. 
+Ti = vti^2*mass_ion -- Ion temperature. 
+omega_pe = math.sqrt((charge_elc * charge_elc) * n0 / (epsilon0 * mass_elc)) -- Electron plasma frequency.
+lambda_D = vte / omega_pe -- Electron Debye length.
+
+k0 = 1.0 -- Perturbed wave number.
+
+-- Simulation parameters.
+Nx = 32 -- Cell count (configuration space: x-direction).
+Nvx = 128 -- Cell count (velocity space: vx-direction).
+Lx = 1.0 -- Domain size (configuration space: x-direction).
+vx_max_elc = 6.0 * Vx_drift_elc -- Domain boundary (velocity space: vx-direction).
+vx_max_ion = 128.0 * vti -- Domain boundary (velocity space: vx-direction).
+poly_order = 2 -- Polynomial order.
+basis_type = "serendipity" -- Basis function set.
+time_stepper = "rk3" -- Time integrator.
+cfl_frac = 0.9 -- CFL coefficient.
+
+t_end = 150.0 -- Final simulation time.
+num_frames = 150 -- Number of output frames.
+field_energy_calcs = GKYL_MAX_INT -- Number of times to calculate field energy.
+integrated_mom_calcs = GKYL_MAX_INT -- Number of times to calculate integrated moments.
+integrated_L2_f_calcs = GKYL_MAX_INT -- Number of times to calculate L2 norm of distribution function.
+dt_failure_tol = 1.0e-4 -- Minimum allowable fraction of initial time-step.
+num_failures_max = 20 -- Maximum allowable number of consecutive small time-steps.
+
+vlasovApp = Vlasov.App.new {
+
+  tEnd = t_end,
+  nFrame = num_frames,
+  fieldEnergyCalcs = field_energy_calcs,
+  integratedL2fCalcs = integrated_L2_f_calcs,
+  integratedMomentCalcs = integrated_mom_calcs,
+  dtFailureTol = dt_failure_tol,
+  numFailuresMax = num_failures_max,
+  lower = { 0.0 },
+  upper = { Lx },
+  cells = { Nx },
+  cflFrac = cfl_frac,
+
+  basis = basis_type,
+  polyOrder = poly_order,
+  timeStepper = time_stepper,
+
+  -- Decomposition for configuration space.
+  decompCuts = { 1 }, -- Cuts in each coodinate direction (x-direction only).
+
+  -- Boundary conditions for configuration space.
+  periodicDirs = { 1 }, -- Periodic directions (x-direction only).
+
+  -- Electrons.
+  elc = Vlasov.Species.new {
+    modelID = G0.Model.Default,
+    charge = charge_elc, mass = mass_elc,
+    
+    -- Velocity space grid.
+    lower = { -vx_max_elc },
+    upper = { vx_max_elc },
+    cells = { Nvx },
+
+    -- Initial conditions.
+    numInit = 1,
+    projections = {
+      {
+        projectionID = G0.Projection.LTE,
+
+        densityInit = function (t, xn)
+          local x = xn[1]
+          return n0*(1.0 + alpha * math.cos(2 * pi *k0 * x)) -- Electron total number density.
+        end,
+        temperatureInit = function (t, xn)
+          return Te -- Electron isotropic temperature.
+        end,
+        driftVelocityInit = function (t, xn)
+          return Vx_drift_elc -- Electron drift velocity.
+        end
+      }
+    },
+
+    evolve = true, -- Evolve species?
+    diagnostics = { "M0", "M1i", "M2" }
+  },
+
+  -- Ions.
+  ion = Vlasov.Species.new {
+    modelID = G0.Model.Default,
+    charge = charge_ion, mass = mass_ion,
+    
+    -- Velocity space grid.
+    lower = { -vx_max_ion },
+    upper = { vx_max_ion },
+    cells = { Nvx },
+
+    -- Initial conditions.
+    numInit = 1,
+    projections = {
+      {
+        projectionID = G0.Projection.LTE,
+
+        densityInit = function (t, xn)
+          return n0 -- Ion total number density.
+        end,
+        temperatureInit = function (t, xn)
+          return Ti -- Ion isotropic temperature.
+        end,
+        driftVelocityInit = function (t, xn)
+          return Vx_drift_ion -- Ion drift velocity.
+        end
+      }
+    },
+
+    evolve = true, -- Evolve species?
+    diagnostics = { "M0", "M1i", "M2" }
+  },
+
+
+  -- Field.
+  field = Vlasov.Field.new {
+    epsilon0 = epsilon0, mu0 = mu0,
+    useGhostCurrent = true, 
+
+    -- Initial conditions function.
+    init = function (t, xn)
+      local x = xn[1]
+
+      local Ex = -alpha * math.sin(2 * pi *k0 * x) / k0 -- Total electric field (x-direction).
+      local Ey = 0.0 -- Total electric field (y-direction).
+      local Ez = 0.0 -- Total electric field (z-direction).
+
+      local Bx = 0.0 -- Total magnetic field (x-direction).
+      local By = 0.0 -- Total magnetic field (y-direction).
+      local Bz = 0.0 -- Total magnetic field (z-direction).
+
+      return Ex, Ey, Ez, Bx, By, Bz, 0.0, 0.0
+    end,
+    
+    evolve = true, -- Evolve field?
+    elcErrorSpeedFactor = 0.0,
+    mgnErrorSpeedFactor = 0.0
+  }
+}
+
+vlasovApp:run()

--- a/regression/lua/rt_vp_buneman_1x1v_p2.lua
+++ b/regression/lua/rt_vp_buneman_1x1v_p2.lua
@@ -1,0 +1,157 @@
+-- Buneman instability with the Vlasov-Poisson system of equations. 
+-- Input parameters match the initial conditions found in entry JE33 of Ammar's Simulation Journal 
+-- (https://ammar-hakim.org/sj/je/je33/je33-buneman.html)
+local Vlasov = G0.Vlasov
+
+-- Mathematical constants (dimensionless).
+pi = math.pi
+
+-- Physical constants (using normalized code units).
+epsilon0 = 1.0 -- Permittivity of free space.
+mass_elc = 1.0 -- Electron mass.
+mass_ion = 25.0 -- Ion mass. 
+charge_elc = -1.0 -- Electron charge.
+charge_ion = 1.0 -- Ion charge. 
+
+n0 = 1.0 -- Reference number density.
+Vx_drift_elc = 0.159 -- Electron drift velocity.
+Vx_drift_ion = 0.0 -- Ion drift velocity
+vte = 0.02 -- Electron thermal velocity.
+vti = 0.001 -- Ion thermal velocity. 
+
+alpha = 1.0e-6 -- Applied perturbation amplitude.
+
+-- Derived physical quantities (using normalized code units).
+Te = vte^2*mass_elc -- Electron temperature. 
+Ti = vti^2*mass_ion -- Ion temperature. 
+omega_pe = math.sqrt((charge_elc * charge_elc) * n0 / (epsilon0 * mass_elc)) -- Electron plasma frequency.
+lambda_D = vte / omega_pe -- Electron Debye length.
+
+k0 = 1.0 -- Perturbed wave number.
+
+-- Simulation parameters.
+Nx = 32 -- Cell count (configuration space: x-direction).
+Nvx = 128 -- Cell count (velocity space: vx-direction).
+Lx = 1.0 -- Domain size (configuration space: x-direction).
+vx_max_elc = 6.0 * Vx_drift_elc -- Domain boundary (velocity space: vx-direction).
+vx_max_ion = 128.0 * vti -- Domain boundary (velocity space: vx-direction).
+poly_order = 2 -- Polynomial order.
+basis_type = "serendipity" -- Basis function set.
+time_stepper = "rk3" -- Time integrator.
+cfl_frac = 0.9 -- CFL coefficient.
+
+t_end = 150.0 -- Final simulation time.
+num_frames = 1 -- Number of output frames.
+field_energy_calcs = GKYL_MAX_INT -- Number of times to calculate field energy.
+integrated_mom_calcs = GKYL_MAX_INT -- Number of times to calculate integrated moments.
+integrated_L2_f_calcs = GKYL_MAX_INT -- Number of times to calculate L2 norm of distribution function.
+dt_failure_tol = 1.0e-4 -- Minimum allowable fraction of initial time-step.
+num_failures_max = 20 -- Maximum allowable number of consecutive small time-steps.
+
+vlasovApp = Vlasov.App.new {
+
+  tEnd = t_end,
+  nFrame = num_frames,
+  fieldEnergyCalcs = field_energy_calcs,
+  integratedL2fCalcs = integrated_L2_f_calcs,
+  integratedMomentCalcs = integrated_mom_calcs,
+  dtFailureTol = dt_failure_tol,
+  numFailuresMax = num_failures_max,
+  lower = { 0.0 },
+  upper = { Lx },
+  cells = { Nx },
+  cflFrac = cfl_frac,
+
+  basis = basis_type,
+  polyOrder = poly_order,
+  timeStepper = time_stepper,
+
+  -- Decomposition for configuration space.
+  decompCuts = { 1 }, -- Cuts in each coodinate direction (x-direction only).
+
+  -- Boundary conditions for configuration space.
+  periodicDirs = { 1 }, -- Periodic directions (x-direction only).
+
+  -- Electrons.
+  elc = Vlasov.Species.new {
+    modelID = G0.Model.Default,
+    charge = charge_elc, mass = mass_elc,
+    
+    -- Velocity space grid.
+    lower = { -vx_max_elc },
+    upper = { vx_max_elc },
+    cells = { Nvx },
+
+    -- Initial conditions.
+    numInit = 1,
+    projections = {
+      {
+        projectionID = G0.Projection.LTE,
+
+        densityInit = function (t, xn)
+          local x = xn[1]
+          return n0*(1.0 + alpha * math.cos(2 * pi *k0 * x)) -- Electron total number density.
+        end,
+        temperatureInit = function (t, xn)
+          return Te -- Electron isotropic temperature.
+        end,
+        driftVelocityInit = function (t, xn)
+          return Vx_drift_elc -- Electron drift velocity.
+        end
+      }
+    },
+
+    evolve = true, -- Evolve species?
+    diagnostics = { "M0", "M1i", "M2" }
+  },
+
+  -- Ions.
+  ion = Vlasov.Species.new {
+    modelID = G0.Model.Default,
+    charge = charge_ion, mass = mass_ion,
+    
+    -- Velocity space grid.
+    lower = { -vx_max_ion },
+    upper = { vx_max_ion },
+    cells = { Nvx },
+
+    -- Initial conditions.
+    numInit = 1,
+    projections = {
+      {
+        projectionID = G0.Projection.LTE,
+
+        densityInit = function (t, xn)
+          return n0 -- Ion total number density.
+        end,
+        temperatureInit = function (t, xn)
+          return Ti -- Ion isotropic temperature.
+        end,
+        driftVelocityInit = function (t, xn)
+          return Vx_drift_ion -- Ion drift velocity.
+        end
+      }
+    },
+
+    evolve = true, -- Evolve species?
+    diagnostics = { "M0", "M1i", "M2" }
+  },
+
+  isElectrostatic = true,
+
+  -- Field.
+  field = Vlasov.Field.new {
+    epsilon0 = epsilon0,
+
+    poissonBcs = {
+      lowerType = {
+        G0.PoissonBc.bcPeriodic
+      },
+      upperType = {
+        G0.PoissonBc.bcPeriodic
+      }
+    }
+  }
+}
+
+vlasovApp:run()


### PR DESCRIPTION
As part of my continued desire for every bit of Ammar's simulation journal to be a regression test within the code so that no confusion arises between old versions and new versions of Gkeyll, I am reintroducing the ghost currents capabilities with the same optional useGhostCurrents functionality in the input files. Also include both a Vlasov-Poisson and Vlasov-Maxwell + ghost currents Buneman instability test.