### PR TITLE
Modify the kernels to calculate BGK cross primitive moments. 

### DIFF
--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p1.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p1.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p1(const double betaGre
   double T2[2] = {0.0}; 
   double T3[2] = {0.0}; 
   double cVtsq[2] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_1d_ser_p1(n_s, nu_sr, msNsNusr); 
   binop_mul_1d_ser_p1(n_r, nu_rs, mrNrNurs); 
@@ -76,9 +76,9 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p1(const double betaGre
   vtsq_sr[1] = vtsq_s[1] + cVtsq[1]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= -0.5*(2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.5*(2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (-0.5*(2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.5*(2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 

--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p2.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p2.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p2(const double betaGre
   double T2[3] = {0.0}; 
   double T3[3] = {0.0}; 
   double cVtsq[3] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_1d_ser_p2(n_s, nu_sr, msNsNusr); 
   binop_mul_1d_ser_p2(n_r, nu_rs, mrNrNurs); 
@@ -86,9 +86,9 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x1v_ser_p2(const double betaGre
   vtsq_sr[2] = vtsq_s[2] + cVtsq[2]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= 0.7071067811865475*(2.23606797749979*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]+vtsq_sr[0]); 
-  prod *= 0.7071067811865475*(2.23606797749979*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]+vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (0.7071067811865475*(2.23606797749979*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.7071067811865475*(2.23606797749979*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 

--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p1.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p1.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p1(const double betaGre
   double T2[2] = {0.0}; 
   double T3[2] = {0.0}; 
   double cVtsq[2] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_1d_ser_p1(n_s, nu_sr, msNsNusr); 
   binop_mul_1d_ser_p1(n_r, nu_rs, mrNrNurs); 
@@ -76,9 +76,9 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p1(const double betaGre
   vtsq_sr[1] = vtsq_s[1] + cVtsq[1]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= -0.5*(2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.5*(2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (-0.5*(2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.5*(2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 

--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p2.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p2.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p2(const double betaGre
   double T2[3] = {0.0}; 
   double T3[3] = {0.0}; 
   double cVtsq[3] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_1d_ser_p2(n_s, nu_sr, msNsNusr); 
   binop_mul_1d_ser_p2(n_r, nu_rs, mrNrNurs); 
@@ -86,9 +86,9 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_1x2v_ser_p2(const double betaGre
   vtsq_sr[2] = vtsq_s[2] + cVtsq[2]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= 0.7071067811865475*(2.23606797749979*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]+vtsq_sr[0]); 
-  prod *= 0.7071067811865475*(2.23606797749979*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]+vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (0.7071067811865475*(2.23606797749979*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.7071067811865475*(2.23606797749979*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 

--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_2x2v_ser_p1.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_2x2v_ser_p1.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_2x2v_ser_p1(const double betaGre
   double T2[4] = {0.0}; 
   double T3[4] = {0.0}; 
   double cVtsq[4] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_2d_ser_p1(n_s, nu_sr, msNsNusr); 
   binop_mul_2d_ser_p1(n_r, nu_rs, mrNrNurs); 
@@ -96,11 +96,11 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_2x2v_ser_p1(const double betaGre
   vtsq_sr[3] = vtsq_s[3] + cVtsq[3]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= 0.5*(3.0*vtsq_sr[3]-1.732050807568877*(vtsq_sr[2]+vtsq_sr[1])+vtsq_sr[0]); 
-  prod *= -0.5*(3.0*vtsq_sr[3]+1.732050807568877*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]-1.0*vtsq_sr[0]); 
-  prod *= -0.5*(3.0*vtsq_sr[3]-1.732050807568877*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]-1.0*vtsq_sr[0]); 
-  prod *= 0.5*(3.0*vtsq_sr[3]+1.732050807568877*(vtsq_sr[2]+vtsq_sr[1])+vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (0.5*(3.0*vtsq_sr[3]-1.732050807568877*(vtsq_sr[2]+vtsq_sr[1])+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (-0.5*(3.0*vtsq_sr[3]+1.732050807568877*vtsq_sr[2]-1.732050807568877*vtsq_sr[1]-1.0*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (-0.5*(3.0*vtsq_sr[3]-1.732050807568877*vtsq_sr[2]+1.732050807568877*vtsq_sr[1]-1.0*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.5*(3.0*vtsq_sr[3]+1.732050807568877*(vtsq_sr[2]+vtsq_sr[1])+vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 

--- a/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_3x2v_ser_p1.c
+++ b/kernels/bgk/gyrokinetic_cross_prim_moms_bgk_3x2v_ser_p1.c
@@ -37,7 +37,7 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_3x2v_ser_p1(const double betaGre
   double T2[8] = {0.0}; 
   double T3[8] = {0.0}; 
   double cVtsq[8] = {0.0}; 
-  double prod = 1.0; 
+  bool negative_cross_temp = false; 
 
   binop_mul_3d_ser_p1(n_s, nu_sr, msNsNusr); 
   binop_mul_3d_ser_p1(n_r, nu_rs, mrNrNurs); 
@@ -136,15 +136,15 @@ GKYL_CU_DH void gyrokinetic_cross_prim_moms_bgk_3x2v_ser_p1(const double betaGre
   vtsq_sr[7] = vtsq_s[7] + cVtsq[7]/dv; 
  
   // If vtsq_sr is negative at a corner, turn off collisions.
-  prod *= -0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*(vtsq_sr[6]+vtsq_sr[5]+vtsq_sr[4])+2.449489742783178*(vtsq_sr[3]+vtsq_sr[2]+vtsq_sr[1])-1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*vtsq_sr[6]-4.242640687119286*(vtsq_sr[5]+vtsq_sr[4])-2.449489742783178*(vtsq_sr[3]+vtsq_sr[2])+2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*vtsq_sr[6]+4.242640687119286*vtsq_sr[5]-4.242640687119286*vtsq_sr[4]-2.449489742783178*vtsq_sr[3]+2.449489742783178*vtsq_sr[2]-2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]); 
-  prod *= -0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*(vtsq_sr[6]+vtsq_sr[5])-4.242640687119286*vtsq_sr[4]+2.449489742783178*vtsq_sr[3]-2.449489742783178*(vtsq_sr[2]+vtsq_sr[1])-1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*(vtsq_sr[6]+vtsq_sr[5])+4.242640687119286*vtsq_sr[4]+2.449489742783178*vtsq_sr[3]-2.449489742783178*(vtsq_sr[2]+vtsq_sr[1])+1.414213562373095*vtsq_sr[0]); 
-  prod *= -0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*vtsq_sr[6]-4.242640687119286*vtsq_sr[5]+4.242640687119286*vtsq_sr[4]-2.449489742783178*vtsq_sr[3]+2.449489742783178*vtsq_sr[2]-2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]); 
-  prod *= -0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*vtsq_sr[6]+4.242640687119286*(vtsq_sr[5]+vtsq_sr[4])-2.449489742783178*(vtsq_sr[3]+vtsq_sr[2])+2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]); 
-  prod *= 0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*(vtsq_sr[6]+vtsq_sr[5]+vtsq_sr[4])+2.449489742783178*(vtsq_sr[3]+vtsq_sr[2]+vtsq_sr[1])+1.414213562373095*vtsq_sr[0]); 
-  if (prod <= 0) { 
+  if (-0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*(vtsq_sr[6]+vtsq_sr[5]+vtsq_sr[4])+2.449489742783178*(vtsq_sr[3]+vtsq_sr[2]+vtsq_sr[1])-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*vtsq_sr[6]-4.242640687119286*(vtsq_sr[5]+vtsq_sr[4])-2.449489742783178*(vtsq_sr[3]+vtsq_sr[2])+2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*vtsq_sr[6]+4.242640687119286*vtsq_sr[5]-4.242640687119286*vtsq_sr[4]-2.449489742783178*vtsq_sr[3]+2.449489742783178*vtsq_sr[2]-2.449489742783178*vtsq_sr[1]+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (-0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*(vtsq_sr[6]+vtsq_sr[5])-4.242640687119286*vtsq_sr[4]+2.449489742783178*vtsq_sr[3]-2.449489742783178*(vtsq_sr[2]+vtsq_sr[1])-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*(vtsq_sr[6]+vtsq_sr[5])+4.242640687119286*vtsq_sr[4]+2.449489742783178*vtsq_sr[3]-2.449489742783178*(vtsq_sr[2]+vtsq_sr[1])+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (-0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*vtsq_sr[6]-4.242640687119286*vtsq_sr[5]+4.242640687119286*vtsq_sr[4]-2.449489742783178*vtsq_sr[3]+2.449489742783178*vtsq_sr[2]-2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (-0.25*(7.348469228349534*vtsq_sr[7]-4.242640687119286*vtsq_sr[6]+4.242640687119286*(vtsq_sr[5]+vtsq_sr[4])-2.449489742783178*(vtsq_sr[3]+vtsq_sr[2])+2.449489742783178*vtsq_sr[1]-1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (0.25*(7.348469228349534*vtsq_sr[7]+4.242640687119286*(vtsq_sr[6]+vtsq_sr[5]+vtsq_sr[4])+2.449489742783178*(vtsq_sr[3]+vtsq_sr[2]+vtsq_sr[1])+1.414213562373095*vtsq_sr[0]) < 0.0) negative_cross_temp = true; 
+  if (negative_cross_temp) { 
     upar_sr[0] = upar_s[0]; 
     vtsq_sr[0] = vtsq_s[0]; 
     upar_sr[1] = upar_s[1]; 


### PR DESCRIPTION
Modify the condition of turning off cross collision. It used to turn off cross collision when the product of vtsq_sr at each corner is negative, which is wrong because the product can be positive when vtsq_sr is negative at even number of corners. Now it turns off cross collision when vtsq_sr is negative at any quadrature point.