### PR TITLE
Hot fix: collision diagnostic determination during initial conditions

### DIFF
--- a/apps/gyrokinetic.c
+++ b/apps/gyrokinetic.c
@@ -827,6 +827,26 @@ gkyl_gyrokinetic_app_apply_ic(gkyl_gyrokinetic_app* app, double t0)
         gk_field_project_init(app);
     }
 
+    // Compute necessary moments and boundary corrections for collisions.
+    for (int i=0; i<app->num_species; ++i) {
+      if (app->species[i].lbo.collision_id == GKYL_LBO_COLLISIONS) {
+        gk_species_lbo_moms(app, &app->species[i], 
+          &app->species[i].lbo, distf[i]);
+      }
+      if (app->species[i].bgk.collision_id == GKYL_BGK_COLLISIONS && !app->has_implicit_coll_scheme) {
+        gk_species_bgk_moms(app, &app->species[i], 
+          &app->species[i].bgk, distf[i]);
+      }
+    }
+
+    // Compute the cross-species collision frequencies.
+    for (int i=0; i<app->num_species; ++i) {
+      struct gk_species *gk_s = &app->species[i];
+      if (gk_s->lbo.collision_id == GKYL_LBO_COLLISIONS) { 
+        gk_species_lbo_cross_nu(app, &app->species[i], &gk_s->lbo);
+      }
+    }
+
   }
 
   // Compute the phase-space advection speeds and boundary fluxes as t=0
@@ -2156,6 +2176,21 @@ gkyl_gyrokinetic_app_from_file_species(gkyl_gyrokinetic_app *app, int sidx,
       // Read volume and time integrated boundary flux diagnostics.
       gk_species_bflux_read_voltime_integrated_mom(app, gk_s, &gk_s->bflux);
     }
+  }
+
+  // Compute necessary moments and boundary corrections for collisions.
+  if (gk_s->lbo.collision_id == GKYL_LBO_COLLISIONS) {
+    gk_species_lbo_moms(app, gk_s, 
+      &gk_s->lbo, gk_s->f);
+  }
+  if (gk_s->bgk.collision_id == GKYL_BGK_COLLISIONS && !app->has_implicit_coll_scheme) {
+    gk_species_bgk_moms(app, gk_s, 
+      &gk_s->bgk, gk_s->f);
+  }
+
+  // Compute the cross-species collision frequencies.
+  if (gk_s->lbo.collision_id == GKYL_LBO_COLLISIONS) { 
+    gk_species_lbo_cross_nu(app, gk_s, &gk_s->lbo);
   }
 
   return rstat;

--- a/regression/rt_gk_wham_1x2v_p1.c
+++ b/regression/rt_gk_wham_1x2v_p1.c
@@ -643,8 +643,11 @@ int main(int argc, char **argv)
     },
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
+      .normNu = true,
       .ctx = &ctx,
       .self_nu = evalNuElc,
+      .n_ref = ctx.n0,
+      .T_ref = ctx.Te0,
       .num_cross_collisions = 1,
       .collide_with = { "ion" },
       .write_diagnostics = true,
@@ -696,8 +699,11 @@ int main(int argc, char **argv)
     },
     .collisions =  {
       .collision_id = GKYL_LBO_COLLISIONS,
+      .normNu = true,
       .ctx = &ctx,
       .self_nu = evalNuIon,
+      .n_ref = ctx.n0,
+      .T_ref = ctx.Ti0,
       .num_cross_collisions = 1,
       .collide_with = { "elc" },
       .write_diagnostics = true,


### PR DESCRIPTION
The test rt_gk_wham_1x2v_p1 gives an error when the diagnostics for the collision frequency are used. After discussing with @manauref, we came to these appropriate changes. The species collision objects must be determined in initialization. The correct PR this was introduced in could be #705, but I'm not too sure. That's a big PR about the collision objects.

## Community Standards

- [ ] Documentation has been updated.
- [x] My code follows the project's coding guidelines.
- [x] Changes to `/zero` should have a unit test.

## Testing: _(x (yes), blank (no))_

- [ ] I added a regression test to test this feature.
- [x] I added this feature to an existing regression test.
- [ ] I added a unit test for this feature.
- [ ] Ran `make check` and unit tests all pass.
- [ ] I ran the code through Valgrind, and it is clean.
- [ ] I ran a few regression tests to ensure no apparent errors.
- [x] Tested and works on CPU.
- [ ] Tested and works on multi-CPU.
- [ ] Tested and works on GPU.
- [ ] Tested and works on multi-GPU.