### PR TITLE
Hot fix ctest_position_map.c

### DIFF
--- a/unit/ctest_position_map.c
+++ b/unit/ctest_position_map.c
@@ -497,8 +497,6 @@ test_position_map_numeric_optimize_1x()
   gkyl_proj_on_basis_advance(projB, 0.0, &localRange, bmag_global);
   gkyl_proj_on_basis_release(projB);
 
-  gkyl_position_map_set_bmag(pos_map, NULL, bmag_global);
-
   struct gkyl_rect_grid grid3D;
   double lower3D[] = {0.4, -0.1, lower[0]}, upper3D[] = {0.6, 0.1, upper[0]};
   int cells3D[] = {1, 1, cells[0]};
@@ -507,6 +505,8 @@ test_position_map_numeric_optimize_1x()
   struct gkyl_range localRange3D, localRange3D_ext; // local, local-ext ranges.
   gkyl_create_grid_ranges(&grid3D, ghost3D, &localRange3D_ext, &localRange3D);
 
+  gkyl_position_map_optimize(pos_map, grid3D, localRange3D);
+  gkyl_position_map_set_bmag(pos_map, NULL, bmag_global);
   gkyl_position_map_optimize(pos_map, grid3D, localRange3D);
 
   double theta_extrema_analytic[5] = {lower[0], lower[0]/2, 0.0, upper[0]/2, upper[0]};
@@ -556,8 +556,6 @@ test_position_map_numeric_calculate_1x()
   gkyl_proj_on_basis_advance(projB, 0.0, &localRange, bmag_global);
   gkyl_proj_on_basis_release(projB);
 
-  gkyl_position_map_set_bmag(pos_map, NULL, bmag_global);
-
   struct gkyl_rect_grid grid3D;
   double lower3D[] = {0.4, -0.1, lower[0]}, upper3D[] = {0.6, 0.1, upper[0]};
   int cells3D[] = {1, 1, cells[0]};
@@ -566,6 +564,8 @@ test_position_map_numeric_calculate_1x()
   struct gkyl_range localRange3D, localRange3D_ext; // local, local-ext ranges.
   gkyl_create_grid_ranges(&grid3D, ghost3D, &localRange3D_ext, &localRange3D);
 
+  gkyl_position_map_optimize(pos_map, grid3D, localRange3D);
+  gkyl_position_map_set_bmag(pos_map, NULL, bmag_global);
   gkyl_position_map_optimize(pos_map, grid3D, localRange3D);
 
   double theta_map = 1.0;


### PR DESCRIPTION
The position map unit test is breaking the build. The unit test wasn't initializing the variable `N_theta_boundaries`, which is used when mallocing the arrays of doubles. Since `N_theta_boundaries = 0`, it malloced zero doubles, then the free method barfed. In the geometry code, the optimize function is always called before set_bmag during the geometry generation, then optimize is called again after.

Unit test passes on my laptop.