### PR TITLE
Fix bug in dg_interpolate 

### DIFF
--- a/unit/ctest_dg_interpolate.c
+++ b/unit/ctest_dg_interpolate.c
@@ -198,7 +198,7 @@ void eval_fdonor_2x(double t, const double *xn, double* restrict fout, void *ctx
 void
 test_2x(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  double lower[] = {0.0, -M_PI}, upper[] = {1.0, M_PI};
+  double lower[] = {9.460546e-01, -1.078908e-01}, upper[] = {1.053945e+00, 1.078908e-01};
   double mass = 1.0;
 
   const int ndim = sizeof(lower)/sizeof(lower[0]);
@@ -791,6 +791,26 @@ void eval_bmag_1x(double t, const double *xn, double* restrict fout, void *ctx)
   fout[0] = B0;
 }
 
+void eval_bmag_2x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1];
+
+  struct test_ctx *tctx = ctx;
+  double B0 = tctx->B0;
+
+  fout[0] = B0;
+}
+
+void eval_bmag_3x(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2];
+
+  struct test_ctx *tctx = ctx;
+  double B0 = tctx->B0;
+
+  fout[0] = B0;
+}
+
 void eval_distf_1x1v_gk(double t, const double *xn, double* restrict fout, void *ctx)
 {
   double x = xn[0], vpar = xn[1];
@@ -821,23 +841,35 @@ static struct gk_geometry* init_gk_geo(int poly_order, struct gkyl_rect_grid con
   struct gkyl_range confLocal, struct gkyl_range confLocal_ext, void *bmag_ctx, bool use_gpu)
 {
   // Initialize GK geometry.
+  int cdim = confBasis.ndim;
   struct gkyl_gk_geometry_inp geometry_input = {
     .geometry_id = GKYL_MAPC2P,
-    .world = {0.0},  .mapc2p = mapc2p,  .c2p_ctx = 0,
-    .bmag_func = eval_bmag_1x,  .bmag_ctx = bmag_ctx,
+    .world = {0.0, 0.0, 0.0},  .mapc2p = mapc2p,  .c2p_ctx = 0,
+    .bmag_func = cdim==1? eval_bmag_1x : (cdim==2? eval_bmag_2x : eval_bmag_3x),  .bmag_ctx = bmag_ctx,
     .basis = confBasis,  .grid = confGrid,
     .local = confLocal,  .local_ext = confLocal_ext,
     .global = confLocal, .global_ext = confLocal_ext,
   };
   int geo_ghost[3] = {1, 1, 1};
-  geometry_input.geo_grid = gkyl_gk_geometry_augment_grid(confGrid, geometry_input);
-  gkyl_cart_modal_serendip(&geometry_input.geo_basis, 3, poly_order);
-  gkyl_create_grid_ranges(&geometry_input.geo_grid, geo_ghost, &geometry_input.geo_global_ext, &geometry_input.geo_global);
-  memcpy(&geometry_input.geo_local, &geometry_input.geo_global, sizeof(struct gkyl_range));
-  memcpy(&geometry_input.geo_local_ext, &geometry_input.geo_global_ext, sizeof(struct gkyl_range));
+  if (cdim < 3) {
+    geometry_input.geo_grid = gkyl_gk_geometry_augment_grid(confGrid, geometry_input);
+    gkyl_cart_modal_serendip(&geometry_input.geo_basis, 3, poly_order);
+    gkyl_create_grid_ranges(&geometry_input.geo_grid, geo_ghost, &geometry_input.geo_global_ext, &geometry_input.geo_global);
+    memcpy(&geometry_input.geo_local, &geometry_input.geo_global, sizeof(struct gkyl_range));
+    memcpy(&geometry_input.geo_local_ext, &geometry_input.geo_global_ext, sizeof(struct gkyl_range));
+  }
+  else {
+    geometry_input.geo_grid = confGrid;
+    geometry_input.geo_basis = confBasis;
+    geometry_input.geo_global = confLocal;
+    geometry_input.geo_global_ext = confLocal_ext;
+    geometry_input.geo_local = confLocal;
+    geometry_input.geo_local_ext = confLocal_ext;
+  }
   // Deflate geometry.
   struct gk_geometry* gk_geom_3d = gkyl_gk_geometry_mapc2p_new(&geometry_input);
-  struct gk_geometry *gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, &geometry_input);
+  struct gk_geometry *gk_geom = cdim < 3? gkyl_gk_geometry_deflate(gk_geom_3d, &geometry_input)
+	                                : gkyl_gk_geometry_acquire(gk_geom_3d);
   gkyl_gk_geometry_release(gk_geom_3d);
   // If we are on the gpu, copy from host.
   if (use_gpu) {
@@ -1371,6 +1403,578 @@ test_1x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gp
   gkyl_proj_on_basis_release(proj_distf);
 }
 
+void eval_distf_2x2v_gk(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], vpar = xn[2], mu = xn[3];
+
+  struct test_ctx *tctx = ctx;
+  double n0 = tctx->n0;
+  double upar0 = tctx->upar0;
+  double T0 = tctx->T0;
+  double mass = tctx->mass;
+  int cdim = tctx->cdim;
+  int vdim = tctx->vdim;
+  double *lower = tctx->lower;
+  double *upper = tctx->upper;
+
+  double Lx[GKYL_MAX_CDIM];
+  for (int d=0; d<cdim; d++) Lx[d] = upper[d] - lower[d];
+
+  double den = n0*(1.0+0.5*sin((2.0*M_PI/Lx[0])*x)*cos((2*2.0*M_PI/Lx[1])*y));
+  double upar = upar0;
+  double temp = T0;
+
+  double vtsq = temp/mass;
+
+  double bmag[1] = {-1.0};
+  eval_bmag_2x(t, xn, bmag, ctx);
+
+  fout[0] = (den/pow(2.0*M_PI*vtsq,vdim/2.0)) * exp(-(pow(vpar-upar,2)+2.0*mu*bmag[0]/mass)/(2.0*vtsq));
+}
+
+void
+test_2x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
+{
+  const int cdim = 2;
+//  double x_min = 0.0;
+//  double x_max = 1.0;
+//  double y_min = 0.0;
+//  double y_max = 1.0;
+//  double vpar_min = -6.0;
+//  double vpar_max =  6.0;
+//  double mu_max =  0.5;
+  double x_min = 9.460546e-01;
+  double x_max = 1.053945e+00;
+  double y_min = -1.078908e-01;
+  double y_max = 1.078908e-01;
+  double vpar_min = -1.744683e+05;
+  double vpar_max =  1.744683e+05;
+  double mu_max =  9.047585e-17;
+  double lower[] = {x_min, y_min, vpar_min, 0.0}, upper[] = {x_max, y_max, vpar_max, mu_max};
+  double mass = 1.67e-27*3.973;
+  double charge = 1.602e-19;
+
+  const int ndim = sizeof(lower)/sizeof(lower[0]);
+  const int vdim = ndim-cdim;
+
+  struct test_ctx proj_ctx = {
+    .n0 = 1.0, // Density.
+    .upar0 = 1.2, // Parallel flow speed.
+    .T0 = 1.0, // Temperature.
+    .B0 = 1.0, // Magnetic field.
+    .mass = mass, // Particle mass.
+    .cdim = cdim, // Number of position space dimensions.
+    .vdim = vdim, // Number of velocity space dimensions.
+    .lower = {lower[0], lower[1], lower[2], lower[3]}, // Lower extents of the grid.
+    .upper = {upper[0], upper[1], upper[2], upper[3]}, // Upper extents of the grid.
+  };
+
+
+  double confLower[cdim], confUpper[cdim];
+  int confCells[cdim];
+  for (int d=0; d<cdim; d++) {
+    confLower[d] = lower[d];
+    confUpper[d] = upper[d];
+    confCells[d] = cells[d];
+  }
+  double velLower[vdim], velUpper[vdim];
+  int velCells[vdim];
+  for (int d=0; d<vdim; d++) {
+    velLower[d] = lower[cdim+d];
+    velUpper[d] = upper[cdim+d];
+    velCells[d] = cells[cdim+d];
+  }
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+  struct gkyl_rect_grid confGrid;
+  gkyl_rect_grid_init(&confGrid, cdim, confLower, confUpper, confCells);
+  struct gkyl_rect_grid velGrid;
+  gkyl_rect_grid_init(&velGrid, vdim, velLower, velUpper, velCells);
+
+  // Basis functions.
+  struct gkyl_basis basis, confBasis;
+  if (poly_order == 1)
+    gkyl_cart_modal_gkhybrid(&basis, cdim, vdim);
+  else
+    gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+  gkyl_cart_modal_serendip(&confBasis, cdim, poly_order);
+
+  // Ranges
+  int confGhost[GKYL_MAX_CDIM] = { 1 };
+  struct gkyl_range confLocal, confLocal_ext; // local, local-ext conf-space ranges
+  gkyl_create_grid_ranges(&confGrid, confGhost, &confLocal_ext, &confLocal);
+
+  int velGhost[3] = { 0 };
+  struct gkyl_range velLocal, velLocal_ext; // local, local-ext vel-space ranges
+  gkyl_create_grid_ranges(&velGrid, velGhost, &velLocal_ext, &velLocal);
+
+  int ghost[GKYL_MAX_DIM] = {0};
+  for (int d=0; d<cdim; d++) ghost[d] = confGhost[d];
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create bmag arrays.
+  struct gkyl_array *bmag = mkarr(use_gpu, confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *bmag_ho = use_gpu? mkarr(false, bmag->ncomp, bmag->size)
+                                      : gkyl_array_acquire(bmag);
+  gkyl_proj_on_basis *proj_bmag = gkyl_proj_on_basis_new(&confGrid, &confBasis,
+    poly_order+1, 1, eval_bmag_2x, &proj_ctx);
+  gkyl_proj_on_basis_advance(proj_bmag, 0.0, &confLocal, bmag_ho);
+  gkyl_array_copy(bmag, bmag_ho);
+
+  // Create distribution function arrays.
+  struct gkyl_array *distf = mkarr(use_gpu, basis.num_basis, local_ext.volume);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(false, distf->ncomp, distf->size)
+                                       : gkyl_array_acquire(distf);
+  gkyl_proj_on_basis *proj_distf = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_distf_2x2v_gk, &proj_ctx);
+  gkyl_proj_on_basis_advance(proj_distf, 0.0, &local, distf_ho);
+  gkyl_array_copy(distf, distf_ho);
+
+  // Initialize geometry.
+  struct gk_geometry *gk_geom = init_gk_geo(poly_order, confGrid, confBasis, confLocal, confLocal_ext, &proj_ctx, use_gpu);
+
+  // Velocity space mapping.
+  struct gkyl_mapc2p_inp c2p_in = { };
+  struct gkyl_velocity_map *gvm = gkyl_velocity_map_new(c2p_in, grid, velGrid,
+    local, local_ext, velLocal, velLocal_ext, use_gpu);
+
+  int num_mom = 3;
+  // Calculate the moments.
+  struct gkyl_array *moms = mkarr(use_gpu, num_mom*confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *moms_ho = use_gpu? mkarr(false, moms->ncomp, moms->size)
+                                      : gkyl_array_acquire(moms);
+  calc_moms_gk(&grid, &confBasis, &basis, &confLocal, &local, mass, charge, gvm, gk_geom, use_gpu, distf, moms);
+  gkyl_array_copy(moms_ho, moms);
+
+  // Calculate the integrated moments.
+  double int_moms[num_mom];
+  for (int i=0; i<num_mom; i++) int_moms[i] = 0.0;
+  calc_int_moms(num_mom, &confGrid, &confBasis, &confLocal, use_gpu, moms, int_moms);
+
+//  // Write donor distribution function to file.
+//  char fname0[1024];
+//  sprintf(fname0, "ctest_dg_interp_2x2v_p%d_N%dx%dx%dx%d-N%dx%dx%dx%d_do.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3]);
+//  gkyl_grid_sub_array_write(&grid, &local, NULL, distf_ho, fname0);
+//
+//  // Write target moments to file.
+//  char fname0m[1024];
+//  sprintf(fname0m, "ctest_dg_interp_2x2v_p%d_N%dx%dx%dx%d-N%dx%dx%dx%d_do_mom.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3]);
+//  gkyl_grid_sub_array_write(&confGrid, &confLocal, NULL, moms_ho, fname0m);
+//
+//  printf("\n  Donor int_moms  = %g %g %g\n", int_moms[0],int_moms[1],int_moms[2]);
+
+  // Target grids.
+  int confCells_tar[cdim], velCells_tar[vdim];
+  for (int d=0; d<cdim; d++)
+    confCells_tar[d] = cells_tar[d];
+  for (int d=0; d<vdim; d++)
+    velCells_tar[d] = cells_tar[cdim+d];
+
+  struct gkyl_rect_grid grid_tar;
+  gkyl_rect_grid_init(&grid_tar, ndim, lower, upper, cells_tar);
+  struct gkyl_rect_grid confGrid_tar;
+  gkyl_rect_grid_init(&confGrid_tar, cdim, confLower, confUpper, confCells_tar);
+  struct gkyl_rect_grid velGrid_tar;
+  gkyl_rect_grid_init(&velGrid_tar, vdim, velLower, velUpper, velCells_tar);
+
+  // Target ranges.
+  struct gkyl_range confLocal_tar, confLocal_tar_ext; // local, local-ext conf-space ranges
+  gkyl_create_grid_ranges(&confGrid_tar, confGhost, &confLocal_tar_ext, &confLocal_tar);
+
+  struct gkyl_range velLocal_tar, velLocal_tar_ext; // local, local-ext vel-space ranges
+  gkyl_create_grid_ranges(&velGrid_tar, velGhost, &velLocal_tar_ext, &velLocal_tar);
+
+  struct gkyl_range local_tar, local_tar_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid_tar, ghost, &local_tar_ext, &local_tar);
+
+  // Target geometry.
+  struct gk_geometry *gk_geom_tar = init_gk_geo(poly_order, confGrid_tar, confBasis,
+    confLocal_tar, confLocal_tar_ext, &proj_ctx, use_gpu);
+
+  // Target velocity space mapping.
+  struct gkyl_velocity_map *gvm_tar = gkyl_velocity_map_new(c2p_in, grid_tar, velGrid_tar,
+    local_tar, local_tar_ext, velLocal_tar, velLocal_tar_ext, use_gpu);
+
+  // Target field.
+  struct gkyl_array *distf_tar = mkarr(use_gpu, basis.num_basis, local_tar_ext.volume);
+  struct gkyl_array *distf_tar_ho = use_gpu? mkarr(false, distf_tar->ncomp, distf_tar->size)
+                                           : gkyl_array_acquire(distf_tar);
+
+  // Create the interpolation operator and interpolate onto the target grid.
+  struct gkyl_dg_interpolate *interp = gkyl_dg_interpolate_new(cdim, &basis,
+    &grid, &grid_tar, &local, &local_tar, ghost, use_gpu);
+
+  gkyl_dg_interpolate_advance(interp, distf, distf_tar);
+
+  // Calculate the moments.
+  struct gkyl_array *moms_tar = mkarr(use_gpu, num_mom*confBasis.num_basis, confLocal_tar_ext.volume);
+  struct gkyl_array *moms_tar_ho = use_gpu? mkarr(false, moms_tar->ncomp, moms_tar->size)
+                                          : gkyl_array_acquire(moms_tar);
+  calc_moms_gk(&grid_tar, &confBasis, &basis, &confLocal_tar, &local_tar,
+    mass, charge, gvm_tar, gk_geom_tar, use_gpu, distf_tar, moms_tar);
+  gkyl_array_copy(moms_tar_ho, moms_tar);
+
+  // Calculate the integrated moments of the target.
+  double int_moms_tar[num_mom];
+  for (int i=0; i<num_mom; i++) int_moms_tar[i] = 0.0;
+  calc_int_moms(num_mom, &confGrid_tar, &confBasis, &confLocal_tar, use_gpu, moms_tar, int_moms_tar);
+
+//  // Write target distribution function to file.
+//  char fname1[1024];
+//  sprintf(fname1, "ctest_dg_interp_2x2v_p%d_N%dx%dx%dx%d-N%dx%dx%dx%d_tar.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3]);
+//  gkyl_grid_sub_array_write(&grid_tar, &local_tar, NULL, distf_tar_ho, fname1);
+//
+//  // Write target moments to file.
+//  char fname1m[1024];
+//  sprintf(fname1m, "ctest_dg_interp_2x2v_p%d_N%dx%dx%dx%d-N%dx%dx%dx%d_tar_mom.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3]);
+//  gkyl_grid_sub_array_write(&confGrid_tar, &confLocal_tar, NULL, moms_tar_ho, fname1m);
+//
+//  printf("\n  Target int_moms = %g %g %g\n", int_moms_tar[0],int_moms_tar[1],int_moms_tar[2]);
+
+  // Check that the moments and integrated moments are the same.
+  bool same_conf_grid = true;
+  for (int d=0; d<cdim; d++) same_conf_grid = same_conf_grid && (cells[d] == cells_tar[d]);
+  if (same_conf_grid) {
+    double m2_tol = 1e-10;
+    if (poly_order == 2 && basis.b_type == GKYL_BASIS_MODAL_SERENDIPITY) {
+      m2_tol = 1e-2; // Because this is not a tensor basis.
+    }
+
+    struct gkyl_range_iter iter;
+    gkyl_range_iter_init(&iter, &confLocal);
+    while (gkyl_range_iter_next(&iter)) {
+      long linidx = gkyl_range_idx(&confLocal, iter.idx);
+      const double *moms_c = gkyl_array_cfetch(moms_ho, linidx);
+      const double *moms_tar_c = gkyl_array_cfetch(moms_tar_ho, linidx);
+      for (int m=0; m<2*confBasis.num_basis; m++) {
+        TEST_CHECK( gkyl_compare(moms_c[m], moms_tar_c[m], 1e-10) );
+        TEST_MSG( "idx=%d | m=%d | Got: %.13e | Expected: %.13e\n", iter.idx[0], m, moms_tar_c[m], moms_c[m]);
+      }
+      for (int m=2*confBasis.num_basis; m<moms->ncomp; m++) {
+        TEST_CHECK( gkyl_compare(moms_c[m], moms_tar_c[m], m2_tol) );
+        TEST_MSG( "idx=%d | m=%d | Got: %.13e | Expected: %.13e\n", iter.idx[0], m, moms_tar_c[m], moms_c[m]);
+      }
+    }
+  }
+
+  for (int i=0; i<num_mom; i++)
+    TEST_CHECK( gkyl_compare(int_moms[i], int_moms_tar[i], 1e-10) );
+
+  gkyl_dg_interpolate_release(interp);
+  gkyl_array_release(moms_tar_ho);
+  gkyl_array_release(moms_tar);
+  gkyl_array_release(distf_tar);
+  gkyl_array_release(distf_tar_ho);
+  gkyl_velocity_map_release(gvm_tar);
+  gkyl_gk_geometry_release(gk_geom_tar);
+  gkyl_array_release(moms_ho);
+  gkyl_array_release(moms);
+  gkyl_velocity_map_release(gvm);
+  gkyl_gk_geometry_release(gk_geom);
+  gkyl_array_release(bmag);
+  gkyl_array_release(distf);
+  gkyl_array_release(bmag_ho);
+  gkyl_array_release(distf_ho);
+  gkyl_proj_on_basis_release(proj_bmag);
+  gkyl_proj_on_basis_release(proj_distf);
+}
+
+void eval_distf_3x2v_gk(double t, const double *xn, double* restrict fout, void *ctx)
+{
+  double x = xn[0], y = xn[1], z = xn[2], vpar = xn[3], mu = xn[4];
+
+  struct test_ctx *tctx = ctx;
+  double n0 = tctx->n0;
+  double upar0 = tctx->upar0;
+  double T0 = tctx->T0;
+  double mass = tctx->mass;
+  int cdim = tctx->cdim;
+  int vdim = tctx->vdim;
+  double *lower = tctx->lower;
+  double *upper = tctx->upper;
+
+  double Lx[GKYL_MAX_CDIM];
+  for (int d=0; d<cdim; d++) Lx[d] = upper[d] - lower[d];
+
+  double den = n0*(1.0+0.5*sin((2.0*M_PI/Lx[0])*x)*cos((2*2.0*M_PI/Lx[1])*y));
+  double upar = upar0;
+  double temp = T0;
+
+  double vtsq = temp/mass;
+
+  double bmag[1] = {-1.0};
+  eval_bmag_3x(t, xn, bmag, ctx);
+
+  fout[0] = (den/pow(2.0*M_PI*vtsq,vdim/2.0)) * exp(-(pow(vpar-upar,2)+2.0*mu*bmag[0]/mass)/(2.0*vtsq));
+}
+
+void
+test_3x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
+{
+  const int cdim = 3;
+//  double x_min = 0.0;
+//  double x_max = 1.0;
+//  double y_min = 0.0;
+//  double y_max = 1.0;
+//  double z_min = 0.0;
+//  double z_max = 1.0;
+//  double vpar_min = -6.0;
+//  double vpar_max =  6.0;
+//  double mu_max =  0.5;
+//  double x_min = 9.460546e-01;
+//  double x_max = 1.053945e+00;
+  double y_min = -1.078908e-01;
+  double y_max = 1.078908e-01;
+  double z_min = -2.000000e+00;
+  double z_max = 2.000000e+00;
+  double vpar_min = -1.06096e+07;
+  double vpar_max =  1.06096e+07;
+  double mu_max =  9.047585e-17;
+  double x_min = 9.460545916e-01;
+  double x_max = 1.053945408e+00;
+//  double y_min = -1.078908169e-01;
+//  double y_max = 1.078908169e-01;
+//  double z_min = -2.000000e+00;
+//  double z_max = 2.000000e+00;
+//  double vpar_min = -1.060964135e+07;
+//  double vpar_max =  1.060964135e+07;
+//  double mu_max =  9.047584868e-17;
+  double lower[] = {x_min, y_min, z_min, vpar_min, 0.0}, upper[] = {x_max, y_max, z_max, vpar_max, mu_max};
+  double mass = 1.67e-27*3.973;
+  double charge = 1.602e-19;
+
+  const int ndim = sizeof(lower)/sizeof(lower[0]);
+  const int vdim = ndim-cdim;
+
+  struct test_ctx proj_ctx = {
+    .n0 = 1.0, // Density.
+    .upar0 = 1.2, // Parallel flow speed.
+    .T0 = 1.0, // Temperature.
+    .B0 = 1.0, // Magnetic field.
+    .mass = mass, // Particle mass.
+    .cdim = cdim, // Number of position space dimensions.
+    .vdim = vdim, // Number of velocity space dimensions.
+    .lower = {lower[0], lower[1], lower[2], lower[3], lower[4]}, // Lower extents of the grid.
+    .upper = {upper[0], upper[1], upper[2], upper[3], upper[4]}, // Upper extents of the grid.
+  };
+
+
+  double confLower[cdim], confUpper[cdim];
+  int confCells[cdim];
+  for (int d=0; d<cdim; d++) {
+    confLower[d] = lower[d];
+    confUpper[d] = upper[d];
+    confCells[d] = cells[d];
+  }
+  double velLower[vdim], velUpper[vdim];
+  int velCells[vdim];
+  for (int d=0; d<vdim; d++) {
+    velLower[d] = lower[cdim+d];
+    velUpper[d] = upper[cdim+d];
+    velCells[d] = cells[cdim+d];
+  }
+
+  // Grids.
+  struct gkyl_rect_grid grid;
+  gkyl_rect_grid_init(&grid, ndim, lower, upper, cells);
+  struct gkyl_rect_grid confGrid;
+  gkyl_rect_grid_init(&confGrid, cdim, confLower, confUpper, confCells);
+  struct gkyl_rect_grid velGrid;
+  gkyl_rect_grid_init(&velGrid, vdim, velLower, velUpper, velCells);
+
+  // Basis functions.
+  struct gkyl_basis basis, confBasis;
+  if (poly_order == 1)
+    gkyl_cart_modal_gkhybrid(&basis, cdim, vdim);
+  else
+    gkyl_cart_modal_serendip(&basis, ndim, poly_order);
+  gkyl_cart_modal_serendip(&confBasis, cdim, poly_order);
+
+  // Ranges
+  int confGhost[GKYL_MAX_CDIM] = { 0 };
+  for (int d=0; d<cdim; d++) confGhost[d] = 1;
+  struct gkyl_range confLocal, confLocal_ext; // local, local-ext conf-space ranges
+  gkyl_create_grid_ranges(&confGrid, confGhost, &confLocal_ext, &confLocal);
+
+  int velGhost[3] = { 0 };
+  struct gkyl_range velLocal, velLocal_ext; // local, local-ext vel-space ranges
+  gkyl_create_grid_ranges(&velGrid, velGhost, &velLocal_ext, &velLocal);
+
+  int ghost[GKYL_MAX_DIM] = {0};
+  for (int d=0; d<cdim; d++) ghost[d] = confGhost[d];
+  struct gkyl_range local, local_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid, ghost, &local_ext, &local);
+
+  // Create bmag arrays.
+  struct gkyl_array *bmag = mkarr(use_gpu, confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *bmag_ho = use_gpu? mkarr(false, bmag->ncomp, bmag->size)
+                                      : gkyl_array_acquire(bmag);
+  gkyl_proj_on_basis *proj_bmag = gkyl_proj_on_basis_new(&confGrid, &confBasis,
+    poly_order+1, 1, eval_bmag_3x, &proj_ctx);
+  gkyl_proj_on_basis_advance(proj_bmag, 0.0, &confLocal, bmag_ho);
+  gkyl_array_copy(bmag, bmag_ho);
+
+  // Create distribution function arrays.
+  struct gkyl_array *distf = mkarr(use_gpu, basis.num_basis, local_ext.volume);
+  struct gkyl_array *distf_ho = use_gpu? mkarr(false, distf->ncomp, distf->size)
+                                       : gkyl_array_acquire(distf);
+  gkyl_proj_on_basis *proj_distf = gkyl_proj_on_basis_new(&grid, &basis,
+    poly_order+1, 1, eval_distf_3x2v_gk, &proj_ctx);
+  gkyl_proj_on_basis_advance(proj_distf, 0.0, &local, distf_ho);
+  gkyl_array_copy(distf, distf_ho);
+
+  // Initialize geometry.
+  struct gk_geometry *gk_geom = init_gk_geo(poly_order, confGrid, confBasis, confLocal, confLocal_ext, &proj_ctx, use_gpu);
+
+  // Velocity space mapping.
+  struct gkyl_mapc2p_inp c2p_in = { };
+  struct gkyl_velocity_map *gvm = gkyl_velocity_map_new(c2p_in, grid, velGrid,
+    local, local_ext, velLocal, velLocal_ext, use_gpu);
+
+  int num_mom = 3;
+  // Calculate the moments.
+  struct gkyl_array *moms = mkarr(use_gpu, num_mom*confBasis.num_basis, confLocal_ext.volume);
+  struct gkyl_array *moms_ho = use_gpu? mkarr(false, moms->ncomp, moms->size)
+                                      : gkyl_array_acquire(moms);
+  calc_moms_gk(&grid, &confBasis, &basis, &confLocal, &local, mass, charge, gvm, gk_geom, use_gpu, distf, moms);
+  gkyl_array_copy(moms_ho, moms);
+
+  // Calculate the integrated moments.
+  double int_moms[num_mom];
+  for (int i=0; i<num_mom; i++) int_moms[i] = 0.0;
+  calc_int_moms(num_mom, &confGrid, &confBasis, &confLocal, use_gpu, moms, int_moms);
+
+//  // Write donor distribution function to file.
+//  char fname0[1024];
+//  sprintf(fname0, "ctest_dg_interp_3x2v_p%d_N%dx%dx%dx%dx%d-N%dx%dx%dx%dx%d_do.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells[4], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3], cells_tar[4]);
+//  gkyl_grid_sub_array_write(&grid, &local, NULL, distf_ho, fname0);
+//
+//  // Write target moments to file.
+//  char fname0m[1024];
+//  sprintf(fname0m, "ctest_dg_interp_3x2v_p%d_N%dx%dx%dx%dx%d-N%dx%dx%dx%dx%d_do_mom.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells[4], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3], cells_tar[4]);
+//  gkyl_grid_sub_array_write(&confGrid, &confLocal, NULL, moms_ho, fname0m);
+//
+//  printf("\n  Donor int_moms  = %g %g %g\n", int_moms[0],int_moms[1],int_moms[2]);
+
+  // Target grids.
+  int confCells_tar[cdim], velCells_tar[vdim];
+  for (int d=0; d<cdim; d++)
+    confCells_tar[d] = cells_tar[d];
+  for (int d=0; d<vdim; d++)
+    velCells_tar[d] = cells_tar[cdim+d];
+
+  struct gkyl_rect_grid grid_tar;
+  gkyl_rect_grid_init(&grid_tar, ndim, lower, upper, cells_tar);
+  struct gkyl_rect_grid confGrid_tar;
+  gkyl_rect_grid_init(&confGrid_tar, cdim, confLower, confUpper, confCells_tar);
+  struct gkyl_rect_grid velGrid_tar;
+  gkyl_rect_grid_init(&velGrid_tar, vdim, velLower, velUpper, velCells_tar);
+
+  // Target ranges.
+  struct gkyl_range confLocal_tar, confLocal_tar_ext; // local, local-ext conf-space ranges
+  gkyl_create_grid_ranges(&confGrid_tar, confGhost, &confLocal_tar_ext, &confLocal_tar);
+
+  struct gkyl_range velLocal_tar, velLocal_tar_ext; // local, local-ext vel-space ranges
+  gkyl_create_grid_ranges(&velGrid_tar, velGhost, &velLocal_tar_ext, &velLocal_tar);
+
+  struct gkyl_range local_tar, local_tar_ext; // local, local-ext phase-space ranges
+  gkyl_create_grid_ranges(&grid_tar, ghost, &local_tar_ext, &local_tar);
+
+  // Target geometry.
+  struct gk_geometry *gk_geom_tar = init_gk_geo(poly_order, confGrid_tar, confBasis,
+    confLocal_tar, confLocal_tar_ext, &proj_ctx, use_gpu);
+
+  // Target velocity space mapping.
+  struct gkyl_velocity_map *gvm_tar = gkyl_velocity_map_new(c2p_in, grid_tar, velGrid_tar,
+    local_tar, local_tar_ext, velLocal_tar, velLocal_tar_ext, use_gpu);
+
+  // Target field.
+  struct gkyl_array *distf_tar = mkarr(use_gpu, basis.num_basis, local_tar_ext.volume);
+  struct gkyl_array *distf_tar_ho = use_gpu? mkarr(false, distf_tar->ncomp, distf_tar->size)
+                                           : gkyl_array_acquire(distf_tar);
+
+  // Create the interpolation operator and interpolate onto the target grid.
+  struct gkyl_dg_interpolate *interp = gkyl_dg_interpolate_new(cdim, &basis,
+    &grid, &grid_tar, &local, &local_tar, ghost, use_gpu);
+
+  gkyl_dg_interpolate_advance(interp, distf, distf_tar);
+
+  // Calculate the moments.
+  struct gkyl_array *moms_tar = mkarr(use_gpu, num_mom*confBasis.num_basis, confLocal_tar_ext.volume);
+  struct gkyl_array *moms_tar_ho = use_gpu? mkarr(false, moms_tar->ncomp, moms_tar->size)
+                                          : gkyl_array_acquire(moms_tar);
+  calc_moms_gk(&grid_tar, &confBasis, &basis, &confLocal_tar, &local_tar,
+    mass, charge, gvm_tar, gk_geom_tar, use_gpu, distf_tar, moms_tar);
+  gkyl_array_copy(moms_tar_ho, moms_tar);
+
+  // Calculate the integrated moments of the target.
+  double int_moms_tar[num_mom];
+  for (int i=0; i<num_mom; i++) int_moms_tar[i] = 0.0;
+  calc_int_moms(num_mom, &confGrid_tar, &confBasis, &confLocal_tar, use_gpu, moms_tar, int_moms_tar);
+
+//  // Write target distribution function to file.
+//  char fname1[1024];
+//  sprintf(fname1, "ctest_dg_interp_3x2v_p%d_N%dx%dx%dx%dx%d-N%dx%dx%dx%dx%d_tar.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells[4], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3], cells_tar[4]);
+//  gkyl_grid_sub_array_write(&grid_tar, &local_tar, NULL, distf_tar_ho, fname1);
+//
+//  // Write target moments to file.
+//  char fname1m[1024];
+//  sprintf(fname1m, "ctest_dg_interp_3x2v_p%d_N%dx%dx%dx%dx%d-N%dx%dx%dx%dx%d_tar_mom.gkyl", poly_order, cells[0], cells[1], cells[2], cells[3], cells[4], cells_tar[0], cells_tar[1], cells_tar[2], cells_tar[3], cells_tar[4]);
+//  gkyl_grid_sub_array_write(&confGrid_tar, &confLocal_tar, NULL, moms_tar_ho, fname1m);
+//
+//  printf("\n  Target int_moms = %g %g %g\n", int_moms_tar[0],int_moms_tar[1],int_moms_tar[2]);
+
+  // Check that the moments and integrated moments are the same.
+  bool same_conf_grid = true;
+  for (int d=0; d<cdim; d++) same_conf_grid = same_conf_grid && (cells[d] == cells_tar[d]);
+  if (same_conf_grid) {
+    double m2_tol = 1e-10;
+    if (poly_order == 2 && basis.b_type == GKYL_BASIS_MODAL_SERENDIPITY) {
+      m2_tol = 1e-2; // Because this is not a tensor basis.
+    }
+
+    struct gkyl_range_iter iter;
+    gkyl_range_iter_init(&iter, &confLocal);
+    while (gkyl_range_iter_next(&iter)) {
+      long linidx = gkyl_range_idx(&confLocal, iter.idx);
+      const double *moms_c = gkyl_array_cfetch(moms_ho, linidx);
+      const double *moms_tar_c = gkyl_array_cfetch(moms_tar_ho, linidx);
+      for (int m=0; m<2*confBasis.num_basis; m++) {
+        TEST_CHECK( gkyl_compare(moms_c[m], moms_tar_c[m], 1e-10) );
+        TEST_MSG( "idx=%d | m=%d | Got: %.13e | Expected: %.13e\n", iter.idx[0], m, moms_tar_c[m], moms_c[m]);
+      }
+      for (int m=2*confBasis.num_basis; m<moms->ncomp; m++) {
+        TEST_CHECK( gkyl_compare(moms_c[m], moms_tar_c[m], m2_tol) );
+        TEST_MSG( "idx=%d | m=%d | Got: %.13e | Expected: %.13e\n", iter.idx[0], m, moms_tar_c[m], moms_c[m]);
+      }
+    }
+  }
+
+  for (int i=0; i<num_mom; i++)
+    TEST_CHECK( gkyl_compare(int_moms[i], int_moms_tar[i], 1e-10) );
+
+  gkyl_dg_interpolate_release(interp);
+  gkyl_array_release(moms_tar_ho);
+  gkyl_array_release(moms_tar);
+  gkyl_array_release(distf_tar);
+  gkyl_array_release(distf_tar_ho);
+  gkyl_velocity_map_release(gvm_tar);
+  gkyl_gk_geometry_release(gk_geom_tar);
+  gkyl_array_release(moms_ho);
+  gkyl_array_release(moms);
+  gkyl_velocity_map_release(gvm);
+  gkyl_gk_geometry_release(gk_geom);
+  gkyl_array_release(bmag);
+  gkyl_array_release(distf);
+  gkyl_array_release(bmag_ho);
+  gkyl_array_release(distf_ho);
+  gkyl_proj_on_basis_release(proj_bmag);
+  gkyl_proj_on_basis_release(proj_distf);
+}
+
 void test_1x_hodev(bool use_gpu)
 {
   // Refine along x.
@@ -1389,40 +1993,40 @@ void test_1x_hodev(bool use_gpu)
 void test_2x_hodev(bool use_gpu)
 {
   // Refine along x.
-  int cells_do0[] = {6, 8};
-  int cells_tar0[] = {12, 8};
-  test_2x(cells_do0, cells_tar0, 1, use_gpu);
-  test_2x(cells_do0, cells_tar0, 2, use_gpu);
-
-  // Coarsen along x.
-  int cells_do1[] = {16, 8};
-  int cells_tar1[] = {8, 8};
-  test_2x(cells_do1, cells_tar1, 1, use_gpu);
-  test_2x(cells_do1, cells_tar1, 2, use_gpu);
+//  int cells_do0[] = {6, 8};
+//  int cells_tar0[] = {12, 8};
+//  test_2x(cells_do0, cells_tar0, 1, use_gpu);
+//  test_2x(cells_do0, cells_tar0, 2, use_gpu);
+//
+//  // Coarsen along x.
+//  int cells_do1[] = {16, 8};
+//  int cells_tar1[] = {8, 8};
+//  test_2x(cells_do1, cells_tar1, 1, use_gpu);
+//  test_2x(cells_do1, cells_tar1, 2, use_gpu);
 
   // Refine along vpar.
-  int cells_do2[] = {8, 8};
-  int cells_tar2[] = {8, 16};
+  int cells_do2[] = {96, 96};
+  int cells_tar2[] = {128, 128};
   test_2x(cells_do2, cells_tar2, 1, use_gpu);
   test_2x(cells_do2, cells_tar2, 2, use_gpu);
 
-  // Coarsen along vpar.
-  int cells_do3[] = {8, 12};
-  int cells_tar3[] = {8, 6};
-  test_2x(cells_do3, cells_tar3, 1, use_gpu);
-  test_2x(cells_do3, cells_tar3, 2, use_gpu);
-
-  // Refine along x and vpar.
-  int cells_do4[] = {8, 8};
-  int cells_tar4[] = {32, 16};
-  test_2x(cells_do4, cells_tar4, 1, use_gpu);
-  test_2x(cells_do4, cells_tar4, 2, use_gpu);
-
-  // Coarsen along x and vpar.
-  int cells_do5[] = {8, 12};
-  int cells_tar5[] = {4, 6};
-  test_2x(cells_do5, cells_tar5, 1, use_gpu);
-  test_2x(cells_do5, cells_tar5, 2, use_gpu);
+//  // Coarsen along vpar.
+//  int cells_do3[] = {8, 12};
+//  int cells_tar3[] = {8, 6};
+//  test_2x(cells_do3, cells_tar3, 1, use_gpu);
+//  test_2x(cells_do3, cells_tar3, 2, use_gpu);
+//
+//  // Refine along x and vpar.
+//  int cells_do4[] = {8, 8};
+//  int cells_tar4[] = {32, 16};
+//  test_2x(cells_do4, cells_tar4, 1, use_gpu);
+//  test_2x(cells_do4, cells_tar4, 2, use_gpu);
+//
+//  // Coarsen along x and vpar.
+//  int cells_do5[] = {8, 12};
+//  int cells_tar5[] = {4, 6};
+//  test_2x(cells_do5, cells_tar5, 1, use_gpu);
+//  test_2x(cells_do5, cells_tar5, 2, use_gpu);
 }
 
 void test_1x1v_vlasov_hodev(bool use_gpu)
@@ -1635,6 +2239,72 @@ void test_1x2v_gk_hodev(bool use_gpu)
   test_1x2v_gk(cells_do11, cells_tar11, 1, use_gpu);
 }
 
+void test_2x2v_gk_hodev(bool use_gpu)
+{
+  // Refine along x.
+  int cells_do0[] = {6, 6, 8, 4};
+  int cells_tar0[] = {12, 6, 8, 4};
+  test_2x2v_gk(cells_do0, cells_tar0, 1, use_gpu);
+
+  // Coarsen along x.
+  int cells_do1[] = {16, 6, 8, 4};
+  int cells_tar1[] = {8, 6, 8, 4};
+  test_2x2v_gk(cells_do1, cells_tar1, 1, use_gpu);
+
+  // Refine along y.
+  int cells_do2[] = {6, 6, 8, 4};
+  int cells_tar2[] = {6, 12, 8, 4};
+  test_2x2v_gk(cells_do2, cells_tar2, 1, use_gpu);
+
+  // Coarsen along y.
+  int cells_do3[] = {6, 16, 8, 4};
+  int cells_tar3[] = {6, 8, 8, 4};
+  test_2x2v_gk(cells_do3, cells_tar3, 1, use_gpu);
+
+  // Refine along x and y.
+  int cells_do4[] = {96, 96, 8, 4};
+  int cells_tar4[] = {128, 128, 8, 4};
+  test_2x2v_gk(cells_do4, cells_tar4, 1, use_gpu);
+
+  // Coarsen along x and y.
+  int cells_do5[] = {16, 16, 8, 4};
+  int cells_tar5[] = {8, 8, 8, 4};
+  test_2x2v_gk(cells_do5, cells_tar5, 1, use_gpu);
+}
+
+void test_3x2v_gk_hodev(bool use_gpu)
+{
+//  // Refine along x.
+//  int cells_do0[] = {6, 6, 8, 8, 4};
+//  int cells_tar0[] = {12, 6, 8, 8, 4};
+//  test_3x2v_gk(cells_do0, cells_tar0, 1, use_gpu);
+//
+//  // Coarsen along x.
+//  int cells_do1[] = {16, 6, 8, 8, 4};
+//  int cells_tar1[] = {8, 6, 8, 8, 4};
+//  test_3x2v_gk(cells_do1, cells_tar1, 1, use_gpu);
+//
+//  // Refine along y.
+//  int cells_do2[] = {6, 6, 8, 8, 4};
+//  int cells_tar2[] = {6, 12, 8, 8, 4};
+//  test_3x2v_gk(cells_do2, cells_tar2, 1, use_gpu);
+//
+//  // Coarsen along y.
+//  int cells_do3[] = {6, 16, 8, 8, 4};
+//  int cells_tar3[] = {6, 8, 8, 8, 4};
+//  test_3x2v_gk(cells_do3, cells_tar3, 1, use_gpu);
+
+  // Refine along x and y.
+  int cells_do4[] = {12, 12, 8, 8, 4};
+  int cells_tar4[] = {16, 16, 8, 8, 4};
+  test_3x2v_gk(cells_do4, cells_tar4, 1, use_gpu);
+
+//  // Coarsen along x and y.
+//  int cells_do5[] = {16, 16, 8, 8, 4};
+//  int cells_tar5[] = {8, 8, 8, 8, 4};
+//  test_3x2v_gk(cells_do5, cells_tar5, 1, use_gpu);
+}
+
 void test_1x_ho()
 {
   test_1x_hodev(false);
@@ -1663,6 +2333,16 @@ void test_1x1v_gk_ho()
 void test_1x2v_gk_ho()
 {
   test_1x2v_gk_hodev(false);
+}
+
+void test_2x2v_gk_ho()
+{
+  test_2x2v_gk_hodev(false);
+}
+
+void test_3x2v_gk_ho()
+{
+  test_3x2v_gk_hodev(false);
 }
 
 #ifdef GKYL_HAVE_CUDA
@@ -1696,6 +2376,15 @@ void test_1x2v_gk_dev()
   test_1x2v_gk_hodev(true);
 }
 
+void test_2x2v_gk_dev()
+{
+  test_2x2v_gk_hodev(true);
+}
+
+void test_3x2v_gk_dev()
+{
+  test_3x2v_gk_hodev(true);
+}
 #endif
 
 TEST_LIST = {
@@ -1705,6 +2394,8 @@ TEST_LIST = {
   { "test_1x2v_vlasov_ho", test_1x2v_vlasov_ho },
   { "test_1x1v_gk_ho", test_1x1v_gk_ho },
   { "test_1x2v_gk_ho", test_1x2v_gk_ho },
+  { "test_2x2v_gk_ho", test_2x2v_gk_ho },
+  { "test_3x2v_gk_ho", test_3x2v_gk_ho },
 #ifdef GKYL_HAVE_CUDA
   { "test_1x_dev", test_1x_dev },
   { "test_2x_dev", test_2x_dev },
@@ -1712,6 +2403,8 @@ TEST_LIST = {
   { "test_1x2v_vlasov_dev", test_1x2v_vlasov_dev },
   { "test_1x1v_gk_dev", test_1x1v_gk_dev },
   { "test_1x2v_gk_dev", test_1x2v_gk_dev },
+  { "test_2x2v_gk_dev", test_2x2v_gk_dev },
+  { "test_3x2v_gk_dev", test_3x2v_gk_dev },
 #endif
   { NULL, NULL },
 };

--- a/unit/ctest_dg_interpolate.c
+++ b/unit/ctest_dg_interpolate.c
@@ -2274,35 +2274,35 @@ void test_2x2v_gk_hodev(bool use_gpu)
 
 void test_3x2v_gk_hodev(bool use_gpu)
 {
-//  // Refine along x.
-//  int cells_do0[] = {6, 6, 8, 8, 4};
-//  int cells_tar0[] = {12, 6, 8, 8, 4};
-//  test_3x2v_gk(cells_do0, cells_tar0, 1, use_gpu);
-//
-//  // Coarsen along x.
-//  int cells_do1[] = {16, 6, 8, 8, 4};
-//  int cells_tar1[] = {8, 6, 8, 8, 4};
-//  test_3x2v_gk(cells_do1, cells_tar1, 1, use_gpu);
-//
-//  // Refine along y.
-//  int cells_do2[] = {6, 6, 8, 8, 4};
-//  int cells_tar2[] = {6, 12, 8, 8, 4};
-//  test_3x2v_gk(cells_do2, cells_tar2, 1, use_gpu);
-//
-//  // Coarsen along y.
-//  int cells_do3[] = {6, 16, 8, 8, 4};
-//  int cells_tar3[] = {6, 8, 8, 8, 4};
-//  test_3x2v_gk(cells_do3, cells_tar3, 1, use_gpu);
+  // Refine along x.
+  int cells_do0[] = {6, 6, 8, 8, 4};
+  int cells_tar0[] = {12, 6, 8, 8, 4};
+  test_3x2v_gk(cells_do0, cells_tar0, 1, use_gpu);
+
+  // Coarsen along x.
+  int cells_do1[] = {16, 6, 8, 8, 4};
+  int cells_tar1[] = {8, 6, 8, 8, 4};
+  test_3x2v_gk(cells_do1, cells_tar1, 1, use_gpu);
+
+  // Refine along y.
+  int cells_do2[] = {6, 6, 8, 8, 4};
+  int cells_tar2[] = {6, 12, 8, 8, 4};
+  test_3x2v_gk(cells_do2, cells_tar2, 1, use_gpu);
+
+  // Coarsen along y.
+  int cells_do3[] = {6, 16, 8, 8, 4};
+  int cells_tar3[] = {6, 8, 8, 8, 4};
+  test_3x2v_gk(cells_do3, cells_tar3, 1, use_gpu);
 
   // Refine along x and y.
-  int cells_do4[] = {12, 12, 8, 8, 4};
-  int cells_tar4[] = {16, 16, 8, 8, 4};
+  int cells_do4[] = {96, 96, 8, 8, 4};
+  int cells_tar4[] = {128, 128, 8, 8, 4};
   test_3x2v_gk(cells_do4, cells_tar4, 1, use_gpu);
 
-//  // Coarsen along x and y.
-//  int cells_do5[] = {16, 16, 8, 8, 4};
-//  int cells_tar5[] = {8, 8, 8, 8, 4};
-//  test_3x2v_gk(cells_do5, cells_tar5, 1, use_gpu);
+  // Coarsen along x and y.
+  int cells_do5[] = {16, 16, 8, 8, 4};
+  int cells_tar5[] = {8, 8, 8, 8, 4};
+  test_3x2v_gk(cells_do5, cells_tar5, 1, use_gpu);
 }
 
 void test_1x_ho()

--- a/unit/ctest_dg_interpolate.c
+++ b/unit/ctest_dg_interpolate.c
@@ -198,7 +198,7 @@ void eval_fdonor_2x(double t, const double *xn, double* restrict fout, void *ctx
 void
 test_2x(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  double lower[] = {9.460546e-01, -1.078908e-01}, upper[] = {1.053945e+00, 1.078908e-01};
+  double lower[] = {0.0, -M_PI}, upper[] = {1.0, M_PI};
   double mass = 1.0;
 
   const int ndim = sizeof(lower)/sizeof(lower[0]);

--- a/zero/dg_interpolate.c
+++ b/zero/dg_interpolate.c
@@ -17,22 +17,6 @@ gkyl_dg_interpolate_new(int cdim, const struct gkyl_basis *basis,
   up->grid_do = *grid_do;
   up->grid_tar = *grid_tar;
 
-  printf("\n");
-  printf("grid_do:\n");
-  printf("  lower: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_do->lower[0],grid_do->lower[1],grid_do->lower[2],grid_do->lower[3],grid_do->lower[4]);
-  printf("  upper: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_do->upper[0],grid_do->upper[1],grid_do->upper[2],grid_do->upper[3],grid_do->upper[4]);
-  printf("  cells: %d, %d, %d, %d, %d\n",grid_do->cells[0],grid_do->cells[1],grid_do->cells[2],grid_do->cells[3],grid_do->cells[4]);
-  printf("grid_tar:\n");
-  printf("  lower: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_tar->lower[0],grid_tar->lower[1],grid_tar->lower[2],grid_tar->lower[3],grid_tar->lower[4]);
-  printf("  upper: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_tar->upper[0],grid_tar->upper[1],grid_tar->upper[2],grid_tar->upper[3],grid_tar->upper[4]);
-  printf("  cells: %d, %d, %d, %d, %d\n",grid_tar->cells[0],grid_tar->cells[1],grid_tar->cells[2],grid_tar->cells[3],grid_tar->cells[4]);
-  printf("range_do:\n");
-  printf("  lower: %d, %d, %d, %d, %d\n",range_do->lower[0],range_do->lower[1],range_do->lower[2],range_do->lower[3],range_do->lower[4]);
-  printf("  upper: %d, %d, %d, %d, %d\n",range_do->upper[0],range_do->upper[1],range_do->upper[2],range_do->upper[3],range_do->upper[4]);
-  printf("range_tar:\n");
-  printf("  lower: %d, %d, %d, %d, %d\n",range_tar->lower[0],range_tar->lower[1],range_tar->lower[2],range_tar->lower[3],range_tar->lower[4]);
-  printf("  upper: %d, %d, %d, %d, %d\n",range_tar->upper[0],range_tar->upper[1],range_tar->upper[2],range_tar->upper[3],range_tar->upper[4]);
-
   // Perform some basic checks:
   assert(grid_do->ndim == grid_tar->ndim);
   for (int d=0; d<up->ndim; d++) {
@@ -128,9 +112,10 @@ gkyl_dg_interpolate_new(int cdim, const struct gkyl_basis *basis,
     // Brute force search. Start with the size of the boundary stencil.
     int maxSize = floor(up->dxRat) + ceil( up->dxRat-floor(up->dxRat) );
     for (int i=2; i<grid_do->cells[up->dir]; i++) {
-       double decimalL = 1-((i-1)*up->dxRat-floor((i-1)*up->dxRat));
-       double decimalU = 1-(ceil(i*up->dxRat)-i*up->dxRat);
-       int currSize = floor(up->dxRat-decimalL-decimalU) + ceil(decimalL) + ceil(decimalU);
+       double decimalL = 1.0-((i-1)*up->dxRat-floor((i-1)*up->dxRat));
+       double decimalU = 1.0-(ceil(i*up->dxRat)-i*up->dxRat);
+       int currSize = dg_interp_floor(up->dxRat-decimalL-decimalU, 1e-14, 0.0) + dg_interp_ceil(decimalL, 1e-14, 0.0)
+         + dg_interp_ceil(decimalU, 1e-14, 0.0);
        maxSize = GKYL_MAX2(maxSize, currSize);
     }
     intStencilSize = maxSize;

--- a/zero/dg_interpolate.c
+++ b/zero/dg_interpolate.c
@@ -17,6 +17,22 @@ gkyl_dg_interpolate_new(int cdim, const struct gkyl_basis *basis,
   up->grid_do = *grid_do;
   up->grid_tar = *grid_tar;
 
+  printf("\n");
+  printf("grid_do:\n");
+  printf("  lower: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_do->lower[0],grid_do->lower[1],grid_do->lower[2],grid_do->lower[3],grid_do->lower[4]);
+  printf("  upper: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_do->upper[0],grid_do->upper[1],grid_do->upper[2],grid_do->upper[3],grid_do->upper[4]);
+  printf("  cells: %d, %d, %d, %d, %d\n",grid_do->cells[0],grid_do->cells[1],grid_do->cells[2],grid_do->cells[3],grid_do->cells[4]);
+  printf("grid_tar:\n");
+  printf("  lower: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_tar->lower[0],grid_tar->lower[1],grid_tar->lower[2],grid_tar->lower[3],grid_tar->lower[4]);
+  printf("  upper: %.9e, %.9e, %.9e, %.9e, %.9e\n",grid_tar->upper[0],grid_tar->upper[1],grid_tar->upper[2],grid_tar->upper[3],grid_tar->upper[4]);
+  printf("  cells: %d, %d, %d, %d, %d\n",grid_tar->cells[0],grid_tar->cells[1],grid_tar->cells[2],grid_tar->cells[3],grid_tar->cells[4]);
+  printf("range_do:\n");
+  printf("  lower: %d, %d, %d, %d, %d\n",range_do->lower[0],range_do->lower[1],range_do->lower[2],range_do->lower[3],range_do->lower[4]);
+  printf("  upper: %d, %d, %d, %d, %d\n",range_do->upper[0],range_do->upper[1],range_do->upper[2],range_do->upper[3],range_do->upper[4]);
+  printf("range_tar:\n");
+  printf("  lower: %d, %d, %d, %d, %d\n",range_tar->lower[0],range_tar->lower[1],range_tar->lower[2],range_tar->lower[3],range_tar->lower[4]);
+  printf("  upper: %d, %d, %d, %d, %d\n",range_tar->upper[0],range_tar->upper[1],range_tar->upper[2],range_tar->upper[3],range_tar->upper[4]);
+
   // Perform some basic checks:
   assert(grid_do->ndim == grid_tar->ndim);
   for (int d=0; d<up->ndim; d++) {

--- a/zero/dg_interpolate.c
+++ b/zero/dg_interpolate.c
@@ -114,8 +114,8 @@ gkyl_dg_interpolate_new(int cdim, const struct gkyl_basis *basis,
     for (int i=2; i<grid_do->cells[up->dir]; i++) {
        double decimalL = 1.0-((i-1)*up->dxRat-floor((i-1)*up->dxRat));
        double decimalU = 1.0-(ceil(i*up->dxRat)-i*up->dxRat);
-       int currSize = dg_interp_floor(up->dxRat-decimalL-decimalU, 1e-14, 0.0) + dg_interp_ceil(decimalL, 1e-14, 0.0)
-         + dg_interp_ceil(decimalU, 1e-14, 0.0);
+       int currSize = dg_interp_floor(up->dxRat-decimalL-decimalU, 1e-13, 0.0) + dg_interp_ceil(decimalL, 1e-13, 0.0)
+         + dg_interp_ceil(decimalU, 1e-13, 0.0);
        maxSize = GKYL_MAX2(maxSize, currSize);
     }
     intStencilSize = maxSize;

--- a/zero/gkyl_dg_interpolate_priv.h
+++ b/zero/gkyl_dg_interpolate_priv.h
@@ -204,6 +204,24 @@ dg_interp_choose_gk_interp_kernel(int cdim, struct gkyl_basis basis, int dir)
   return 0;
 }
 
+static int dg_interp_floor(double a, double tol, double b)
+{
+  // Floor function but if tol<|a|, it assumes it is b;
+  if (tol < fabs(a))
+    return floor(a);
+  else
+    return b;
+}
+
+static int dg_interp_ceil(double a, double tol, double b)
+{
+  // Ceiling function but if tol<|a|, it assumes it is b;
+  if (tol < fabs(a))
+    return ceil(a);
+  else
+    return b;
+}
+
 static int dg_interp_prime_factors(int n, int *pfs, int pfs_size)
 {
   // Find the prime factors of number `n`, and put them into `pfs`. We assume
@@ -321,12 +339,8 @@ dg_interpolate_check_cell_overlap(struct gkyl_dg_interpolate *up, const struct g
       for (int d=0; d<up->ndim; d++) {
         bool overlaps = (xlo_do[d] <= xup_tar[d]) && (xlo_tar[d] <= xup_do[d]);
         if (!overlaps) {
-//        if (!overlaps || (
-////				idx_do[0]==1 &&	idx_do[1]==10 &&	idx_do[2]==1 &&	idx_do[3]==1 &&	idx_do[4]==1 &&
-//				idx_tar[0]==1 &&	idx_tar[1]==15 &&	idx_tar[2]==1 &&	idx_tar[3]==1 &&	idx_tar[4]==1
-//			 )) {
           // Print some info and exit.
-          printf("\nidx_sten=%d offset_upper[idx_sten]=%d off=%d idx_tar_lo=%d idx_do=",idx_sten,offset_upper[idx_sten],off,idx_tar_lo);
+          printf("\nidx_do=");
           for (int d=0; d<up->ndim; d++)
             printf("%d ",idx_do[d]);
           printf(" extents=");

--- a/zero/gkyl_dg_interpolate_priv.h
+++ b/zero/gkyl_dg_interpolate_priv.h
@@ -321,8 +321,12 @@ dg_interpolate_check_cell_overlap(struct gkyl_dg_interpolate *up, const struct g
       for (int d=0; d<up->ndim; d++) {
         bool overlaps = (xlo_do[d] <= xup_tar[d]) && (xlo_tar[d] <= xup_do[d]);
         if (!overlaps) {
+//        if (!overlaps || (
+////				idx_do[0]==1 &&	idx_do[1]==10 &&	idx_do[2]==1 &&	idx_do[3]==1 &&	idx_do[4]==1 &&
+//				idx_tar[0]==1 &&	idx_tar[1]==15 &&	idx_tar[2]==1 &&	idx_tar[3]==1 &&	idx_tar[4]==1
+//			 )) {
           // Print some info and exit.
-          printf("\nidx_do=");
+          printf("\nidx_sten=%d offset_upper[idx_sten]=%d off=%d idx_tar_lo=%d idx_do=",idx_sten,offset_upper[idx_sten],off,idx_tar_lo);
           for (int d=0; d<up->ndim; d++)
             printf("%d ",idx_do[d]);
           printf(" extents=");
@@ -330,7 +334,7 @@ dg_interpolate_check_cell_overlap(struct gkyl_dg_interpolate *up, const struct g
             printf("[%e,%e] ",xlo_do[d],xup_do[d]);
           printf("\nidx_tar=");
           for (int d=0; d<up->ndim; d++)
-            printf("%d ",idx_do[d]);
+            printf("%d ",idx_tar[d]);
           printf(" extents=");
           for (int d=0; d<up->ndim; d++)
             printf("[%e,%e] ",xlo_tar[d],xup_tar[d]);


### PR DESCRIPTION
This bug only shows up in some machines (e.g. Stellar but not Mac), and for some resolutions.  The problem is that a `floor` function was used to bring things down to 0, but sometimes the argument was -1e-15 and it brought things down to -1.

Unit tests pass.