### PR TITLE
microfix: missing assert header in gk geom cuda file

### DIFF
--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -8,6 +8,7 @@ extern "C" {
 #include <gkyl_math.h>
 #include <gkyl_util.h>
 #include <gkyl_gk_geometry.h>
+#include <assert.h>
 }
 // CPU interface to create and track a GPU object
 struct gk_geometry* 


### PR DESCRIPTION
The assert header in `gk_geometry_cu.cu` is missing and prevents compilation of main with GPU since PR #718 got merged.