### PR TITLE
Fixing LTE moms for gk neut to use correctly ordered g_ij and gij.

### DIFF
--- a/apps/gk_neut_species_lte.c
+++ b/apps/gk_neut_species_lte.c
@@ -10,9 +10,6 @@ gk_neut_species_lte_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_specie
   // allocate moments needed for lte update
   gk_neut_species_moment_init(app, s, &lte->moms, "LTEMoments");
 
-  struct gkyl_array *g_ij = app->cdim < 3 ? app->gk_geom->g_ij_neut : app->gk_geom->g_ij; 
-  struct gkyl_array *gij = app->cdim < 3 ? app->gk_geom->gij_neut : app->gk_geom->gij; 
-
   struct gkyl_vlasov_lte_proj_on_basis_inp inp_proj = {
     .phase_grid = &s->grid,
     .vel_grid = &s->grid_vel, 
@@ -22,8 +19,8 @@ gk_neut_species_lte_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_specie
     .conf_range_ext = &app->local_ext,
     .vel_range = &s->local_vel,
     .phase_range = &s->local,
-    .h_ij = g_ij,
-    .h_ij_inv = gij,
+    .h_ij = s->g_ij,
+    .h_ij_inv = s->gij,
     .det_h = app->gk_geom->jacobgeo,
     .hamil = s->hamil,
     .model_id = s->model_id,
@@ -46,8 +43,8 @@ gk_neut_species_lte_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_specie
       .conf_range_ext = &app->local_ext,
       .vel_range = &s->local_vel,
       .phase_range = &s->local,
-      .h_ij = g_ij,
-      .h_ij_inv = gij,
+      .h_ij = s->g_ij,
+      .h_ij_inv = s->gij,
       .det_h = app->gk_geom->jacobgeo,
       .hamil = s->hamil,
       .model_id = s->model_id,


### PR DESCRIPTION
The 1d tests in cylindrical geometry produces expected results now.

![Screenshot 2025-04-28 at 3 28 02 PM](https://github.com/user-attachments/assets/c6088254-5eb6-491f-a2b2-c140e2b1b690)
