### PR TITLE
Stack overflow memory issues in position map

### DIFF
--- a/zero/gkyl_position_map.h
+++ b/zero/gkyl_position_map.h
@@ -67,9 +67,9 @@ struct gkyl_position_map_const_B_ctx {
   // Constant B mapping
   int N_theta_boundaries; // Number of times dB/dz changes sign
   int num_extrema; // Number of extrema in the magnetic field
-  double theta_extrema[16]; // The theta values of the extrema
-  double bmag_extrema[16]; // The Bmag values of the extrema
-  bool min_or_max[16]; // Whether the extrema is a minima or maxima. 1 is maxima, 0 is minima
+  double *theta_extrema; // The theta values of the extrema
+  double *bmag_extrema; // The Bmag values of the extrema
+  bool *min_or_max; // Whether the extrema is a minima or maxima. 1 is maxima, 0 is minima
   double dB_cell; // The change in Bmag per cell
 };
 

--- a/zero/gkyl_position_map_priv.h
+++ b/zero/gkyl_position_map_priv.h
@@ -355,12 +355,12 @@ find_B_field_extrema(struct gkyl_position_map *gpm)
   }
   
   // Set final extrema after the loop. MR April 22 2025
-  theta_extrema[0] = theta_lo;
-  xp[Z_IDX] = theta_lo;
+  theta_extrema[0] = constB_ctx->theta_min;
+  xp[Z_IDX] = constB_ctx->theta_min;
   gkyl_calc_bmag_global(0.0, xp, &bmag_extrema[0], bmag_ctx);
 
-  theta_extrema[extrema] = theta_hi;
-  xp[Z_IDX] = theta_hi;
+  theta_extrema[extrema] = constB_ctx->theta_max;
+  xp[Z_IDX] = constB_ctx->theta_max;
   gkyl_calc_bmag_global(0.0, xp, &bmag_extrema[extrema], bmag_ctx);
   extrema++;
 

--- a/zero/gkyl_position_map_priv.h
+++ b/zero/gkyl_position_map_priv.h
@@ -307,12 +307,12 @@ find_B_field_extrema(struct gkyl_position_map *gpm)
   double theta_lo = constB_ctx->theta_min;
   double theta_hi = constB_ctx->theta_max;
   double theta_dxi = (theta_hi - theta_lo) / npts;
-  double bmag_vals[npts];
-  double dbmag_vals[npts];
+  double *bmag_vals = gkyl_malloc(sizeof(double) * (npts + 1));
+  double *dbmag_vals = gkyl_malloc(sizeof(double) * (npts + 1));
 
   int extrema = 1; // Offset by 1 for the first point
-  double theta_extrema[16];
-  double bmag_extrema[16];
+  double *theta_extrema = gkyl_malloc(sizeof(double) * (npts + 1));
+  double *bmag_extrema = gkyl_malloc(sizeof(double) * (npts + 1));
 
   for (int i = 0; i <= npts; i++){
     double theta = theta_lo + i * theta_dxi;
@@ -399,6 +399,12 @@ find_B_field_extrema(struct gkyl_position_map *gpm)
   {    gpm->constB_ctx->min_or_max[extrema-1] = 0; } // Minimum
   else  
   {    printf("Error: Extrema is not an extrema. Position_map optimization failed\n");  }
+
+  // Free mallocs
+  gkyl_free(bmag_vals);
+  gkyl_free(dbmag_vals);
+  gkyl_free(theta_extrema);
+  gkyl_free(bmag_extrema);
 }
 
 /**

--- a/zero/position_map.c
+++ b/zero/position_map.c
@@ -111,6 +111,10 @@ gkyl_position_map_set_bmag(struct gkyl_position_map* gpm, struct gkyl_comm* comm
   struct gkyl_array* bmag)
 {
   gpm->to_optimize = true;
+  int N_boundaries = gpm->constB_ctx->N_theta_boundaries;
+  gpm->constB_ctx->theta_extrema = gkyl_malloc(sizeof(double) * N_boundaries);
+  gpm->constB_ctx->bmag_extrema = gkyl_malloc(sizeof(double) * N_boundaries);
+  gpm->constB_ctx->min_or_max = gkyl_malloc(sizeof(bool) * N_boundaries);
   if (comm == NULL) {
     gkyl_array_release(gpm->bmag_ctx->bmag);
     gpm->bmag_ctx->bmag = gkyl_array_acquire(bmag);
@@ -248,6 +252,12 @@ gkyl_position_map_free(const struct gkyl_ref_count *ref)
   struct gkyl_position_map *gpm = container_of(ref, struct gkyl_position_map, ref_count);
   gkyl_array_release(gpm->mc2nu);
   gkyl_array_release(gpm->bmag_ctx->bmag);
+  if (gpm->to_optimize == true)
+  {
+    gkyl_free(gpm->constB_ctx->theta_extrema);
+    gkyl_free(gpm->constB_ctx->bmag_extrema);
+    gkyl_free(gpm->constB_ctx->min_or_max);
+  }
   gkyl_free(gpm->bmag_ctx);
   gkyl_free(gpm->constB_ctx);
   gkyl_free(gpm);


### PR DESCRIPTION
The issue is that the position map was allocating `double foo[]` objects of hundreds of lengths, which was overflowing the stack. Instead, we should malloc this kind of memory and free it.

The memory can be allocated when bmag is set and the `to_optimize` flag is tripped. Without having B in the position map, these objects are not used because there is no magnetic field to loop over. It's also a convenient flag to use in memory-free operations.

Before this fix, Perlmutter segfaulted at a later stage of the optimization because memory was freed from the stack that it needed to access.

rt_gk_wham_nonuniformx_1x2v_numeric is valgrind clean.
Valgrind did not show me any issues with a stack overflow here.

Tested on stellar-amd, personal Ubuntu 24.04, and perlmutter with rt_gk_wham_nonuniformx_1x2v_numeric. Geometry looks correct. Peaks of B are detected correctly.

Tested using GPU builds on stellar-amd and Perlmutter, but a CPU build on my Ubuntu laptop.