### PR TITLE
Re-enable diagnostics for the spatially dependent collision frequency

### DIFF
--- a/apps/gk_species_lbo.c
+++ b/apps/gk_species_lbo.c
@@ -318,7 +318,7 @@ gk_species_lbo_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, doub
     app->stat.n_diag_io += 1;   
 
     // Uncomment the following to write out nu_sum and nu_prim_moms
-    /*const char *fmt = "%s-%s_nu_sum_%d.gkyl";
+    const char *fmt = "%s-%s_nu_sum_%d.gkyl";
     int sz = gkyl_calc_strlen(fmt, app->name, gks->info.name, frame);
     char fileNm[sz+1]; // ensures no buffer overflow
     snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, frame);
@@ -329,7 +329,7 @@ gk_species_lbo_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, doub
     snprintf(fileNm_nu_prim, sizeof fileNm_nu_prim, fmt_nu_prim, app->name, gks->info.name, frame);
     
     if (gks->lbo.num_cross_collisions)
-      gk_species_lbo_cross_moms(app, gk_s, &gks->lbo, gks->f);
+      gk_species_lbo_cross_moms(app, gks, &gks->lbo, gks->f);
     
     // copy data from device to host before writing it out
     if (app->use_gpu) {
@@ -338,7 +338,7 @@ gk_species_lbo_write_mom(gkyl_gyrokinetic_app* app, struct gk_species *gks, doub
     }
     
     gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.nu_sum_host, fileNm);
-    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.nu_prim_moms_host, fileNm_nu_prim);*/
+    gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, gks->lbo.nu_prim_moms_host, fileNm_nu_prim);
 
     gk_array_meta_release(mt); 
   }

--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -632,6 +632,7 @@ int main(int argc, char **argv)
       .self_nu = evalNuElc,
       .num_cross_collisions = 1,
       .collide_with = { "ion" },
+      .write_diagnostics = true,
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
@@ -683,6 +684,7 @@ int main(int argc, char **argv)
       .self_nu = evalNuIon,
       .num_cross_collisions = 1,
       .collide_with = { "elc" },
+      .write_diagnostics = true,
     },
     .source = {
       .source_id = GKYL_PROJ_SOURCE,


### PR DESCRIPTION
# Feature

## Summary

Purpose: This code already existed. I want to re-enable it so I can look at the collision frequency in the mirror simulations. I checked and this runs on the regression test on CPU.

## Community Standards

- [ ] Documentation has been updated.
- [x] My code follows the project's coding guidelines.
- [x] Changes to `/zero` should have a unit test.

## Testing: 

- [x] I added a regression test to test this feature.
- [x] I added this feature to an existing regression test.
- [ ] I added a unit test to test this feature.
- [ ] Ran `make check` and unit tests all pass.
- [ ] I ran the code through Valgrind, and it is clean.
- [x] I ran a few regression tests to ensure no apparent errors.
- [x] Tested and works on CPU.
- [ ] Tested and works on multi-CPU.
- [x] Tested and works on GPU.
- [ ] Tested and works on multi-GPU.

## Additional Notes
