### PR TITLE
--c2p option works with deflated mc2p and mc2nu_pos arrays

### DIFF
--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -835,13 +835,16 @@ gkyl_gyrokinetic_app_write_geometry(gkyl_gyrokinetic_app* app)
 
   // Gather geo into a global array
   struct gkyl_array* arr_ho1 = mkarr(false,   app->basis.num_basis, app->local_ext.volume);
+  struct gkyl_array* arr_hocdim = mkarr(false, app->cdim*app->basis.num_basis, app->local_ext.volume);
   struct gkyl_array* arr_ho3 = mkarr(false, 3*app->basis.num_basis, app->local_ext.volume);
   struct gkyl_array* arr_ho6 = mkarr(false, 6*app->basis.num_basis, app->local_ext.volume);
   struct gkyl_array* arr_ho9 = mkarr(false, 9*app->basis.num_basis, app->local_ext.volume);
 
   struct timespec wtm = gkyl_wall_clock();
   gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->mc2p        , arr_ho3, "mapc2p", mt);
-  gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->mc2nu_pos        , arr_ho3, "mc2nu_pos", mt);
+  gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->mc2p_reduced, arr_hocdim, "mapc2p_reduced", mt);  
+  gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->mc2nu_pos   , arr_ho3, "mc2nu_pos", mt);
+  gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->mc2nu_pos_reduced, arr_hocdim, "mc2nu_pos_reduced", mt);  
   gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->bmag        , arr_ho1, "bmag", mt);
   gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->g_ij        , arr_ho6, "g_ij", mt);
   gyrokinetic_app_geometry_copy_and_write(app, app->gk_geom->dxdz        , arr_ho9, "dxdz", mt);

--- a/zero/array_ops.c
+++ b/zero/array_ops.c
@@ -126,6 +126,30 @@ gkyl_array_set_offset(struct gkyl_array* out, double a,
 }
 
 struct gkyl_array*
+gkyl_array_set_offset_comp(struct gkyl_array* out, double a,
+  const struct gkyl_array* inp, int component_offset_out, 
+  int component_offset_inp, int num_basis)
+{
+  assert(out->type == GKYL_DOUBLE);
+  assert(out->size == inp->size);
+
+#ifdef GKYL_HAVE_CUDA
+  assert(gkyl_array_is_cu_dev(out)==gkyl_array_is_cu_dev(inp));
+  if (gkyl_array_is_cu_dev(out)) { gkyl_array_set_offset_comp_cu(out, a, inp, component_offset_out, component_offset_inp, num_basis); return out; }
+#endif
+
+  int offset_out = component_offset_out * num_basis;
+  int offset_inp = component_offset_inp * num_basis;
+
+  double *out_d = out->data;
+  const double *inp_d = inp->data;
+  for (size_t i=0; i<out->size; ++i)
+    for (size_t d=0; d<num_basis; ++d)
+      out_d[i*NCOM(out)+d+offset_out] = a*inp_d[i*NCOM(inp)+d+offset_inp];
+  return out;
+}
+
+struct gkyl_array*
 gkyl_array_scale(struct gkyl_array* out, double a)
 {
 #ifdef GKYL_HAVE_CUDA

--- a/zero/array_ops_cu.cu
+++ b/zero/array_ops_cu.cu
@@ -93,6 +93,20 @@ gkyl_array_set_offset_cu_kernel(struct gkyl_array* out, double a,
         out_d[linc*NCOM(out)+coff+k] = a*inp_d[linc*NCOM(inp)+k];
   }
 }
+__global__ void
+gkyl_array_set_offset_comp_cu_kernel(struct gkyl_array* out, double a,
+  const struct gkyl_array* inp, int component_offset_out, 
+  int component_offset_inp, int num_basis)
+{
+  int offset_out = component_offset_out * num_basis;
+  int offset_inp = component_offset_inp * num_basis;
+
+  double *out_d = (double*)out->data;
+  const double *inp_d = (const double*)inp->data;
+  for (unsigned long linc = START_ID; linc < NSIZE(out); linc += blockDim.x*gridDim.x)
+    for (size_t d=0; d<num_basis; ++d)
+      out_d[linc*NCOM(out)+d+offset_out] = a*inp_d[linc*NCOM(inp)+d+offset_inp];
+}
 
 __global__ void
 gkyl_array_scale_by_cell_cu_kernel(struct gkyl_array* out, const struct gkyl_array* a)
@@ -142,6 +156,16 @@ gkyl_array_set_offset_cu(struct gkyl_array* out, double a, const struct gkyl_arr
 {
   int nblocks = gkyl_int_div_up(out->size, out->nthreads);
   gkyl_array_set_offset_cu_kernel<<<nblocks, out->nthreads>>>(out->on_dev, a, inp->on_dev, coff);
+}
+
+void
+gkyl_array_set_offset_comp_cu(struct gkyl_array* out, double a,
+  const struct gkyl_array* inp, int component_offset_out, 
+  int component_offset_inp, int num_basis)
+{
+  int nblocks = gkyl_int_div_up(out->size, out->nthreads);
+  gkyl_array_set_offset_comp_cu_kernel<<<nblocks, out->nthreads>>>(out->on_dev, a, inp->on_dev, 
+    component_offset_out, component_offset_inp, num_basis);
 }
 
 void

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -32,7 +32,9 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
+  up->mc2p_reduced = gkyl_array_new(GKYL_DOUBLE, up->grid.ndim*up->basis.num_basis, up->local_ext.volume);
   up->mc2nu_pos = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
+  up->mc2nu_pos_reduced = gkyl_array_new(GKYL_DOUBLE, up->grid.ndim*up->basis.num_basis, up->local_ext.volume);
   up->bmag = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
@@ -241,7 +243,9 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
+  up->mc2p_reduced = gkyl_array_new(GKYL_DOUBLE, up->grid.ndim*up->basis.num_basis, up->local_ext.volume);
   up->mc2nu_pos = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
+  up->mc2nu_pos_reduced = gkyl_array_new(GKYL_DOUBLE, up->grid.ndim*up->basis.num_basis, up->local_ext.volume);
   up->bmag = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->g_ij = gkyl_array_new(GKYL_DOUBLE, 6*up->basis.num_basis, up->local_ext.volume);
   up->dxdz = gkyl_array_new(GKYL_DOUBLE, 9*up->basis.num_basis, up->local_ext.volume);
@@ -301,6 +305,21 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   // Done deflating
   gkyl_deflate_geo_release(deflator);
 
+  if (up->grid.ndim==1) {
+    gkyl_array_set_offset_comp(up->mc2p_reduced, 1.0, up->mc2p, 0, 1, up->basis.num_basis);
+    gkyl_array_set_offset_comp(up->mc2nu_pos_reduced, 1.0, up->mc2nu_pos, 0, 2, up->basis.num_basis);
+  }
+  else if (up->grid.ndim==2) {
+    gkyl_array_set_offset_comp(up->mc2p_reduced, 1.0, up->mc2p, 0, 0, up->basis.num_basis);
+    gkyl_array_set_offset_comp(up->mc2p_reduced, 1.0, up->mc2p, 1, 1, up->basis.num_basis);
+    gkyl_array_set_offset_comp(up->mc2nu_pos_reduced, 1.0, up->mc2nu_pos, 0, 0, up->basis.num_basis);
+    gkyl_array_set_offset_comp(up->mc2nu_pos_reduced, 1.0, up->mc2nu_pos, 1, 2, up->basis.num_basis);
+  }
+  else if (up->grid.ndim==3) {
+    gkyl_array_copy(up->mc2p_reduced, up->mc2p);
+    gkyl_array_copy(up->mc2nu_pos_reduced, up->mc2nu_pos);
+  }
+
   up->flags = 0;
   GKYL_CLEAR_CU_ALLOC(up->flags);
   up->ref_count = gkyl_ref_count_init(gkyl_gk_geometry_free);
@@ -314,7 +333,9 @@ gkyl_gk_geometry_free(const struct gkyl_ref_count *ref)
 {
   struct gk_geometry *up = container_of(ref, struct gk_geometry, ref_count);
   gkyl_array_release(up->mc2p);
+  gkyl_array_release(up->mc2p_reduced);
   gkyl_array_release(up->mc2nu_pos);
+  gkyl_array_release(up->mc2nu_pos_reduced);
   gkyl_array_release(up->bmag);
   gkyl_array_release(up->g_ij);
   gkyl_array_release(up->jacobgeo);

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -356,6 +356,9 @@ void gkyl_array_set_cu(struct gkyl_array* out, double a, const struct gkyl_array
 
 void gkyl_array_set_offset_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp, int coff);
 
+void gkyl_array_set_offset_comp_cu(struct gkyl_array* out, double a, const struct gkyl_array* inp,
+   int component_offset_out,  int component_offset_inp, int num_basis);
+
 void gkyl_array_scale_cu(struct gkyl_array* out, double a);
 
 void gkyl_array_scale_by_cell_cu(struct gkyl_array* out, const struct gkyl_array* a);

--- a/zero/gkyl_array_ops.h
+++ b/zero/gkyl_array_ops.h
@@ -93,6 +93,10 @@ struct gkyl_array* gkyl_array_set(struct gkyl_array *out,
  * Set out = a*inp[coff] where coff is a component-offset if
  * out->ncomp < inp->ncomp, or out[coff] = a*inp if
  * out->ncomp > inp->ncomp. Returns out.
+ * 
+ * Sets all components greater than the coeff offset to the output
+ * e.g. out[0,1,2, ...] = a*inp[2,3,4,...]
+ * where the middle indicies are the different components
  *
  * @param out Output array
  * @param a Factor to multiply input array
@@ -102,6 +106,29 @@ struct gkyl_array* gkyl_array_set(struct gkyl_array *out,
  */
 struct gkyl_array* gkyl_array_set_offset(struct gkyl_array *out,
   double a, const struct gkyl_array *inp, int coff);
+
+/*
+ * Component wise set_offset
+ *
+ * Sets only the specified component of out to the specific
+ * component of inp. Returns out.
+ * Set out[component_offset_out] = a*inp[component_offset_inp]
+ * 
+ * e.g. out[3] = a*inp[2]
+ * where the indicies are the different components
+ * 
+ * @param out Output array
+ * @param a Factor to multiply input array
+ * @param inp Input array
+ * @param component_offset_out Component offset of out
+ * @param component_offset_inp Component offset of inp
+ * @param num_basis Number of basis functions per component
+ * @return out array
+*/
+struct gkyl_array* gkyl_array_set_offset_comp(struct gkyl_array* out,
+  double a, const struct gkyl_array* inp, int component_offset_out, 
+  int component_offset_inp, int num_basis);
+
 
 /**
  * Scale out = a*out. Returns out.

--- a/zero/gkyl_gk_geometry.h
+++ b/zero/gkyl_gk_geometry.h
@@ -27,7 +27,9 @@ struct gk_geometry {
   // GK Equation and Poisson Equation and to apply certain BC's
   // The first 20 are defined on the configuration space domain. The last is a single element.
   struct gkyl_array* mc2p; // 3 components. Cartesian X,Y, and Z
+  struct gkyl_array* mc2p_reduced; // cdim components. Component removed (Z in 1x, R,Z in 2x, R,Z,phi in 3x)
   struct gkyl_array* mc2nu_pos; // 3 components. Uniform computational space to non-uniform computational space mapping
+  struct gkyl_array* mc2nu_pos_reduced; // cdim components. Uniform computational space to non-uniform computational space mapping
   struct gkyl_array* bmag; // 1 component. B Magnitude of magnetic field
   struct gkyl_array* g_ij; // 6 components. 
                            // Metric coefficients g_{ij} Stored in order g_11, g12, g_13, g_22, g_23, g_33


### PR DESCRIPTION
# Bug fix

## Summary

Description: So for a long time, I've been trying to use the `--c2p` option in postgkyl on my mirror simulations. In a 1x simulation, I'd expect the x-axis and coordinate to by cylindrical Z. Instead it would give an error that the interpolation wasn't working. This has puzzled me for a long time and I finally got around to fixing this issue.

Issue link: I was bad and didn't make an issue for this. In the postgkyl repo, it's here https://github.com/ammarhakim/postgkyl/issues/157

## Solution

The issue is that mapc2p is always written as a 3 component array. It always has R,Z,phi. They can either be a function of 1,2, or 3 components, but there are always 3 of them. This is packaged inside mapc2p. Postgkyl expects an array that has the number of components as the dimension of the array. So in 2x, it would expect only to have R,Z or Z,phi. We are giving it too many parts when using --c2p <>-mapc2p.gkyl. The solution is to create a file <>-mapc2p_reduced.gkyl which has selected components removed. Furthermore, we also do this with <>-mc2nu_pos_reduced.gkyl. **This is only intended to be used for plotting purposes**. 

I discussed with @akashukla and it seems reasonable that a 1x simulation would want cylindrical Z and a 2x simulation would look for the R,Z plane. This makes a lot of sense for tokamaks and mirrors, but not so much for mapc2p geometries. We will not consider those because they can be setup in any orientation the user wants. In mapc2p geometry, it will plot y in 1x,  and x,y in 2x. For the non-uniform grids and position maps, <>-mc2nu_pos_reduced.gkyl will plot z in 1x, and x,z in 2x.

Rather than changing postgkyl to work with GK, it is much safer to change GK to fit postgkyl and create plotting-only outputs.

In doing this, I needed to make a new array operation that assigns components of one array to another. The existing operation applies all components > input, but I want to select each component individually. I implemented this on GPU and CPU. Tested and verified with a unit test. I added some comments to the files to clarify what these functions are doing.

This change is very important for plotting non-uniform grids.

Impacted files: 
gyrokinetic.c
gk_geometry.c
array_ops.c
array_ops_cu.cu
ctest_array_ops.c

Automated testing: Unit test is added for the array operation added

## Community Standards

- [x] Documentation has been updated.
- [x] My code follows the project's coding guidelines.
- [x] Changes to `/zero` should have a unit test.

## Testing:

- [ ] I added a regression test to test this feature.
- [x] I added this feature to an existing regression test.
- [x] I added a unit test for this feature.
- [ ] Ran `make check` and unit tests all pass.
- [ ] I ran the code through Valgrind, and it is clean.
- [ ] I ran a few regression tests to ensure no apparent errors.
- [x] Tested and works on CPU.
- [ ] Tested and works on multi-CPU.
- [x] Tested and works on GPU.
- [ ] Tested and works on multi-GPU.

## Additional Notes

Here is an example of the 2x2v mirror regression test being plotted. 
![image](https://github.com/user-attachments/assets/20fa7ef7-5aec-4bc6-9e19-b358a6bc5233)
