### PR TITLE
Correct and centralize creation of core/SOL ranges in IWL GK sims

### DIFF
--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -800,7 +800,6 @@ gk_field_release(const gkyl_gyrokinetic_app* app, struct gk_field *f)
       gkyl_bc_twistshift_release(f->bc_T_LU_lo);
     }
     gkyl_skin_surf_from_ghost_release(f->ssfg_lo);
-    // gkyl_array_release(f->bc_buffer);
   }
 
   gkyl_dynvec_release(f->integ_energy);

--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -61,10 +61,7 @@ gk_field_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_
   // Define sub range of ghost and skin cells that spans only the core
   double xLCFS = app->gk_geom->x_LCFS;
   // Index of the cell that abuts the xLCFS from below.
-  int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
-
-  // check that idxLCFS_m is within the local range
-  assert(idxLCFS_m >= app->local.lower[0] && idxLCFS_m <= app->local.upper[0]);
+  int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
 
   // Create a core local range, extended in the BC dir.
   int ndim = app->cdim;
@@ -309,7 +306,7 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
     // construct core and SOL ranges.
     double xLCFS = app->gk_geom->x_LCFS;
     // Index of the cell that abuts the xLCFS from below.
-    int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
+    int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
     gkyl_range_shorten_from_below(&f->global_sol, &app->global, 0, app->grid.cells[0]-idxLCFS_m+1);
     gkyl_range_shorten_from_below(&f->global_ext_sol, &app->global_ext, 0, app->grid.cells[0]-idxLCFS_m+1);
     gkyl_range_shorten_from_above(&f->global_core, &app->global, 0, idxLCFS_m+1);

--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -59,7 +59,7 @@ gk_field_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_
   int zdir = app->cdim - 1;
 
   // Define sub range of ghost and skin cells that spans only the core
-  double xLCFS = f->info.xLCFS;
+  double xLCFS = app->gk_geom->x_LCFS;
   // Index of the cell that abuts the xLCFS from below.
   int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
 
@@ -307,7 +307,7 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
       fem_parproj_bc_sol = GKYL_FEM_PARPROJ_NONE;
     }
     // construct core and SOL ranges.
-    double xLCFS = f->info.xLCFS;
+    double xLCFS = app->gk_geom->x_LCFS;
     // Index of the cell that abuts the xLCFS from below.
     int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
     gkyl_range_shorten_from_below(&f->global_sol, &app->global, 0, app->grid.cells[0]-idxLCFS_m+1);

--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -55,25 +55,8 @@ gk_field_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_
   struct gk_species *gks = &app->species[0];
   // Get the z BC info from the first species in our app
   const struct gkyl_gyrokinetic_bcs *bcz = &gks->info.bcz;
-  // define the parallel direction index (handle 2x and 3x cases)
+  // Define the parallel direction index (handle 2x and 3x cases).
   int zdir = app->cdim - 1;
-
-  // Define sub range of ghost and skin cells that spans only the core
-  double xLCFS = app->gk_geom->x_LCFS;
-  // Index of the cell that abuts the xLCFS from below.
-  int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
-
-  // Create a core local range, extended in the BC dir.
-  int ndim = app->cdim;
-  int lower_bcdir_ext[ndim], upper_bcdir_ext[ndim];
-  for (int i=0; i<ndim; i++) {
-    lower_bcdir_ext[i] = app->local.lower[i];
-    upper_bcdir_ext[i] = app->local.upper[i];
-  }
-  upper_bcdir_ext[0] = idxLCFS_m;
-  lower_bcdir_ext[zdir] = app->local_ext.lower[zdir];
-  upper_bcdir_ext[zdir] = app->local_ext.upper[zdir];
-  gkyl_sub_range_init(&f->local_par_ext_core, &app->local_ext, lower_bcdir_ext, upper_bcdir_ext);
 
   // TSBC updaters
   int ghost[] = {1, 1, 1};
@@ -86,7 +69,7 @@ gk_field_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_
       .shear_dir = 0, // shift varies with x.
       .edge = GKYL_LOWER_EDGE,
       .cdim = app->cdim,
-      .bcdir_ext_update_r = f->local_par_ext_core,
+      .bcdir_ext_update_r = app->local_par_ext_core,
       .num_ghost = ghost, // one ghost per config direction
       .basis = app->basis,
       .grid = app->grid,
@@ -98,17 +81,9 @@ gk_field_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_
     f->bc_T_LU_lo = gkyl_bc_twistshift_new(&T_LU_lo);
   }
 
-  // SSFG updaters
-  int ghost_par[] = {0, 0, 0};
-  ghost_par[zdir] = 1;
-  // create lower and upper skin and ghost ranges for the z BC in the core region
-  gkyl_skin_ghost_ranges( &f->lower_skin_core, &f->lower_ghost_core, zdir, 
-                          GKYL_LOWER_EDGE, &f->local_par_ext_core, ghost_par);
-  gkyl_skin_ghost_ranges( &f->upper_skin_core, &f->upper_ghost_core, zdir, 
-                          GKYL_UPPER_EDGE, &f->local_par_ext_core, ghost_par);
-  // add the SSFG updater for lower and upper application
-  f->ssfg_lo = gkyl_skin_surf_from_ghost_new(zdir,GKYL_LOWER_EDGE,
-                app->basis,&f->lower_skin_core,&f->lower_ghost_core,app->use_gpu);
+  // Add the SSFG updater for lower and upper application.
+  f->ssfg_lo = gkyl_skin_surf_from_ghost_new(zdir, GKYL_LOWER_EDGE,
+    app->basis, &app->lower_skin_par_core, &app->lower_ghost_par_core, app->use_gpu);
 }
 
 static void
@@ -303,18 +278,10 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
       fem_parproj_bc_core = GKYL_FEM_PARPROJ_NONE;
       fem_parproj_bc_sol = GKYL_FEM_PARPROJ_NONE;
     }
-    // construct core and SOL ranges.
-    double xLCFS = app->gk_geom->x_LCFS;
-    // Index of the cell that abuts the xLCFS from below.
-    int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
-    gkyl_range_shorten_from_below(&f->global_sol, &app->global, 0, app->grid.cells[0]-idxLCFS_m+1);
-    gkyl_range_shorten_from_below(&f->global_ext_sol, &app->global_ext, 0, app->grid.cells[0]-idxLCFS_m+1);
-    gkyl_range_shorten_from_above(&f->global_core, &app->global, 0, idxLCFS_m+1);
-    gkyl_range_shorten_from_above(&f->global_ext_core, &app->global_ext, 0, idxLCFS_m+1);
 
-    f->fem_parproj_core = gkyl_fem_parproj_new(&f->global_core, &app->basis,
+    f->fem_parproj_core = gkyl_fem_parproj_new(&app->global_core, &app->basis,
       fem_parproj_bc_core, 0, 0, app->use_gpu);
-    f->fem_parproj_sol = gkyl_fem_parproj_new(&f->global_sol, &app->basis,
+    f->fem_parproj_sol = gkyl_fem_parproj_new(&app->global_sol, &app->basis,
       fem_parproj_bc_sol, 0, 0, app->use_gpu);
   } 
   else {

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -928,13 +928,6 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
       // applying sheath BCs in the SOL.
       gks->periodic_dirs[gks->num_periodic_dir] = app->cdim-1; // The last direction is the parallel one.
       gks->num_periodic_dir += 1;
-      // Check that the LCFS is the same on both BCs and that it's on a cell boundary within our grid.
-      double xLCFS = app->gk_geom->x_LCFS;
-      assert(fabs(xLCFS-gks->upper_bc[dir].aux_parameter) < 1e-14);
-      // Check the split happens within the domain and at a cell boundary.
-      assert((app->grid.lower[0]<xLCFS) && (xLCFS<app->grid.upper[0]));
-      double needint = (xLCFS-app->grid.lower[0])/app->grid.dx[0];
-      assert(floor(fabs(needint-floor(needint))) < 1.);
     }
   }
   
@@ -1015,7 +1008,7 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
     else if (gks->lower_bc[d].type == GKYL_SPECIES_GK_IWL) {
       double xLCFS = app->gk_geom->x_LCFS;
       // Index of the cell that abuts the xLCFS from below.
-      int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
+      int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
       gkyl_range_shorten_from_below(&gks->lower_skin_par_sol, &gks->lower_skin[d], 0, app->grid.cells[0]-idxLCFS_m+1);
       gkyl_range_shorten_from_below(&gks->lower_ghost_par_sol, &gks->lower_ghost[d], 0, app->grid.cells[0]-idxLCFS_m+1);
 
@@ -1092,7 +1085,7 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
     else if (gks->upper_bc[d].type == GKYL_SPECIES_GK_IWL) {
       double xLCFS = app->gk_geom->x_LCFS;
       // Index of the cell that abuts the xLCFS from below.
-      int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
+      int idxLCFS_m = app->gk_geom->idx_LCFS_lo;
       gkyl_range_shorten_from_below(&gks->upper_skin_par_sol, &gks->upper_skin[d], 0, app->grid.cells[0]-idxLCFS_m+1);
       gkyl_range_shorten_from_below(&gks->upper_ghost_par_sol, &gks->upper_ghost[d], 0, app->grid.cells[0]-idxLCFS_m+1);
 

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -929,7 +929,7 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
       gks->periodic_dirs[gks->num_periodic_dir] = app->cdim-1; // The last direction is the parallel one.
       gks->num_periodic_dir += 1;
       // Check that the LCFS is the same on both BCs and that it's on a cell boundary within our grid.
-      double xLCFS = gks->lower_bc[dir].aux_parameter;
+      double xLCFS = app->gk_geom->x_LCFS;
       assert(fabs(xLCFS-gks->upper_bc[dir].aux_parameter) < 1e-14);
       // Check the split happens within the domain and at a cell boundary.
       assert((app->grid.lower[0]<xLCFS) && (xLCFS<app->grid.upper[0]));
@@ -1013,7 +1013,7 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
         cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
     }
     else if (gks->lower_bc[d].type == GKYL_SPECIES_GK_IWL) {
-      double xLCFS = gks->lower_bc[d].aux_parameter;
+      double xLCFS = app->gk_geom->x_LCFS;
       // Index of the cell that abuts the xLCFS from below.
       int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
       gkyl_range_shorten_from_below(&gks->lower_skin_par_sol, &gks->lower_skin[d], 0, app->grid.cells[0]-idxLCFS_m+1);
@@ -1090,7 +1090,7 @@ gk_species_new_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *
         cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
     }
     else if (gks->upper_bc[d].type == GKYL_SPECIES_GK_IWL) {
-      double xLCFS = gks->upper_bc[d].aux_parameter;
+      double xLCFS = app->gk_geom->x_LCFS;
       // Index of the cell that abuts the xLCFS from below.
       int idxLCFS_m = (xLCFS-1e-8 - app->grid.lower[0])/app->grid.dx[0]+1;
       gkyl_range_shorten_from_below(&gks->upper_skin_par_sol, &gks->upper_skin[d], 0, app->grid.cells[0]-idxLCFS_m+1);

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -1672,11 +1672,11 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
 
     int len_core_ext = idx_LCFS_lo+1;
     int len_sol_ext = gks->global_ext.upper[0]-len_core;
-    gkyl_range_shorten_from_above(&gks->global_ext_core, &gks->global_ext, 0, len_core);
-    gkyl_range_shorten_from_below(&gks->global_ext_sol , &gks->global_ext, 0, len_sol);
+    gkyl_range_shorten_from_above(&gks->global_ext_core, &gks->global_ext, 0, len_core_ext);
+    gkyl_range_shorten_from_below(&gks->global_ext_sol , &gks->global_ext, 0, len_sol_ext);
     // Same for local ranges.
-    gkyl_range_shorten_from_above(&gks->local_ext_core , &gks->local_ext , 0, len_core);
-    gkyl_range_shorten_from_below(&gks->local_ext_sol  , &gks->local_ext , 0, len_sol);
+    gkyl_range_shorten_from_above(&gks->local_ext_core , &gks->local_ext , 0, len_core_ext);
+    gkyl_range_shorten_from_below(&gks->local_ext_sol  , &gks->local_ext , 0, len_sol_ext);
 
     // Create core and SOL parallel skin and ghost ranges.
     int par_dir = app->cdim-1;

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -140,12 +140,14 @@ struct gkyl_gyrokinetic_geometry {
   // pointer to bmag function
   void (*bmag_func)(double t, const double *xc, double *xp, void *ctx);
 
+  double world[3]; // extra computational coordinates for cases with reduced dimensionality
+
+  double x_LCFS; // x coordinate of the last closed flux surface.
+
   struct gkyl_efit_inp efit_info; // context with RZ data such as efit file for a tokamak or mirror
   struct gkyl_tok_geo_grid_inp tok_grid_info; // context for tokamak geometry with computational domain info
   struct gkyl_mirror_geo_grid_inp mirror_grid_info; // context for mirror geometry with computational domain info
   struct gkyl_position_map_inp position_map_info; // position map object
-
-  double world[3]; // extra computational coordinates for cases with reduced dimensionality
 };
 
 // Parameters for species radiation
@@ -341,7 +343,6 @@ struct gkyl_gyrokinetic_field {
 
   double polarization_bmag; 
   double kperpSq; // kperp^2 parameter for 1D field equations
-  double xLCFS; // radial location of the LCFS.
 
   // parameters for adiabatic electrons simulations
   double electron_mass, electron_charge, electron_density, electron_temp;

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -142,7 +142,8 @@ struct gkyl_gyrokinetic_geometry {
 
   double world[3]; // extra computational coordinates for cases with reduced dimensionality
 
-  double x_LCFS; // x coordinate of the last closed flux surface.
+  bool has_LCFS; // Whether the geometry has a last closed flux surface (LCFS).
+  double x_LCFS; // x coordinate of the LCFS.
 
   struct gkyl_efit_inp efit_info; // context with RZ data such as efit file for a tokamak or mirror
   struct gkyl_tok_geo_grid_inp tok_grid_info; // context for tokamak geometry with computational domain info

--- a/apps/gkyl_gyrokinetic_multib.h
+++ b/apps/gkyl_gyrokinetic_multib.h
@@ -157,7 +157,6 @@ struct gkyl_gyrokinetic_multib_field_pb {
 struct gkyl_gyrokinetic_multib_field {
   enum gkyl_gkfield_id gkfield_id;
   double kperpSq; // kperp^2 parameter for 1D field equations
-  double xLCFS; // radial location of the LCFS.
 
   // parameters for adiabatic electrons simulations
   double electron_mass, electron_charge, electron_density, electron_temp;

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -710,11 +710,15 @@ struct gk_species {
   struct gkyl_range global_lower_ghost[GKYL_MAX_DIM];
   struct gkyl_range global_upper_skin[GKYL_MAX_DIM];
   struct gkyl_range global_upper_ghost[GKYL_MAX_DIM];
-  // GK_IWL sims need SOL ghost and skin ranges.
-  struct gkyl_range lower_skin_par_sol, lower_ghost_par_sol;
-  struct gkyl_range upper_skin_par_sol, upper_ghost_par_sol;
+  // Core and SOL ranges for IWL sims.
+  struct gkyl_range global_core, global_ext_core, global_sol, global_ext_sol;
+  struct gkyl_range local_core, local_ext_core, local_sol, local_ext_sol;
+  struct gkyl_range lower_skin_par_core, lower_ghost_par_core;
+  struct gkyl_range upper_skin_par_core, upper_ghost_par_core;
+  struct gkyl_range lower_skin_par_sol , lower_ghost_par_sol;
+  struct gkyl_range upper_skin_par_sol , upper_ghost_par_sol;
   // GK IWL sims need a core range extended in z, and a TS BC updater.
-  struct gkyl_range local_par_ext_core;
+  struct gkyl_range local_par_ext_core; // Core range extended in parallel direction.
   struct gkyl_bc_twistshift *bc_ts_lo, *bc_ts_up;
 
   struct gk_proj proj_init; // Projector for initial conditions.
@@ -1007,19 +1011,12 @@ struct gk_field {
   struct gkyl_array *phi_wall_up_host; // host copy for use in IO and projecting
   gkyl_eval_on_nodes *phi_wall_up_proj; // projector for biased wall potential on upper wall 
 
-  // Core and SOL ranges for IWL sims.
-  struct gkyl_range global_core, global_ext_core, global_sol, global_ext_sol;
-
-
   // Pointer to function that computes the time rate of change of the energy.
   void (*calc_energy_dt_func)(gkyl_gyrokinetic_app *app, const struct gk_field *field, double dt, double *energy_reduced);
 
   // Objects used in IWL simulations and TS BCs.
-  struct gkyl_range local_par_ext_core; // Core range extended in parallel direction
   struct gkyl_bc_twistshift *bc_T_LU_lo; // TS BC updater.
   // Objects used by the skin surface to ghost (SSFG) operator.
-  struct gkyl_range lower_skin_core, lower_ghost_core;
-  struct gkyl_range upper_skin_core, upper_ghost_core;
   struct gkyl_skin_surf_from_ghost *ssfg_lo;
   
   // Pointer to function for the twist-and-shift BCs.
@@ -1056,6 +1053,15 @@ struct gkyl_gyrokinetic_app {
   struct gkyl_range global_lower_ghost[GKYL_MAX_DIM];
   struct gkyl_range global_upper_skin[GKYL_MAX_DIM];
   struct gkyl_range global_upper_ghost[GKYL_MAX_DIM];
+
+  // Core and SOL ranges for IWL sims.
+  struct gkyl_range global_core, global_ext_core, global_sol, global_ext_sol;
+  struct gkyl_range local_core, local_ext_core, local_sol, local_ext_sol;
+  struct gkyl_range lower_skin_par_core, lower_ghost_par_core;
+  struct gkyl_range upper_skin_par_core, upper_ghost_par_core;
+  struct gkyl_range lower_skin_par_sol , lower_ghost_par_sol;
+  struct gkyl_range upper_skin_par_sol , upper_ghost_par_sol;
+  struct gkyl_range local_par_ext_core; // Core range extended in parallel direction.
 
   struct gkyl_basis basis; // conf-space basis
   

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -312,6 +312,7 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
     .global_ext = app->global_ext,
     .basis = app->basis,
     .comm = app->comm,
+    .has_LCFS = gk->geometry.has_LCFS,
     .x_LCFS = gk->geometry.x_LCFS,
   };
   for(int i = 0; i<3; i++)
@@ -407,6 +408,50 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
   gkyl_dg_mul_op_range(app->basis, 0, tmp, 0, app->gk_geom->bmag, 0, app->gk_geom->jacobgeo, &app->local); 
   gkyl_dg_inv_op_range(app->basis, 0, app->jacobtot_inv_weak, 0, tmp, &app->local); 
   gkyl_array_release(tmp);
+
+  if (gk->geometry.has_LCFS) {
+    // IWL simulation. Create core and SOL global ranges.
+    int idx_LCFS_lo = app->gk_geom->idx_LCFS_lo;
+    int len_core = idx_LCFS_lo;
+    int len_sol = app->global.upper[0]-len_core;
+    gkyl_range_shorten_from_above(&app->global_core, &app->global, 0, len_core);
+    gkyl_range_shorten_from_below(&app->global_sol , &app->global, 0, len_sol);
+    // Same for local ranges.
+    gkyl_range_shorten_from_above(&app->local_core , &app->local , 0, len_core);
+    gkyl_range_shorten_from_below(&app->local_sol  , &app->local , 0, len_sol);
+
+    int len_core_ext = idx_LCFS_lo+1;
+    int len_sol_ext = app->global_ext.upper[0]-len_core;
+    gkyl_range_shorten_from_above(&app->global_ext_core, &app->global_ext, 0, len_core);
+    gkyl_range_shorten_from_below(&app->global_ext_sol , &app->global_ext, 0, len_sol);
+    // Same for local ranges.
+    gkyl_range_shorten_from_above(&app->local_ext_core , &app->local_ext , 0, len_core);
+    gkyl_range_shorten_from_below(&app->local_ext_sol  , &app->local_ext , 0, len_sol);
+
+    // Create core and SOL parallel skin and ghost ranges.
+    int par_dir = app->cdim-1;
+    for (int e=0; e<2; e++) {
+      gkyl_range_shorten_from_above(e==0? &app->lower_skin_par_core  : &app->upper_skin_par_core,
+                                    e==0? &app->lower_skin[par_dir]  : &app->upper_skin[par_dir], 0, len_core);
+      gkyl_range_shorten_from_above(e==0? &app->lower_ghost_par_core : &app->upper_ghost_par_core,
+                                    e==0? &app->lower_ghost[par_dir] : &app->upper_ghost[par_dir], 0, len_core);
+      gkyl_range_shorten_from_below(e==0? &app->lower_skin_par_sol   : &app->upper_skin_par_sol,
+                                    e==0? &app->lower_skin[par_dir]  : &app->upper_skin[par_dir], 0, len_sol);
+      gkyl_range_shorten_from_below(e==0? &app->lower_ghost_par_sol  : &app->upper_ghost_par_sol,
+                                    e==0? &app->lower_ghost[par_dir] : &app->upper_ghost[par_dir], 0, len_sol);
+    }
+
+    // Create a core local range, extended in the BC dir.
+    int ndim = app->cdim;
+    int lower_bcdir_ext[ndim], upper_bcdir_ext[ndim];
+    for (int i=0; i<ndim; i++) {
+      lower_bcdir_ext[i] = app->local_core.lower[i];
+      upper_bcdir_ext[i] = app->local_core.upper[i];
+    }
+    lower_bcdir_ext[par_dir] = app->local_ext_core.lower[par_dir];
+    upper_bcdir_ext[par_dir] = app->local_ext_core.upper[par_dir];
+    gkyl_sub_range_init(&app->local_par_ext_core, &app->local_ext_core, lower_bcdir_ext, upper_bcdir_ext);
+  }
 
   return app;
 }

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -312,6 +312,7 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
     .global_ext = app->global_ext,
     .basis = app->basis,
     .comm = app->comm,
+    .x_LCFS = gk->geometry.x_LCFS,
   };
   for(int i = 0; i<3; i++)
     geometry_inp.world[i] = gk->geometry.world[i];

--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -422,11 +422,11 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
 
     int len_core_ext = idx_LCFS_lo+1;
     int len_sol_ext = app->global_ext.upper[0]-len_core;
-    gkyl_range_shorten_from_above(&app->global_ext_core, &app->global_ext, 0, len_core);
-    gkyl_range_shorten_from_below(&app->global_ext_sol , &app->global_ext, 0, len_sol);
+    gkyl_range_shorten_from_above(&app->global_ext_core, &app->global_ext, 0, len_core_ext);
+    gkyl_range_shorten_from_below(&app->global_ext_sol , &app->global_ext, 0, len_sol_ext);
     // Same for local ranges.
-    gkyl_range_shorten_from_above(&app->local_ext_core , &app->local_ext , 0, len_core);
-    gkyl_range_shorten_from_below(&app->local_ext_sol  , &app->local_ext , 0, len_sol);
+    gkyl_range_shorten_from_above(&app->local_ext_core , &app->local_ext , 0, len_core_ext);
+    gkyl_range_shorten_from_below(&app->local_ext_sol  , &app->local_ext , 0, len_sol_ext);
 
     // Create core and SOL parallel skin and ghost ranges.
     int par_dir = app->cdim-1;

--- a/apps/gyrokinetic_multib.c
+++ b/apps/gyrokinetic_multib.c
@@ -498,7 +498,6 @@ singleb_app_new_solver(const struct gkyl_gyrokinetic_multib *mbinp, int bid,
   struct gkyl_gyrokinetic_field field_inp = { };
   field_inp.gkfield_id = fld->gkfield_id;
   field_inp.kperpSq = fld->kperpSq; 
-  field_inp.xLCFS = fld->xLCFS; 
   field_inp.time_rate_diagnostics = fld->time_rate_diagnostics; 
 
   // Adiabatic electron inputs.

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -618,8 +618,7 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-//      .num_sources = 2,
-      .num_sources = 1,
+      .num_sources = 2,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
         .ctx_density = &ctx,
@@ -629,23 +628,23 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_elc_srcOMP,
       },
-//      .projection[1] = {
-//        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
-//        .ctx_density = &ctx,
-//        .ctx_upar = &ctx,
-//        .ctx_temp = &ctx,
-//        .density = density_elc_srcGB,
-//        .upar = zero_func,
-//        .temp = temp_elc_srcGB,
-//      },
+      .projection[1] = {
+        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
+        .ctx_density = &ctx,
+        .ctx_upar = &ctx,
+        .ctx_temp = &ctx,
+        .density = density_elc_srcGB,
+        .upar = zero_func,
+        .temp = temp_elc_srcGB,
+      },
     },
 
-//    .diffusion = {
-//      .num_diff_dir = 1,
-//      .diff_dirs = { 0 },
-//      .D = { 0.5 },
-//      .order = 2,
-//    },
+    .diffusion = {
+      .num_diff_dir = 1,
+      .diff_dirs = { 0 },
+      .D = { 0.5 },
+      .order = 2,
+    },
 
     .bcx = {
       .lower = {.type = GKYL_SPECIES_ABSORB,},
@@ -689,8 +688,7 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-//      .num_sources = 2,
-      .num_sources = 1,
+      .num_sources = 2,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
         .ctx_density = &ctx,
@@ -699,24 +697,24 @@ main(int argc, char **argv)
         .density = density_srcOMP,
         .upar = zero_func,
         .temp = temp_ion_srcOMP,
+    },
+      .projection[1] = {
+        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
+        .ctx_density = &ctx,
+        .ctx_upar = &ctx,
+        .ctx_temp = &ctx,
+        .density = density_ion_srcGB,
+        .upar = zero_func,
+        .temp = temp_ion_srcGB,
       },
-//      .projection[1] = {
-//        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
-//        .ctx_density = &ctx,
-//        .ctx_upar = &ctx,
-//        .ctx_temp = &ctx,
-//        .density = density_ion_srcGB,
-//        .upar = zero_func,
-//        .temp = temp_ion_srcGB,
-//      },
     },
 
-//    .diffusion = {
-//      .num_diff_dir = 1,
-//      .diff_dirs = { 0 },
-//      .D = { 0.5 },
-//      .order = 2,
-//    },
+    .diffusion = {
+      .num_diff_dir = 1,
+      .diff_dirs = { 0 },
+      .D = { 0.5 },
+      .order = 2,
+    },
 
     .bcx = {
       .lower = {.type = GKYL_SPECIES_ABSORB,},

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -589,7 +589,7 @@ main(int argc, char **argv)
   // Construct communicator for use in app.
   struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, stderr);
 
-  // electrons
+  // Electrons.
   struct gkyl_gyrokinetic_species elc = {
     .name = "elc",
     .charge = ctx.qe, .mass = ctx.me,
@@ -618,7 +618,8 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .num_sources = 2,
+//      .num_sources = 2,
+      .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
         .ctx_density = &ctx,
@@ -628,40 +629,38 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_elc_srcOMP,
       },
-      .projection[1] = {
-        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
-        .ctx_density = &ctx,
-        .ctx_upar = &ctx,
-        .ctx_temp = &ctx,
-        .density = density_elc_srcGB,
-        .upar = zero_func,
-        .temp = temp_elc_srcGB,
-      },
+//      .projection[1] = {
+//        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
+//        .ctx_density = &ctx,
+//        .ctx_upar = &ctx,
+//        .ctx_temp = &ctx,
+//        .density = density_elc_srcGB,
+//        .upar = zero_func,
+//        .temp = temp_elc_srcGB,
+//      },
     },
 
-    .diffusion = {
-      .num_diff_dir = 1,
-      .diff_dirs = { 0 },
-      .D = { 0.5 },
-      .order = 2,
-    },
+//    .diffusion = {
+//      .num_diff_dir = 1,
+//      .diff_dirs = { 0 },
+//      .D = { 0.5 },
+//      .order = 2,
+//    },
 
     .bcx = {
-      .lower={.type = GKYL_SPECIES_ABSORB,},
-      .upper={.type = GKYL_SPECIES_ABSORB,},
+      .lower = {.type = GKYL_SPECIES_ABSORB,},
+      .upper = {.type = GKYL_SPECIES_ABSORB,},
     },
     .bcy = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,},
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,},
+      .lower = {.type = GKYL_SPECIES_GK_IWL,},
+      .upper = {.type = GKYL_SPECIES_GK_IWL,},
     },
 
-    .num_diag_moments = 5,
-    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
+    .num_diag_moments = 4,
+    .diag_moments = { "M1", "M2par", "M2perp", "BiMaxwellianMoments" },
   };
 
-  // ions
+  // Ions.
   struct gkyl_gyrokinetic_species ion = {
     .name = "ion",
     .charge = ctx.qi, .mass = ctx.mi,
@@ -690,7 +689,8 @@ main(int argc, char **argv)
 
     .source = {
       .source_id = GKYL_PROJ_SOURCE,
-      .num_sources = 2,
+//      .num_sources = 2,
+      .num_sources = 1,
       .projection[0] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
         .ctx_density = &ctx,
@@ -700,43 +700,40 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_ion_srcOMP,
       },
-      .projection[1] = {
-        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
-        .ctx_density = &ctx,
-        .ctx_upar = &ctx,
-        .ctx_temp = &ctx,
-        .density = density_ion_srcGB,
-        .upar = zero_func,
-        .temp = temp_ion_srcGB,
-      },
+//      .projection[1] = {
+//        .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
+//        .ctx_density = &ctx,
+//        .ctx_upar = &ctx,
+//        .ctx_temp = &ctx,
+//        .density = density_ion_srcGB,
+//        .upar = zero_func,
+//        .temp = temp_ion_srcGB,
+//      },
     },
 
-    .diffusion = {
-      .num_diff_dir = 1,
-      .diff_dirs = { 0 },
-      .D = { 0.5 },
-      .order = 2,
-    },
+//    .diffusion = {
+//      .num_diff_dir = 1,
+//      .diff_dirs = { 0 },
+//      .D = { 0.5 },
+//      .order = 2,
+//    },
 
     .bcx = {
-      .lower={.type = GKYL_SPECIES_ABSORB,},
-      .upper={.type = GKYL_SPECIES_ABSORB,},
+      .lower = {.type = GKYL_SPECIES_ABSORB,},
+      .upper = {.type = GKYL_SPECIES_ABSORB,},
     },
     .bcy = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,},
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,},
+      .lower = {.type = GKYL_SPECIES_GK_IWL,},
+      .upper = {.type = GKYL_SPECIES_GK_IWL,},
     },
 
-    .num_diag_moments = 5,
-    .diag_moments = { "M0", "M1", "M2", "M2par", "M2perp" },
+    .num_diag_moments = 4,
+    .diag_moments = { "M1", "M2par", "M2perp", "BiMaxwellianMoments" },
   };
 
   // field
   struct gkyl_gyrokinetic_field field = {
     .gkfield_id = GKYL_GK_FIELD_ES_IWL,
-    .xLCFS = ctx.x_LCFS,
     .poisson_bcs = {.lo_type = {GKYL_POISSON_DIRICHLET},
                     .up_type = {GKYL_POISSON_DIRICHLET},
                     .lo_value = {0.0}, .up_value = {0.0}},
@@ -759,10 +756,11 @@ main(int argc, char **argv)
     .geometry = {
       .geometry_id = GKYL_MAPC2P,
       .world = {0.},
-      .mapc2p = mapc2p, // mapping of computational to physical space
+      .mapc2p = mapc2p, // Mapping of computational to physical space.
       .c2p_ctx = &ctx,
-      .bmag_func = bmag_func, // magnetic field magnitude
-      .bmag_ctx = &ctx
+      .bmag_func = bmag_func, // Magnetic field magnitude.
+      .bmag_ctx = &ctx,
+      .x_LCFS = ctx.x_LCFS, // Location of last closed flux surface.
     },
 
     .num_periodic_dir = 0,

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -760,6 +760,7 @@ main(int argc, char **argv)
       .c2p_ctx = &ctx,
       .bmag_func = bmag_func, // Magnetic field magnitude.
       .bmag_ctx = &ctx,
+      .has_LCFS = true,
       .x_LCFS = ctx.x_LCFS, // Location of last closed flux surface.
     },
 

--- a/regression/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_3x2v_p1.c
@@ -850,6 +850,7 @@ main(int argc, char **argv)
       .c2p_ctx = &ctx,
       .bmag_func = bmag_func, // magnetic field magnitude
       .bmag_ctx = &ctx,
+      .has_LCFS = true,
       .x_LCFS = ctx.x_LCFS, // Location of last closed flux surface.
     },
 

--- a/regression/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_3x2v_p1.c
@@ -718,19 +718,17 @@ main(int argc, char **argv)
     },
 
     .bcx = {
-      .lower={.type = GKYL_SPECIES_ABSORB,},
-      .upper={.type = GKYL_SPECIES_ABSORB,},
+      .lower = {.type = GKYL_SPECIES_ABSORB,},
+      .upper = {.type = GKYL_SPECIES_ABSORB,},
     },
     .bcz = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,
-              .aux_profile = bc_shift_func_lo,
-              .aux_ctx = &ctx,
+      .lower = {.type = GKYL_SPECIES_GK_IWL,
+                .aux_profile = bc_shift_func_lo,
+                .aux_ctx = &ctx,
       },
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,
-              .aux_profile = bc_shift_func_up,
-              .aux_ctx = &ctx,
+      .upper = {.type = GKYL_SPECIES_GK_IWL,
+                .aux_profile = bc_shift_func_up,
+                .aux_ctx = &ctx,
       },
     },
 
@@ -794,19 +792,17 @@ main(int argc, char **argv)
     },
 
     .bcx = {
-      .lower={.type = GKYL_SPECIES_ABSORB,},
-      .upper={.type = GKYL_SPECIES_ABSORB,},
+      .lower = {.type = GKYL_SPECIES_ABSORB,},
+      .upper = {.type = GKYL_SPECIES_ABSORB,},
     },
     .bcz = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,
-              .aux_profile = bc_shift_func_lo,
-              .aux_ctx = &ctx,
+      .lower = {.type = GKYL_SPECIES_GK_IWL,
+                .aux_profile = bc_shift_func_lo,
+                .aux_ctx = &ctx,
       },
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.x_LCFS,
-              .aux_profile = bc_shift_func_up,
-              .aux_ctx = &ctx,
+      .upper = {.type = GKYL_SPECIES_GK_IWL,
+                .aux_profile = bc_shift_func_up,
+                .aux_ctx = &ctx,
       },
     },
 
@@ -828,7 +824,6 @@ main(int argc, char **argv)
   // field
   struct gkyl_gyrokinetic_field field = {
     .gkfield_id = GKYL_GK_FIELD_ES_IWL,
-    .xLCFS = ctx.x_LCFS,
     .poisson_bcs = {.lo_type = {GKYL_POISSON_DIRICHLET},
                     .up_type = {GKYL_POISSON_DIRICHLET},
                     .lo_value = {0.0}, .up_value = {0.0}},
@@ -854,7 +849,8 @@ main(int argc, char **argv)
       .mapc2p = mapc2p, // mapping of computational to physical space
       .c2p_ctx = &ctx,
       .bmag_func = bmag_func, // magnetic field magnitude
-      .bmag_ctx = &ctx
+      .bmag_ctx = &ctx,
+      .x_LCFS = ctx.x_LCFS, // Location of last closed flux surface.
     },
 
     .num_periodic_dir = 1,

--- a/regression/rt_gk_ltx_iwl_2x2v_p1.c
+++ b/regression/rt_gk_ltx_iwl_2x2v_p1.c
@@ -145,7 +145,7 @@ create_ctx(void)
   // Geometry and magnetic field.
   double Lz        = 2.0*(M_PI-1e-14);    // Domain size along magnetic field.
   double B0 = 0.24;
-  double psi_LCFS= -5.4760172700000003e-03; // psi at LCFS. Taken from efit
+  double psi_LCFS = -5.4760172700000003e-03; // psi at LCFS. Taken from efit
   double psi_min = psi_LCFS - 0.0004; // inner flux surface of domain
   double psi_max = psi_LCFS + 0.0012; // outer flux surface of domain
   double Lx = psi_max - psi_min;
@@ -349,10 +349,8 @@ int main(int argc, char **argv)
       .upper={.type = GKYL_SPECIES_ABSORB,},
     },
     .bcy = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.psi_LCFS,},
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.psi_LCFS,},
+      .lower={.type = GKYL_SPECIES_GK_IWL,},
+      .upper={.type = GKYL_SPECIES_GK_IWL,},
     },
 
     .num_diag_moments = 5,
@@ -413,10 +411,8 @@ int main(int argc, char **argv)
       .upper={.type = GKYL_SPECIES_ABSORB,},
     },
     .bcy = {
-      .lower={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.psi_LCFS,},
-      .upper={.type = GKYL_SPECIES_GK_IWL,
-              .aux_parameter = ctx.psi_LCFS,},
+      .lower={.type = GKYL_SPECIES_GK_IWL,},
+      .upper={.type = GKYL_SPECIES_GK_IWL,},
     },
     
     .num_diag_moments = 5,
@@ -426,7 +422,6 @@ int main(int argc, char **argv)
   // field
   struct gkyl_gyrokinetic_field field = {
     .gkfield_id = GKYL_GK_FIELD_ES_IWL,
-    .xLCFS = ctx.psi_LCFS,
     .poisson_bcs = {.lo_type = {GKYL_POISSON_DIRICHLET},
                     .up_type = {GKYL_POISSON_DIRICHLET},
                     .lo_value = {0.0}, .up_value = {0.0}},
@@ -444,9 +439,9 @@ int main(int argc, char **argv)
     .ftype = GKYL_IWL,
     .rclose = 0.7,
     .rleft= 0.1,
-    .rright= 0.7,
-    .rmin=0.1,
-    .rmax=0.7,
+    .rright = 0.7,
+    .rmin = 0.1,
+    .rmax = 0.7,
     .zmin = -0.35,
     .zmax = 0.35,
   }; 
@@ -467,6 +462,7 @@ int main(int argc, char **argv)
       .geometry_id = GKYL_TOKAMAK,
       .efit_info = efit_inp,
       .tok_grid_info = grid_inp,
+      .x_LCFS = ctx.psi_LCFS, // Location of last closed flux surface.
     },
 
     .num_periodic_dir = 0,

--- a/regression/rt_gk_ltx_iwl_2x2v_p1.c
+++ b/regression/rt_gk_ltx_iwl_2x2v_p1.c
@@ -462,6 +462,7 @@ int main(int argc, char **argv)
       .geometry_id = GKYL_TOKAMAK,
       .efit_info = efit_inp,
       .tok_grid_info = grid_inp,
+      .has_LCFS = true,
       .x_LCFS = ctx.psi_LCFS, // Location of last closed flux surface.
     },
 

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -43,7 +43,8 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
     }
     else {
       up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
     }
   }
 

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -17,7 +17,7 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
 {
 
 #ifdef GKYL_HAVE_CUDA
-  if(use_gpu) {
+  if (use_gpu) {
     return gkyl_gk_geometry_cu_dev_new(geo_host, geometry_inp);
   } 
 #endif 
@@ -30,6 +30,7 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->global_ext = geometry_inp->global_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
+  up->x_LCFS = geometry_inp->x_LCFS;
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
@@ -52,11 +53,11 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->jacobtot_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->bmag_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->bmag_inv_sq = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxxj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxyj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gyyj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxzj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->eps2= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxxj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxyj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gyyj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxzj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->eps2 = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
 
   up->flags = 0;
   GKYL_CLEAR_CU_ALLOC(up->flags);
@@ -242,6 +243,7 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   up->local_ext = geometry_inp->local_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = up_3d->geqdsk_sign_convention;
+  up->x_LCFS = up_3d->x_LCFS;
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -33,12 +33,18 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->has_LCFS = geometry_inp->has_LCFS;
   if (up->has_LCFS) {
     up->x_LCFS = geometry_inp->x_LCFS;
-    // Check the split happens within the domain and at a cell boundary.
-    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
-    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
-    assert(floor(fabs(needint-floor(needint))) < 1.);
-    // Index of the cell that abuts the x_LCFS from below.
-    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+    // Check that the split happens within the domain.
+    assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
+    // If the split is not at a cell boundary, move it to the nearest one.
+    double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
+    double rem = fabs(needint-floor(needint));
+    if (rem < 1.0e-12) {
+      up->idx_LCFS_lo = (int) needint;
+    }
+    else {
+      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+    }
   }
 
   // bmag, metrics and derived geo quantities

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -31,6 +31,14 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
   up->x_LCFS = geometry_inp->x_LCFS;
+  if (fabs(up->x_LCFS) > 1e-16) {
+    // Check the split happens within the domain and at a cell boundary.
+    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
+    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
+    assert(floor(fabs(needint-floor(needint))) < 1.);
+    // Index of the cell that abuts the x_LCFS from below.
+    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+  }
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);
@@ -244,6 +252,7 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = up_3d->geqdsk_sign_convention;
   up->x_LCFS = up_3d->x_LCFS;
+  up->idx_LCFS_lo = up_3d->idx_LCFS_lo;
 
   // bmag, metrics and derived geo quantities
   up->mc2p = gkyl_array_new(GKYL_DOUBLE, 3*up->basis.num_basis, up->local_ext.volume);

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -30,8 +30,9 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
   up->global_ext = geometry_inp->global_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
-  up->x_LCFS = geometry_inp->x_LCFS;
-  if (fabs(up->x_LCFS) > 1e-16) {
+  up->has_LCFS = geometry_inp->has_LCFS;
+  if (up->has_LCFS) {
+    up->x_LCFS = geometry_inp->x_LCFS;
     // Check the split happens within the domain and at a cell boundary.
     assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
     double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
@@ -251,6 +252,7 @@ gkyl_gk_geometry_deflate(const struct gk_geometry* up_3d, struct gkyl_gk_geometr
   up->local_ext = geometry_inp->local_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = up_3d->geqdsk_sign_convention;
+  up->has_LCFS = up_3d->has_LCFS;
   up->x_LCFS = up_3d->x_LCFS;
   up->idx_LCFS_lo = up_3d->idx_LCFS_lo;
 

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -22,8 +22,9 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->global_ext = geometry_inp->global_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
-  up->x_LCFS = geo_host->x_LCFS;
-  if (fabs(up->x_LCFS) > 1e-16) {
+  up->has_LCFS = geo_host->has_LCFS;
+  if (up->has_LCFS) {
+    up->x_LCFS = geo_host->x_LCFS;
     // Check the split happens within the domain and at a cell boundary.
     assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
     double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -35,7 +35,8 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
     }
     else {
       up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
     }
   }
 

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -22,6 +22,7 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->global_ext = geometry_inp->global_ext;
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
+  up->x_LCFS = geo_host->x_LCFS;
 
   // Copy the host-side initialized geometry object to the device
   struct gkyl_array *mc2p_dev = gkyl_array_cu_dev_new(geo_host->mc2p->type, geo_host->mc2p->ncomp, geo_host->mc2p->size);
@@ -77,31 +78,31 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   gkyl_array_copy(eps2_dev, geo_host->eps2);
 
   // this is for the memcpy below
-  up->mc2p  = mc2p_dev->on_dev;
-  up->mc2nu_pos  = mc2nu_pos_dev->on_dev;
-  up->bmag  = bmag_dev->on_dev;
-  up->g_ij  = g_ij_dev->on_dev;
-  up->g_ij_neut  = g_ij_neut_dev->on_dev;
-  up->dxdz  = dxdz_dev->on_dev;
-  up->dzdx  = dzdx_dev->on_dev;
-  up->dualmag  = dualmag_dev->on_dev;
-  up->normals  = normals_dev->on_dev;
-  up->jacobgeo  = jacobgeo_dev->on_dev;
+  up->mc2p = mc2p_dev->on_dev;
+  up->mc2nu_pos = mc2nu_pos_dev->on_dev;
+  up->bmag = bmag_dev->on_dev;
+  up->g_ij = g_ij_dev->on_dev;
+  up->g_ij_neut = g_ij_neut_dev->on_dev;
+  up->dxdz = dxdz_dev->on_dev;
+  up->dzdx = dzdx_dev->on_dev;
+  up->dualmag = dualmag_dev->on_dev;
+  up->normals = normals_dev->on_dev;
+  up->jacobgeo = jacobgeo_dev->on_dev;
   up->jacobgeo_inv = jacobgeo_inv_dev->on_dev;
-  up->gij  = gij_dev->on_dev;
-  up->gij_neut  = gij_neut_dev->on_dev;
-  up->b_i  = b_i_dev->on_dev;
-  up->bcart  = bcart_dev->on_dev;
-  up->cmag  =  cmag_dev->on_dev;
-  up->jacobtot  = jacobtot_dev->on_dev;
+  up->gij = gij_dev->on_dev;
+  up->gij_neut = gij_neut_dev->on_dev;
+  up->b_i = b_i_dev->on_dev;
+  up->bcart = bcart_dev->on_dev;
+  up->cmag = cmag_dev->on_dev;
+  up->jacobtot = jacobtot_dev->on_dev;
   up->jacobtot_inv = jacobtot_inv_dev->on_dev;
-  up->bmag_inv  = bmag_inv_dev->on_dev;
+  up->bmag_inv = bmag_inv_dev->on_dev;
   up->bmag_inv_sq = bmag_inv_sq_dev->on_dev;
-  up->gxxj  = gxxj_dev->on_dev;
-  up->gxyj  = gxyj_dev->on_dev;
-  up->gyyj  = gyyj_dev->on_dev;
-  up->gxzj  = gxzj_dev->on_dev;
-  up->eps2  = eps2_dev->on_dev;
+  up->gxxj = gxxj_dev->on_dev;
+  up->gxyj = gxyj_dev->on_dev;
+  up->gyyj = gyyj_dev->on_dev;
+  up->gxzj = gxzj_dev->on_dev;
+  up->eps2 = eps2_dev->on_dev;
 
   up->flags = 0;
   GKYL_SET_CU_ALLOC(up->flags);
@@ -113,31 +114,31 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->on_dev = up_cu;
 
   // geometry object should store host pointer
-  up->mc2p  = mc2p_dev;
+  up->mc2p = mc2p_dev;
   up->mc2nu_pos  = mc2nu_pos_dev;
-  up->bmag  = bmag_dev;
-  up->g_ij  = g_ij_dev;
-  up->g_ij_neut  = g_ij_neut_dev;
-  up->dxdz  = dxdz_dev;
-  up->dzdx  = dzdx_dev;
-  up->dualmag  = dualmag_dev;
-  up->normals  = normals_dev;
-  up->jacobgeo  = jacobgeo_dev;
+  up->bmag = bmag_dev;
+  up->g_ij = g_ij_dev;
+  up->g_ij_neut = g_ij_neut_dev;
+  up->dxdz = dxdz_dev;
+  up->dzdx = dzdx_dev;
+  up->dualmag = dualmag_dev;
+  up->normals = normals_dev;
+  up->jacobgeo = jacobgeo_dev;
   up->jacobgeo_inv = jacobgeo_inv_dev;
-  up->gij  = gij_dev;
-  up->gij_neut  = gij_neut_dev;
-  up->b_i  = b_i_dev;
-  up->bcart  = bcart_dev;
-  up->cmag  =  cmag_dev;
-  up->jacobtot  = jacobtot_dev;
+  up->gij = gij_dev;
+  up->gij_neut = gij_neut_dev;
+  up->b_i = b_i_dev;
+  up->bcart = bcart_dev;
+  up->cmag = cmag_dev;
+  up->jacobtot = jacobtot_dev;
   up->jacobtot_inv = jacobtot_inv_dev;
-  up->bmag_inv  = bmag_inv_dev;
+  up->bmag_inv = bmag_inv_dev;
   up->bmag_inv_sq = bmag_inv_sq_dev;
-  up->gxxj  = gxxj_dev;
-  up->gxyj  = gxyj_dev;
-  up->gyyj  = gyyj_dev;
-  up->gxzj  = gxzj_dev;
-  up->eps2  = eps2_dev;
+  up->gxxj = gxxj_dev;
+  up->gxyj = gxyj_dev;
+  up->gyyj = gyyj_dev;
+  up->gxzj = gxzj_dev;
+  up->eps2 = eps2_dev;
   
   return up;
 }

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -23,6 +23,14 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->grid = geometry_inp->grid;
   up->geqdsk_sign_convention = geo_host->geqdsk_sign_convention;
   up->x_LCFS = geo_host->x_LCFS;
+  if (fabs(up->x_LCFS) > 1e-16) {
+    // Check the split happens within the domain and at a cell boundary.
+    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
+    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
+    assert(floor(fabs(needint-floor(needint))) < 1.);
+    // Index of the cell that abuts the x_LCFS from below.
+    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+  }
 
   // Copy the host-side initialized geometry object to the device
   struct gkyl_array *mc2p_dev = gkyl_array_cu_dev_new(geo_host->mc2p->type, geo_host->mc2p->ncomp, geo_host->mc2p->size);

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -25,12 +25,18 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
   up->has_LCFS = geo_host->has_LCFS;
   if (up->has_LCFS) {
     up->x_LCFS = geo_host->x_LCFS;
-    // Check the split happens within the domain and at a cell boundary.
-    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
-    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
-    assert(floor(fabs(needint-floor(needint))) < 1.);
-    // Index of the cell that abuts the x_LCFS from below.
-    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+    // Check that the split happens within the domain.
+    assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
+    // If the split is not at a cell boundary, move it to the nearest one.
+    double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
+    double rem = fabs(needint-floor(needint));
+    if (rem < 1.0e-12) {
+      up->idx_LCFS_lo = (int) needint;
+    }
+    else {
+      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+    }
   }
 
   // Copy the host-side initialized geometry object to the device

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -188,12 +188,18 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->has_LCFS = geometry_inp->has_LCFS;
   if (up->has_LCFS) {
     up->x_LCFS = geometry_inp->x_LCFS;
-    // Check the split happens within the domain and at a cell boundary.
-    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
-    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
-    assert(floor(fabs(needint-floor(needint))) < 1.);
-    // Index of the cell that abuts the x_LCFS from below.
-    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+    // Check that the split happens within the domain.
+    assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
+    // If the split is not at a cell boundary, move it to the nearest one.
+    double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
+    double rem = fabs(needint-floor(needint));
+    if (rem < 1.0e-12) {
+      up->idx_LCFS_lo = (int) needint;
+    }
+    else {
+      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+    }
   }
 
   struct gkyl_range nrange;

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -198,7 +198,8 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
     }
     else {
       up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0]);
+      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
     }
   }
 

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -184,6 +184,7 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global = geometry_inp->geo_global;
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
+  up->x_LCFS = geometry_inp->x_LCFS;
 
   struct gkyl_range nrange;
   double dzc[3] = {0.0};
@@ -227,11 +228,11 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->jacobtot_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->bmag_inv = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
   up->bmag_inv_sq = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxxj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxyj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gyyj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->gxzj= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
-  up->eps2= gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxxj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxyj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gyyj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->gxzj = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
+  up->eps2 = gkyl_array_new(GKYL_DOUBLE, up->basis.num_basis, up->local_ext.volume);
 
   gk_geometry_mapc2p_advance(up, &nrange, dzc, geometry_inp->mapc2p, geometry_inp->c2p_ctx,
     geometry_inp->bmag_func, geometry_inp->bmag_ctx, mc2p_nodal_fd, mc2p_nodal, up->mc2p,
@@ -256,7 +257,6 @@ gkyl_gk_geometry_mapc2p_new(struct gkyl_gk_geometry_inp *geometry_inp)
   struct gk_geometry* gk_geom_3d;
   struct gk_geometry* gk_geom;
 
-
   if (geometry_inp->position_map == 0){
     geometry_inp->position_map = gkyl_position_map_new((struct gkyl_position_map_inp) {}, \
       geometry_inp->grid, geometry_inp->local, geometry_inp->local_ext, geometry_inp->local, \
@@ -271,7 +271,7 @@ gkyl_gk_geometry_mapc2p_new(struct gkyl_gk_geometry_inp *geometry_inp)
         geometry_inp->position_map->id == GKYL_PMAP_CONSTANT_DB_NUMERIC) {
       // The array mc2nu is computed using the uniform geometry, so we need to deflate it
       // Must deflate the 3D uniform geometry in order for the allgather to work
-      if(geometry_inp->grid.ndim < 3)
+      if (geometry_inp->grid.ndim < 3)
         gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, geometry_inp);
       else
         gk_geom = gkyl_gk_geometry_acquire(gk_geom_3d);

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -185,8 +185,9 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global = geometry_inp->geo_global;
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
-  up->x_LCFS = geometry_inp->x_LCFS;
-  if (fabs(up->x_LCFS) > 1e-16) {
+  up->has_LCFS = geometry_inp->has_LCFS;
+  if (up->has_LCFS) {
+    up->x_LCFS = geometry_inp->x_LCFS;
     // Check the split happens within the domain and at a cell boundary.
     assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
     double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -13,6 +13,7 @@
 #include <gkyl_gk_geometry_mapc2p.h>
 #include <gkyl_math.h>
 #include <gkyl_nodal_ops.h>
+#include <assert.h>
 
 static
 void gk_geometry_mapc2p_advance(struct gk_geometry* up, struct gkyl_range *nrange, double dzc[3], 
@@ -185,6 +186,14 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
   up->x_LCFS = geometry_inp->x_LCFS;
+  if (fabs(up->x_LCFS) > 1e-16) {
+    // Check the split happens within the domain and at a cell boundary.
+    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
+    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
+    assert(floor(fabs(needint-floor(needint))) < 1.);
+    // Index of the cell that abuts the x_LCFS from below.
+    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+  }
 
   struct gkyl_range nrange;
   double dzc[3] = {0.0};

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -15,6 +15,7 @@
 #include <gkyl_tok_calc_derived_geo.h>
 #include <gkyl_calc_metric.h>
 #include <gkyl_calc_bmag.h>
+#include <assert.h>
 
 struct gk_geometry*
 gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
@@ -28,6 +29,14 @@ gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
   up->x_LCFS = geometry_inp->x_LCFS;
+  if (fabs(up->x_LCFS) > 1e-16) {
+    // Check the split happens within the domain and at a cell boundary.
+    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
+    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
+    assert(floor(fabs(needint-floor(needint))) < 1.);
+    // Index of the cell that abuts the x_LCFS from below.
+    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+  }
 
   struct gkyl_range nrange;
   double dzc[3] = {0.0};

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -31,12 +31,19 @@ gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->has_LCFS = geometry_inp->has_LCFS;
   if (up->has_LCFS) {
     up->x_LCFS = geometry_inp->x_LCFS;
-    // Check the split happens within the domain and at a cell boundary.
-    assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
-    double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];
-    assert(floor(fabs(needint-floor(needint))) < 1.);
-    // Index of the cell that abuts the x_LCFS from below.
-    up->idx_LCFS_lo = (up->x_LCFS-1e-8 - up->grid.lower[0])/up->grid.dx[0]+1;
+    // Check that the split happens within the domain.
+    assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
+    // If the split is not at a cell boundary, move it to the nearest one.
+    double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
+    double rem = fabs(needint-floor(needint));
+    if (rem < 1.0e-12) {
+      up->idx_LCFS_lo = (int) needint;
+    }
+    else {
+      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
+      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
+      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
+    }
   }
 
   struct gkyl_range nrange;

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -28,8 +28,9 @@ gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global = geometry_inp->geo_global;
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
-  up->x_LCFS = geometry_inp->x_LCFS;
-  if (fabs(up->x_LCFS) > 1e-16) {
+  up->has_LCFS = geometry_inp->has_LCFS;
+  if (up->has_LCFS) {
+    up->x_LCFS = geometry_inp->x_LCFS;
     // Check the split happens within the domain and at a cell boundary.
     assert((up->grid.lower[0] < up->x_LCFS) && (up->x_LCFS < up->grid.upper[0]));
     double needint = (up->x_LCFS-up->grid.lower[0])/up->grid.dx[0];

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -27,6 +27,7 @@ gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
   up->global = geometry_inp->geo_global;
   up->global_ext = geometry_inp->geo_global_ext;
   up->grid = geometry_inp->geo_grid;
+  up->x_LCFS = geometry_inp->x_LCFS;
 
   struct gkyl_range nrange;
   double dzc[3] = {0.0};

--- a/zero/gkyl_gk_geometry.h
+++ b/zero/gkyl_gk_geometry.h
@@ -63,6 +63,7 @@ struct gk_geometry {
   int geqdsk_sign_convention; // 0 if psi increases away from magnetic axis
                               // 1 if psi increases toward magnetic axis
 
+  bool has_LCFS; // Whether the geometry has an LCFS.
   double x_LCFS; // For mapc2p IWL geometry, the user has to provide the
                  // location of the LCFS. For numerical IWL, it may be stored
                  // in the eqdsk.
@@ -96,7 +97,8 @@ struct gkyl_gk_geometry_inp {
 
   double world[3]; // extra computational coordinates for cases with reduced dimensionality
 
-  double x_LCFS; // x location of the last closed flux surface.
+  bool has_LCFS; // Whether the geometry has a last closed flux surface (LCFS).
+  double x_LCFS; // x location of the LCFS.
 
   // 3D grid ranges and basis
   struct gkyl_rect_grid geo_grid;

--- a/zero/gkyl_gk_geometry.h
+++ b/zero/gkyl_gk_geometry.h
@@ -44,8 +44,8 @@ struct gk_geometry {
                               // Cartesian components of normal vectors in order n^1,, n^2, n^3
   struct gkyl_array* jacobgeo; // 1 component. Configuration space jacobian J
   struct gkyl_array* jacobgeo_inv; // 1 component. 1/J
-  struct gkyl_array* gij; // Matric coefficients g^{ij}. See g_ij for order.
-  struct gkyl_array* gij_neut; // Matric coefficients g^{ij}. See g_ij for order. 
+  struct gkyl_array* gij; // Metric coefficients g^{ij}. See g_ij for order.
+  struct gkyl_array* gij_neut; // Metric coefficients g^{ij}. See g_ij for order. 
                                // Calculated with coord definition alpha = phi for tokamak geometry
   struct gkyl_array* b_i; // 3 components. Contravariant components of magnetic field vector b_1, b_2, b_3.
   struct gkyl_array* bcart; // 3 components. Cartesian components of magnetic field vector b_X, b_Y, b_Z.
@@ -63,6 +63,9 @@ struct gk_geometry {
   int geqdsk_sign_convention; // 0 if psi increases away from magnetic axis
                               // 1 if psi increases toward magnetic axis
 
+  double x_LCFS; // For mapc2p IWL geometry, the user has to provide the
+                 // location of the LCFS. For numerical IWL, it may be stored
+                 // in the eqdsk.
   uint32_t flags;
   struct gkyl_ref_count ref_count;  
   struct gk_geometry *on_dev; // pointer to itself or device object
@@ -90,6 +93,8 @@ struct gkyl_gk_geometry_inp {
   struct gkyl_comm *comm; // communicator object
 
   double world[3]; // extra computational coordinates for cases with reduced dimensionality
+
+  double x_LCFS; // x location of the last closed flux surface.
 
   // 3D grid ranges and basis
   struct gkyl_rect_grid geo_grid;

--- a/zero/gkyl_gk_geometry.h
+++ b/zero/gkyl_gk_geometry.h
@@ -66,6 +66,8 @@ struct gk_geometry {
   double x_LCFS; // For mapc2p IWL geometry, the user has to provide the
                  // location of the LCFS. For numerical IWL, it may be stored
                  // in the eqdsk.
+  int idx_LCFS_lo; // Index of the cell that abuts the LCFS from below.
+
   uint32_t flags;
   struct gkyl_ref_count ref_count;  
   struct gk_geometry *on_dev; // pointer to itself or device object


### PR DESCRIPTION
Some of the ranges in GK IWL clopen simulations were wrong (off by 1). For sure the global core range is wrong, and it's likely the extended core and sol ranges were also wrong.

Here we correct that.

Also, to avoid numerous definitions of LCFS related quantities (i.e. the index of the cell to its left, and the core and sol ranges) throughout the app (i.e. in GK app, in species, field, sources, bflux), and thus having an increased risk for making a mistake, we centralize the location of the LCFS parameters (x_LCFS and idx_LCFS_lo) to gk_geometry, and the ranges are only created in one place (in gyrokinetic for conf- and in species for phase-space). This way other modules can simply fetch them from these places rather than creating them again. This addreses issue #711 .

Here's proof that the ranges are correct now, done with rt_gk_d3d_iwl_3x2v_p1:
```
x_LCFS was not at a cell boundary. Moved to: 9.375000000e-02

conf grid: 0:0.15,-0.0707482:0.0707482,-3.14159:3.14159 | cells= 8, 4, 8

x_LCFS = 0.09375 | idx_LCFS_lo =  5

app->global      =  1: 8, 1: 4, 1: 8
app->global_core =  1: 5, 1: 4, 1: 8
app->global_sol  =  6: 8, 1: 4, 1: 8

app->global_ext      =  0: 9, 0: 5, 0: 9
app->global_ext_core =  0: 5, 0: 5, 0: 9
app->global_ext_sol  =  6: 9, 0: 5, 0: 9

app->lower_skin_par_core  =  1: 5, 1: 4, 1: 1
app->lower_skin_par_sol   =  6: 8, 1: 4, 1: 1
app->lower_ghost_par_core =  1: 5, 1: 4, 0: 0
app->lower_ghost_par_sol  =  6: 8, 1: 4, 0: 0

app->upper_skin_par_core  =  1: 5, 1: 4, 8: 8
app->upper_skin_par_sol   =  6: 8, 1: 4, 8: 8
app->upper_ghost_par_core =  1: 5, 1: 4, 9: 9
app->upper_ghost_par_sol  =  6: 8, 1: 4, 9: 9

app->local_par_ext_core =  1: 5, 1: 4, 0: 9
```