### PR TITLE
Update the normalization of u_par error.

### DIFF
--- a/zero/gk_maxwellian_correct.c
+++ b/zero/gk_maxwellian_correct.c
@@ -168,13 +168,12 @@ gkyl_gk_maxwellian_correct_all_moments(gkyl_gk_maxwellian_correct *up,
           // so that we can converge to the correct target moments in SI units and minimize finite precision issues.
           up->error[0] = fmax(fabs(moms_local[0*nc] - moms_target_local[0*nc])/moms_target_local[0*nc],fabs(up->error[0]));
           up->error[2] = fmax(fabs(moms_local[2*nc] - moms_target_local[2*nc])/moms_target_local[2*nc],fabs(up->error[2]));
-          // However, u_par may be ~ 0 and if it is, we need to use absolute error. We can converge safely using
-          // absolute error if u_par ~ O(1). Otherwise, we use relative error for u_par. 
-          if (fabs(moms_target_local[1*nc]) < 1.0) {
-            up->error[1] = fmax(fabs(moms_local[1*nc] - moms_target_local[1*nc]),fabs(up->error[1]));
+          // However, u_par may be ~ 0 and if it is, we normalize it with the target thermal veocity instead.
+          if (fabs(moms_target_local[1*nc]) < sqrt(moms_target_local[2*nc])) {
+            up->error[1] = fmax(fabs(moms_local[1*nc] - moms_target_local[1*nc])/sqrt(moms_target_local[2*nc]),fabs(up->error[1]));
           }
           else {
-            up->error[1] = fmax(fabs(moms_local[1*nc] - moms_target_local[1*nc])/moms_target_local[1*nc],fabs(up->error[1]));
+            up->error[1] = fmax(fabs(moms_local[1*nc] - moms_target_local[1*nc])/fabs(moms_target_local[1*nc]),fabs(up->error[1]));
           }
           // Check if density and temperature (or parallel temperature) are positive, 
           // if they aren't we will break out of the iteration

--- a/zero/gk_maxwellian_correct_cu.cu
+++ b/zero/gk_maxwellian_correct_cu.cu
@@ -50,14 +50,13 @@ gkyl_gk_maxwellian_correct_all_moments_abs_diff_cu_ker(struct gkyl_range conf_ra
     // Also: for density and temperature(s), this error is a relative error 
     // compared to the target moment value so that we can converge to the 
     // correct target moments in SI units and minimize finite precision issues.
-    // However, upar (1st component) may be ~ 0 and if it is, we need to use 
-    // absolute error. We can converge safely using absolute error if upar ~ O(1). 
-    // Otherwise, we use relative error for upar. 
-    if (linc2 == 1 && moms_target_local[linc2*nc] < 1.0) {
-      abs_diff_moms_local[linc2] = fabs(moms_local[linc2*nc] - moms_target_local[linc2*nc]);
+    // However, upar (1st component) may be ~ 0 and if it is, 
+    // we normalize it with the target thermal veocity instead.
+    if (linc2 == 1 && moms_target_local[linc2*nc] < sqrt(moms_target_local[2*nc])) {
+      abs_diff_moms_local[linc2] = fabs(moms_local[linc2*nc] - moms_target_local[linc2*nc])/sqrt(moms_target_local[2*nc]);
     }
     else {
-      abs_diff_moms_local[linc2] = fabs(moms_local[linc2*nc] - moms_target_local[linc2*nc])/moms_target_local[linc2*nc];
+      abs_diff_moms_local[linc2] = fabs(moms_local[linc2*nc] - moms_target_local[linc2*nc])/fabs(moms_target_local[linc2*nc]);
     }
   }
 }


### PR DESCRIPTION
Normalize the error in u_par by thermal velocity when u_par is smaller than thermal velocity.
Fix a bug in computing the relative u_par error when u_par is larger than thermal velocity: the denominator should be the absolute value of u_par instead of u_par itself since it can be negative.