### PR TITLE
fix of logical in gk_field.c

### DIFF
--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -358,7 +358,7 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
       1, GKYL_ARRAY_INTEGRATE_OP_SQ, app->use_gpu);
   }
   else {
-    if (!f->gkfield_id == GKYL_GK_FIELD_BOLTZMANN)
+    if (f->gkfield_id != GKYL_GK_FIELD_BOLTZMANN)
       gkyl_array_set(f->es_energy_fac, 0.5, f->epsilon);
 
     f->calc_em_energy = gkyl_array_integrate_new(&app->grid, &app->basis, 


### PR DESCRIPTION
Small fix in logical that I found thanks to a CPU compilation warning.

BTW: I recommend to compile using `make -j 12 install > mk.out` so that the normal output is redirected to the `mk.out` file. In that way, the terminal displays only the warnings and error and it's much easier to catch them that way.

E.g. when I compiled the main I just had:
```
ahoffman@ahoffman-lt ~/g/gkylzero (main)> make -j 12 install > mk.out
apps/gk_field.c:361:9: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
  361 |     if (!f->gkfield_id == GKYL_GK_FIELD_BOLTZMANN)
      |         ^              ~~
apps/gk_field.c:361:9: note: add parentheses after the '!' to evaluate the comparison first
  361 |     if (!f->gkfield_id == GKYL_GK_FIELD_BOLTZMANN)
      |         ^                                        
      |          (                                       )
apps/gk_field.c:361:9: note: add parentheses around left hand side expression to silence this warning
  361 |     if (!f->gkfield_id == GKYL_GK_FIELD_BOLTZMANN)
      |         ^
      |         (             )
1 warning generated.
ahoffman@ahoffman-lt ~/g/gkylzero (main)>
```