### PR TITLE
Create a species metric in Canonical PB neutrals to fix projections/moments

### DIFF
--- a/apps/gk_neut_species_moment.c
+++ b/apps/gk_neut_species_moment.c
@@ -12,8 +12,6 @@ gk_neut_species_moment_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_spe
 
   sm->is_maxwellian_moms = strcmp("LTEMoments", nm) == 0;
   if (sm->is_maxwellian_moms) {
-    struct gkyl_array *g_ij = app->cdim < 3 ? app->gk_geom->g_ij_neut : app->gk_geom->g_ij; 
-    struct gkyl_array *gij = app->cdim < 3 ? app->gk_geom->gij_neut : app->gk_geom->gij; 
     struct gkyl_vlasov_lte_moments_inp inp_mom = {
       .phase_grid = &s->grid,
       .vel_grid = &s->grid_vel, 
@@ -23,8 +21,8 @@ gk_neut_species_moment_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_spe
       .conf_range_ext = &app->local_ext,
       .vel_range = &s->local_vel,
       .phase_range = &s->local,
-      .h_ij = g_ij,
-      .h_ij_inv = gij,
+      .h_ij = s->g_ij,
+      .h_ij_inv = s->gij,
       .det_h = app->gk_geom->jacobgeo,
       .hamil = s->hamil,
       .model_id = s->model_id,

--- a/apps/gk_neut_species_projection.c
+++ b/apps/gk_neut_species_projection.c
@@ -102,10 +102,6 @@ gk_neut_species_projection_calc(gkyl_gyrokinetic_app *app, const struct gk_neut_
     gkyl_proj_on_basis_advance(proj->proj_temp, tm, &app->local, proj->vtsq);
     gkyl_array_scale(proj->vtsq, 1/s->info.mass);
 
-    // Multiply density by the conf-space jacobian.
-    gkyl_dg_mul_op_range(app->basis, 0, proj->dens, 
-      0, app->gk_geom->jacobgeo, 0, proj->dens, &app->local);
-
     // Projection routines expect the LTE moments as a single array.
     gkyl_array_set_offset(proj->prim_moms_host, 1.0, proj->dens, 0*app->basis.num_basis);
     gkyl_array_set_offset(proj->prim_moms_host, 1.0, proj->udrift, 1*app->basis.num_basis);
@@ -113,6 +109,10 @@ gk_neut_species_projection_calc(gkyl_gyrokinetic_app *app, const struct gk_neut_
 
     // Copy the contents into the array we will use (potentially on GPUs).
     gkyl_array_copy(proj->prim_moms, proj->prim_moms_host);
+
+    // Multiply density by the conf-space jacobian.
+    gkyl_dg_mul_op_range(app->basis, 0, proj->prim_moms, 
+      0, app->gk_geom->jacobgeo, 0, proj->prim_moms, &app->local);
 
     // Project the Maxwellian distribution function.
     // Projection routine also corrects the density of the projected distribution function.

--- a/apps/gk_neut_species_projection.c
+++ b/apps/gk_neut_species_projection.c
@@ -37,9 +37,6 @@ gk_neut_species_projection_init(struct gkyl_gyrokinetic_app *app, struct gk_neut
       s->basis.poly_order+1, 1, inp.temp, inp.ctx_temp);
 
 
-    struct gkyl_array *g_ij = app->cdim < 3 ? app->gk_geom->g_ij_neut : app->gk_geom->g_ij; 
-    struct gkyl_array *gij = app->cdim < 3 ? app->gk_geom->gij_neut : app->gk_geom->gij; 
-
     struct gkyl_vlasov_lte_proj_on_basis_inp inp_proj = {
       .phase_grid = &s->grid,
       .conf_basis = &app->basis,
@@ -49,8 +46,8 @@ gk_neut_species_projection_init(struct gkyl_gyrokinetic_app *app, struct gk_neut
       .vel_range = &s->local_vel,
       .vel_map = s->vel_map,
       .phase_range = &s->local,
-      .h_ij = g_ij,
-      .h_ij_inv = gij,
+      .h_ij = s->g_ij,
+      .h_ij_inv = s->gij,
       .det_h = app->gk_geom->jacobgeo,
       .hamil = s->hamil,
       .model_id = s->model_id,
@@ -70,11 +67,11 @@ gk_neut_species_projection_init(struct gkyl_gyrokinetic_app *app, struct gk_neut
         .conf_range_ext = &app->local_ext,
         .vel_range = &s->local_vel,
         .vel_map = s->vel_map,
-	      .phase_range = &s->local,
-	      .h_ij = g_ij,
-	      .h_ij_inv = gij,
-	      .det_h = app->gk_geom->jacobgeo,
-	      .hamil = s->hamil,	
+        .phase_range = &s->local,
+        .h_ij = s->g_ij,
+        .h_ij_inv = s->gij,
+        .det_h = app->gk_geom->jacobgeo,
+        .hamil = s->hamil,	
         .model_id = s->model_id,
         .use_gpu = app->use_gpu,
         .max_iter = 100,
@@ -100,10 +97,14 @@ gk_neut_species_projection_calc(gkyl_gyrokinetic_app *app, const struct gk_neut_
   }
   else if (proj->proj_id == GKYL_PROJ_MAXWELLIAN_PRIM) {
     int vdim = app->vdim+1;
-    gkyl_proj_on_basis_advance(proj->proj_dens, tm, &app->local_ext, proj->dens); 
-    gkyl_proj_on_basis_advance(proj->proj_udrift, tm, &app->local_ext, proj->udrift);
-    gkyl_proj_on_basis_advance(proj->proj_temp, tm, &app->local_ext, proj->vtsq);
+    gkyl_proj_on_basis_advance(proj->proj_dens, tm, &app->local, proj->dens); 
+    gkyl_proj_on_basis_advance(proj->proj_udrift, tm, &app->local, proj->udrift);
+    gkyl_proj_on_basis_advance(proj->proj_temp, tm, &app->local, proj->vtsq);
     gkyl_array_scale(proj->vtsq, 1/s->info.mass);
+
+    // Multiply density by the conf-space jacobian.
+    gkyl_dg_mul_op_range(app->basis, 0, proj->dens, 
+      0, app->gk_geom->jacobgeo, 0, proj->dens, &app->local);
 
     // Projection routines expect the LTE moments as a single array.
     gkyl_array_set_offset(proj->prim_moms_host, 1.0, proj->dens, 0*app->basis.num_basis);
@@ -124,10 +125,6 @@ gk_neut_species_projection_calc(gkyl_gyrokinetic_app *app, const struct gk_neut_
         f, proj->prim_moms, &s->local, &app->local);
     } 
   }
-
-  // Multiply by the configuration space jacobian.
-  gkyl_dg_mul_conf_phase_op_range(&app->basis, &s->basis, f, 
-    app->gk_geom->jacobgeo, f, &app->local_ext, &s->local_ext);  
 }
 
 void

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -788,6 +788,7 @@ struct gk_neut_species {
   enum gkyl_field_id field_id; // type of field equation (always GKYL_FIELD_NULL)
   enum gkyl_model_id model_id; // type of Vlasov equation (always GKYL_MODEL_CANONICAL_PB)
 
+  struct gkyl_array *g_ij, *gij; // Metric tensor and its conjugate.
   struct gkyl_array *hamil; // Specified hamiltonian function for canonical poisson bracket
   struct gkyl_array *hamil_host; // Host side hamiltonian array for intial projection
   struct gkyl_array *alpha_surf; // array for surface phase space flux (v^i = v . e^i)

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -366,7 +366,7 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
 
   // deflate geometry if necessary
   if (geometry_inp.geometry_id != GKYL_GEOMETRY_FROMFILE) {
-    if(app->cdim < 3)
+    if (app->cdim < 3)
       app->gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, &geometry_inp);
     else
       app->gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);

--- a/kernels/neutral/gk_neut_hamil_1x3v_tensor_p1.c
+++ b/kernels/neutral/gk_neut_hamil_1x3v_tensor_p1.c
@@ -6,12 +6,12 @@ GKYL_CU_DH void gk_neut_hamil_1x3v_tensor_p1(const double *w, const double *dxv,
   // gij[12]:  Contravariant components of metric tensor.
   // hamil:    Gk neut species Hamiltonian.
  
-  const double *g00 = &gij[10]; 
-  const double *g01 = &gij[4]; 
-  const double *g02 = &gij[8]; 
-  const double *g11 = &gij[0]; 
-  const double *g12 = &gij[2]; 
-  const double *g22 = &gij[6]; 
+  const double *g00 = &gij[0]; 
+  const double *g01 = &gij[2]; 
+  const double *g02 = &gij[4]; 
+  const double *g11 = &gij[6]; 
+  const double *g12 = &gij[8]; 
+  const double *g22 = &gij[10]; 
 
   const double w0 = w[1]; 
   const double dv0 = dxv[1]; 

--- a/kernels/neutral/gk_neut_hamil_2x3v_tensor_p1.c
+++ b/kernels/neutral/gk_neut_hamil_2x3v_tensor_p1.c
@@ -7,11 +7,11 @@ GKYL_CU_DH void gk_neut_hamil_2x3v_tensor_p1(const double *w, const double *dxv,
   // hamil:    Gk neut species Hamiltonian.
  
   const double *g00 = &gij[0]; 
-  const double *g01 = &gij[8]; 
-  const double *g02 = &gij[4]; 
-  const double *g11 = &gij[20]; 
+  const double *g01 = &gij[4]; 
+  const double *g02 = &gij[8]; 
+  const double *g11 = &gij[12]; 
   const double *g12 = &gij[16]; 
-  const double *g22 = &gij[12]; 
+  const double *g22 = &gij[20]; 
 
   const double w0 = w[2]; 
   const double dv0 = dxv[2]; 

--- a/kernels/neutral/gk_neut_hamil_3x3v_tensor_p1.c
+++ b/kernels/neutral/gk_neut_hamil_3x3v_tensor_p1.c
@@ -1,6 +1,5 @@
 #include <gkyl_dg_gk_neut_hamil_kernels.h> 
-GKYL_CU_DH
-void gk_neut_hamil_3x3v_tensor_p1(const double *w, const double *dxv, const double *gij, double* GKYL_RESTRICT hamil) 
+GKYL_CU_DH void gk_neut_hamil_3x3v_tensor_p1(const double *w, const double *dxv, const double *gij, double* GKYL_RESTRICT hamil) 
 { 
   // w:        Cell-center coordinates.
   // dxv:      Cell spacing.

--- a/regression/rt_gk_step_2x2v_p1_cons.c
+++ b/regression/rt_gk_step_2x2v_p1_cons.c
@@ -244,7 +244,7 @@ create_ctx(void)
   double vpar_max_ion = 4.0*vtIon;
   double mu_max_ion = 12*mi*vtIon*vtIon/(2.0*B0);
 
-  double vpar_max_D0 = 8.0*vtD0;
+  double vpar_max_D0 = 4.0*vtD0;
 
 
   // Number of cells.
@@ -591,8 +591,8 @@ main(int argc, char **argv)
     // neutral Deuterium
   struct gkyl_gyrokinetic_neut_species D0 = {
     .name = "D0", .mass = ctx.massIon,
-    .lower = { -ctx.vpar_max_D0, -ctx.vpar_max_D0, -ctx.vpar_max_D0},
-    .upper = { ctx.vpar_max_D0, ctx.vpar_max_D0, ctx.vpar_max_D0 },
+    .lower = { -ctx.vpar_max_D0, -ctx.vpar_max_D0*3.0, -ctx.vpar_max_D0*4.0},
+    .upper = { ctx.vpar_max_D0, ctx.vpar_max_D0*3.0, ctx.vpar_max_D0*4.0 },
     .cells = { cells_v[0], cells_v[0], cells_v[0] },
     .is_static = false,
 
@@ -678,8 +678,8 @@ main(int argc, char **argv)
 	    },
     },
     
-    .num_diag_moments = 3,
-    .diag_moments = { "M0", "M1i", "M2"}, //, "M2par", "M2perp" },
+    .num_diag_moments = 4,
+    .diag_moments = { "M0", "M1i", "M2", "LTEMoments"},
   };
 
 

--- a/zero/calc_metric.c
+++ b/zero/calc_metric.c
@@ -297,7 +297,7 @@ void gkyl_calc_metric_advance_rz_neut(
               grFld_n[1] = 0.0;
               grFld_n[2] = R*R/jac/jac*(dxdz[0][0]*dxdz[0][2] + dxdz[1][0]*dxdz[1][2] );
               grFld_n[3] = 1/jac/jac*(dxdz[0][0]*dxdz[0][0]*dxdz[1][2]*dxdz[1][2] + dxdz[1][0]*dxdz[1][0]*dxdz[0][2]*dxdz[0][2]);
-              grFld_n[3] = 0.0;
+              grFld_n[4] = 0.0;
               grFld_n[5] = R*R/jac/jac*(dxdz[0][0]*dxdz[0][0] + dxdz[1][0]*dxdz[1][0] );
 
       }


### PR DESCRIPTION
This goes with [PR 73 in gkylcas](https://github.com/ammarhakim/gkylcas/pull/73).
Don't merge either before testing your ICs first @akashukla @tnbernard .

The initial temperature is coming out incorrect for Canonical PB neutrals. I suspect that it is incorrect in calculations in the time loop too. My hypothesis is that this is happening because the Hamiltonian is computed with a reorganized metric tensor (for cdim<3), but the projection of ICs and/or calculation of moments is using the non-reorganized metric.

Here we fix this by using Hamiltonian-computing kernels that don't reorganize the metric, and instead we give the species its own metric array, which it reorganizes if needed, and the hamiltonian, the projection of ICs, and moment calculators all use this reorganized metric.

NOTE:
I think there's one more requirement to get the correct initial temperature, and to set Canonical PB neutrals overall. The velocity space needs to be set in a way that is not intuitive given how we'd been setting GK v-space grids or Cartesian neutral v-space grids, because the velocity coordinates for Canonical PB neutrals are not as intuitive anymore. So the velocity limits may not be as simple as
```
.lower = {-vmax, -vmax, -vmax },
.upper = { vmax,  vmax,  vmax },
```
and may actually depend on the geometry. Notice for example that in the rt_gk_neut_recycle_1x3v test with polar coordinates we use
```
.lower = {-vmax, -vmax, -vmax/64 },
.upper = { vmax,  vmax,  vmax/64 },
```
but this factor of 1/64 is actually dependent on what radius we are trying to do a sim at (i.e. the `.world` argument in the geometry table).