### PR TITLE
Fixes to boundary flux diag moms and enable conservation diagnostics for GK IWL sims

### DIFF
--- a/apps/gk_species_bflux.c
+++ b/apps/gk_species_bflux.c
@@ -431,9 +431,10 @@ gk_species_bflux_write_mom_dynamic(gkyl_gyrokinetic_app* app, void *spec_in,
     int dir = bflux->boundaries_dir[b];
     int edi = bflux->boundaries_edge[b]==GKYL_LOWER_EDGE? 0 : 1;
 
-    if ((edi == 0 && rank == 0) || (edi == 1 && rank == comm_size-1)) {
+    if (dir < app->cdim-1 || ((edi == 0 && rank == 0) || (edi == 1 && rank == comm_size-1))) {
       for (int m=0; m<num_diag_mom; ++m) {
         int mom_idx = bflux->diag_mom_idx[m];
+        struct gkyl_array *mom_arr = bflux->f[b*bflux->num_calc_moms+mom_idx];
 
         const char *fmt = "%s-%s_bflux_%s%s_%s_%d.gkyl";
         const char *mom_name = gks->info.boundary_flux_diagnostics.diag_moments[mom_idx];
@@ -442,7 +443,6 @@ gk_species_bflux_write_mom_dynamic(gkyl_gyrokinetic_app* app, void *spec_in,
         snprintf(fileNm, sizeof fileNm, fmt, app->name, gks->info.name, vars[dir], edge[edi], mom_name, frame);
         
         // For now copy the moment to the skin ghost and write it out.
-        struct gkyl_array *mom_arr = bflux->f[b*bflux->num_calc_moms+mom_idx];
         gkyl_array_copy_range_to_range(mom_arr, mom_arr,
           bflux->boundaries_conf_skin[b], bflux->boundaries_conf_ghost[b]);
 

--- a/apps/gk_species_source.c
+++ b/apps/gk_species_source.c
@@ -221,33 +221,33 @@ gk_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
       }
     }
 
-    s->src.moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_mom]));
+    src->moms = gkyl_malloc(sizeof(struct gk_species_moment[src->num_diag_mom]));
     for (int m=0; m<src->num_diag_mom; ++m) {
-      gk_species_moment_init(app, s, &s->src.moms[m], s->info.source.diagnostics.diag_moments[m], false);
+      gk_species_moment_init(app, s, &src->moms[m], s->info.source.diagnostics.diag_moments[m], false);
     }
 
     // Allocate data and updaters for integrated moments.
     src->num_diag_int_mom = s->info.source.diagnostics.num_integrated_diag_moments;
     assert(src->num_diag_int_mom < 2); // 1 int moment allowed now.
-    if (s->src.evolve || src->num_diag_int_mom > 0) {
-      gk_species_moment_init(app, s, &s->src.integ_moms,
+    if (src->evolve || src->num_diag_int_mom > 0) {
+      gk_species_moment_init(app, s, &src->integ_moms,
         src->num_diag_int_mom == 0? "FourMoments" : s->info.source.diagnostics.integrated_diag_moments[0], true);
-      int num_mom = s->src.integ_moms.num_mom;
+      int num_mom = src->integ_moms.num_mom;
       if (app->use_gpu) {
-        s->src.red_integ_diag = gkyl_cu_malloc(sizeof(double[num_mom]));
-        s->src.red_integ_diag_global = gkyl_cu_malloc(sizeof(double[num_mom]));
+        src->red_integ_diag = gkyl_cu_malloc(sizeof(double[num_mom]));
+        src->red_integ_diag_global = gkyl_cu_malloc(sizeof(double[num_mom]));
       } 
       else {
-        s->src.red_integ_diag = gkyl_malloc(sizeof(double[num_mom]));
-        s->src.red_integ_diag_global = gkyl_malloc(sizeof(double[num_mom]));
+        src->red_integ_diag = gkyl_malloc(sizeof(double[num_mom]));
+        src->red_integ_diag_global = gkyl_malloc(sizeof(double[num_mom]));
       }
       // Allocate dynamic-vector to store all-reduced integrated moments.
-      s->src.integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, num_mom);
-      s->src.is_first_integ_write_call = true;
+      src->integ_diag = gkyl_dynvec_new(GKYL_DOUBLE, num_mom);
+      src->is_first_integ_write_call = true;
     }
     
     // Set function pointers chosen at runtime.
-    if (s->src.evolve) {
+    if (src->evolve) {
       src->write_func = gk_species_source_write_enabled;
       src->write_mom_func = gk_species_source_write_mom_enabled;
       src->calc_integrated_mom_func = gk_species_source_calc_integrated_mom_enabled;
@@ -273,12 +273,10 @@ gk_species_source_calc(gkyl_gyrokinetic_app *app, const struct gk_species *s,
   struct gk_source *src, double tm)
 {
   if (src->source_id) {
-    struct gkyl_array *source_tmp = mkarr(app->use_gpu, s->basis.num_basis, s->local_ext.volume);
     for (int k=0; k<s->info.source.num_sources; k++) {
-      gk_species_projection_calc(app, s, &src->proj_source[k], source_tmp, tm);
-      gkyl_array_accumulate(src->source, 1., source_tmp);
+      gk_species_projection_calc(app, s, &src->proj_source[k], s->fnew, tm);
+      gkyl_array_accumulate(src->source, 1., s->fnew);
     }
-    gkyl_array_release(source_tmp);
   }
 }
 

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -383,6 +383,7 @@ struct gk_boundary_fluxes {
   enum gkyl_edge_loc boundaries_edge[2*GKYL_MAX_CDIM]; // Edge of bflux boundaries.
   struct gkyl_range *boundaries_conf_skin[2*GKYL_MAX_CDIM]; // Conf-space ghost range of boundaries.
   struct gkyl_range *boundaries_conf_ghost[2*GKYL_MAX_CDIM]; // Conf-space ghost range of boundaries.
+  struct gkyl_range *boundaries_phase_skin[2*GKYL_MAX_CDIM]; // Phase-space skin range of boundaries.
   struct gkyl_range *boundaries_phase_ghost[2*GKYL_MAX_CDIM]; // Phase-space ghost range of boundaries.
   struct gkyl_range *boundaries_phase_ghost_nosub; // Not a sub range of local_ext.
   struct gkyl_range *boundaries_conf_skin_fullx[2*GKYL_MAX_CDIM]; // Whole x range (for IWL).

--- a/apps/gkyl_gyrokinetic_priv.h
+++ b/apps/gkyl_gyrokinetic_priv.h
@@ -385,6 +385,7 @@ struct gk_boundary_fluxes {
   struct gkyl_range *boundaries_conf_ghost[2*GKYL_MAX_CDIM]; // Conf-space ghost range of boundaries.
   struct gkyl_range *boundaries_phase_ghost[2*GKYL_MAX_CDIM]; // Phase-space ghost range of boundaries.
   struct gkyl_range *boundaries_phase_ghost_nosub; // Not a sub range of local_ext.
+  struct gkyl_range *boundaries_conf_skin_fullx[2*GKYL_MAX_CDIM]; // Whole x range (for IWL).
   gkyl_boundary_flux *flux_slvr[2*GKYL_MAX_CDIM]; // boundary flux solver
   struct gkyl_array **flux; // Array storing boundary fluxes.
   // Objects used for calculating moments.

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -390,8 +390,8 @@ create_ctx(void)
   double R_axis    = 1.72068012;         // Magnetic axis major radius [m].
   double B_axis    = 2.0;                // Magnetic field at the magnetic axis [T].
   double R_LCFSmid = 2.2801477223421736; // Major radius of the LCFS at the outboard midplane [m].
-  double Rmid_min  = R_LCFSmid - 0.1;    // Minimum midplane major radius of simulation box [m].
-  double Rmid_max  = R_LCFSmid + 0.05;   // Maximum midplane major radius of simulation box [m].
+  double Rmid_min  = R_LCFSmid - 5*0.15/8;    // Minimum midplane major radius of simulation box [m].
+  double Rmid_max  = R_LCFSmid + 3*0.15/8;   // Maximum midplane major radius of simulation box [m].
   double R0        = 0.5*(Rmid_min+Rmid_max);  // Major radius of the simulation box [m].
 
   double a_mid     = R_LCFSmid-R_axis;   // Minor radius at outboard midplane [m].

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -637,6 +637,11 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_elc_srcGB,
       },
+      .diagnostics = {
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { "HamiltonianMoments" },
+//        .time_integrated = true,
+      },
     },
 
     .diffusion = {
@@ -708,7 +713,7 @@ main(int argc, char **argv)
         .density = density_srcOMP,
         .upar = zero_func,
         .temp = temp_ion_srcOMP,
-    },
+      },
       .projection[1] = {
         .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM,
         .ctx_density = &ctx,
@@ -717,6 +722,11 @@ main(int argc, char **argv)
         .density = density_ion_srcGB,
         .upar = zero_func,
         .temp = temp_ion_srcGB,
+      },
+      .diagnostics = {
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { "HamiltonianMoments" },
+//        .time_integrated = true,
       },
     },
 

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -657,6 +657,17 @@ main(int argc, char **argv)
 
     .num_diag_moments = 4,
     .diag_moments = { "M1", "M2par", "M2perp", "BiMaxwellianMoments" },
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { "HamiltonianMoments" },
+    .time_rate_diagnostics = true,
+
+    .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { "HamiltonianMoments" },
+//      .time_integrated = true,
+    },
   };
 
   // Ions.
@@ -727,6 +738,17 @@ main(int argc, char **argv)
 
     .num_diag_moments = 4,
     .diag_moments = { "M1", "M2par", "M2perp", "BiMaxwellianMoments" },
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { "HamiltonianMoments" },
+    .time_rate_diagnostics = true,
+
+    .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { "HamiltonianMoments" },
+//      .time_integrated = true,
+    },
   };
 
   // field
@@ -735,6 +757,7 @@ main(int argc, char **argv)
     .poisson_bcs = {.lo_type = {GKYL_POISSON_DIRICHLET},
                     .up_type = {GKYL_POISSON_DIRICHLET},
                     .lo_value = {0.0}, .up_value = {0.0}},
+    .time_rate_diagnostics = true,
   };
 
   // GK app

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -454,7 +454,7 @@ create_ctx(void)
 
   // Grid parameters
   int Nx = 8;
-  int Nz = 8;
+  int Nz = 12;
   int Nvpar = 8;
   int Nmu = 4;
   int poly_order = 1;
@@ -464,8 +464,8 @@ create_ctx(void)
   double vpar_max_ion = 4.*vti;
   double mu_max_ion = mi*pow(4*vti,2)/(2*B0);
 
-  double t_end = 1.e-6;
-  int num_frames = 10;
+  double t_end = 9.98218e-08; //1.e-6;
+  int num_frames = 1;
   double write_phase_freq = 0.2; // Frequency of writing phase-space diagnostics (as a fraction of num_frames).
   int int_diag_calc_num = num_frames*100;
   double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.

--- a/regression/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_2x2v_p1.c
@@ -464,7 +464,7 @@ create_ctx(void)
   double vpar_max_ion = 4.*vti;
   double mu_max_ion = mi*pow(4*vti,2)/(2*B0);
 
-  double t_end = 9.98218e-08; //1.e-6;
+  double t_end = 1.e-6;
   int num_frames = 1;
   double write_phase_freq = 0.2; // Frequency of writing phase-space diagnostics (as a fraction of num_frames).
   int int_diag_calc_num = num_frames*100;

--- a/regression/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_3x2v_p1.c
@@ -715,6 +715,11 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_elc_srcGB,
       },
+      .diagnostics = {
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { "HamiltonianMoments" },
+//        .time_integrated = true,
+      },
     },
 
     .bcx = {
@@ -734,6 +739,17 @@ main(int argc, char **argv)
 
     .num_diag_moments = 1,
     .diag_moments = { "MaxwellianMoments" },
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { "HamiltonianMoments" },
+    .time_rate_diagnostics = true,
+
+    .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { "HamiltonianMoments" },
+//      .time_integrated = true,
+    },
   };
 
   // ions
@@ -789,6 +805,11 @@ main(int argc, char **argv)
         .upar = zero_func,
         .temp = temp_ion_srcGB,
       },
+      .diagnostics = {
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { "HamiltonianMoments" },
+//        .time_integrated = true,
+      },
     },
 
     .bcx = {
@@ -808,6 +829,17 @@ main(int argc, char **argv)
 
     .num_diag_moments = 1,
     .diag_moments = { "MaxwellianMoments" },
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { "HamiltonianMoments" },
+    .time_rate_diagnostics = true,
+
+    .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { "HamiltonianMoments" },
+//      .time_integrated = true,
+    },
   };
 
   struct gkyl_poisson_bias_plane target_corner_bc = {
@@ -827,7 +859,8 @@ main(int argc, char **argv)
     .poisson_bcs = {.lo_type = {GKYL_POISSON_DIRICHLET},
                     .up_type = {GKYL_POISSON_DIRICHLET},
                     .lo_value = {0.0}, .up_value = {0.0}},
-    .bias_plane_list = &bias_plane_list
+    .bias_plane_list = &bias_plane_list,
+    .time_rate_diagnostics = true,
   };
 
   // GK app

--- a/regression/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/regression/rt_gk_d3d_iwl_3x2v_p1.c
@@ -455,8 +455,8 @@ create_ctx(void)
   double R_axis    = 1.6;                // Magnetic axis major radius [m].
   double B_axis    = 2.0*R_axisTrue/R_axis; // Magnetic field at the magnetic axis [T].
   double R_LCFSmid = 2.17;               // Major radius of the LCFS at the outboard midplane [m].
-  double Rmid_min  = R_LCFSmid - 0.1;    // Minimum midplane major radius of simulation box [m].
-  double Rmid_max  = R_LCFSmid + 0.05;   // Maximum midplane major radius of simulation box [m].
+  double Rmid_min  = R_LCFSmid - 5*0.15/8;    // Minimum midplane major radius of simulation box [m].
+  double Rmid_max  = R_LCFSmid + 3*0.15/8;   // Maximum midplane major radius of simulation box [m].
   double R0        = 0.5*(Rmid_min+Rmid_max);  // Major radius of the simulation box [m].
 
   // Minor radius at outboard midplane [m]. Redefine it with

--- a/regression/rt_gk_sheath_3x2v_p1.c
+++ b/regression/rt_gk_sheath_3x2v_p1.c
@@ -645,6 +645,8 @@ main(int argc, char **argv)
     .time_rate_diagnostics = true,
 
     .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
       .num_integrated_diag_moments = 1,
       .integrated_diag_moments = { "HamiltonianMoments" },
 //      .time_integrated = true,
@@ -718,6 +720,8 @@ main(int argc, char **argv)
     .time_rate_diagnostics = true,
 
     .boundary_flux_diagnostics = {
+      .num_diag_moments = 1,
+      .diag_moments = { "HamiltonianMoments" },
       .num_integrated_diag_moments = 1,
       .integrated_diag_moments = { "HamiltonianMoments" },
 //      .time_integrated = true,

--- a/zero/gk_geometry.c
+++ b/zero/gk_geometry.c
@@ -35,16 +35,14 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
     up->x_LCFS = geometry_inp->x_LCFS;
     // Check that the split happens within the domain.
     assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
-    // If the split is not at a cell boundary, move it to the nearest one.
+    // Check that the split happens at a cell boundary;
     double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
-    double rem = fabs(needint-floor(needint));
-    if (rem < 1.0e-12) {
+    if (fabs(needint-floor(needint)) < 1.0e-12) {
       up->idx_LCFS_lo = (int) needint;
     }
     else {
-      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
+      fprintf(stderr, "x_LCFS = %.9e must be at a cell boundary.\n", up->x_LCFS);
+      assert(false);
     }
   }
 

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -8,6 +8,7 @@ extern "C" {
 #include <gkyl_math.h>
 #include <gkyl_util.h>
 #include <gkyl_gk_geometry.h>
+#include <assert.h>
 }
 // CPU interface to create and track a GPU object
 struct gk_geometry* 

--- a/zero/gk_geometry_cu.cu
+++ b/zero/gk_geometry_cu.cu
@@ -28,16 +28,14 @@ gkyl_gk_geometry_cu_dev_new(struct gk_geometry* geo_host, struct gkyl_gk_geometr
     up->x_LCFS = geo_host->x_LCFS;
     // Check that the split happens within the domain.
     assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
-    // If the split is not at a cell boundary, move it to the nearest one.
+    // Check that the split happens at a cell boundary;
     double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
-    double rem = fabs(needint-floor(needint));
-    if (rem < 1.0e-12) {
+    if (fabs(needint-floor(needint)) < 1.0e-12) {
       up->idx_LCFS_lo = (int) needint;
     }
     else {
-      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
+      fprintf(stderr, "x_LCFS = %.9e must be at a cell boundary.\n", up->x_LCFS);
+      assert(false);
     }
   }
 

--- a/zero/gk_geometry_mapc2p.c
+++ b/zero/gk_geometry_mapc2p.c
@@ -190,16 +190,14 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
     up->x_LCFS = geometry_inp->x_LCFS;
     // Check that the split happens within the domain.
     assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
-    // If the split is not at a cell boundary, move it to the nearest one.
+    // Check that the split happens at a cell boundary;
     double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
-    double rem = fabs(needint-floor(needint));
-    if (rem < 1.0e-12) {
+    if (fabs(needint-floor(needint)) < 1.0e-12) {
       up->idx_LCFS_lo = (int) needint;
     }
     else {
-      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
+      fprintf(stderr, "x_LCFS = %.9e must be at a cell boundary.\n", up->x_LCFS);
+      assert(false);
     }
   }
 

--- a/zero/gk_geometry_tok.c
+++ b/zero/gk_geometry_tok.c
@@ -33,16 +33,14 @@ gk_geometry_tok_init(struct gkyl_gk_geometry_inp *geometry_inp)
     up->x_LCFS = geometry_inp->x_LCFS;
     // Check that the split happens within the domain.
     assert((up->grid.lower[0] <= up->x_LCFS) && (up->x_LCFS <= up->grid.upper[0]));
-    // If the split is not at a cell boundary, move it to the nearest one.
+    // Check that the split happens at a cell boundary;
     double needint = (up->x_LCFS - up->grid.lower[0])/up->grid.dx[0];
-    double rem = fabs(needint-floor(needint));
-    if (rem < 1.0e-12) {
+    if (fabs(needint-floor(needint)) < 1.0e-12) {
       up->idx_LCFS_lo = (int) needint;
     }
     else {
-      up->idx_LCFS_lo = rem <= 0.5? floor(needint) : ceil(needint);
-      up->x_LCFS = up->grid.lower[0]+up->idx_LCFS_lo*up->grid.dx[0];
-      fprintf(stderr, "x_LCFS was not at a cell boundary. Moved to: %.9e\n", up->x_LCFS);
+      fprintf(stderr, "x_LCFS = %.9e must be at a cell boundary.\n", up->x_LCFS);
+      assert(false);
     }
   }
 

--- a/zero/translate_dim.c
+++ b/zero/translate_dim.c
@@ -43,9 +43,22 @@ gkyl_translate_dim_advance(gkyl_translate_dim* up,
   struct gkyl_array *GKYL_RESTRICT ftar)
 {
   // Perform some basic checks:
-  for (int d=0; d<up->cdim_do-1; d++) {
-    assert(rng_do->lower[d] == rng_tar->lower[d]);
-    assert(rng_do->upper[d] == rng_tar->upper[d]);
+  const struct gkyl_range *hidim_rng, *lodim_rng;
+  if (rng_do->ndim > rng_tar->ndim) {
+    hidim_rng = rng_do;
+    lodim_rng = rng_tar;
+  }
+  else {
+    hidim_rng = rng_tar;
+    lodim_rng = rng_do;
+  }
+  int c = 0;
+  for (int d=0; d<hidim_rng->ndim; d++) {
+    if (d != up->dir) {
+      assert(hidim_rng->lower[d] == lodim_rng->lower[c]);
+      assert(hidim_rng->upper[d] == lodim_rng->upper[c]);
+      c++;
+    }
   }
   for (int d=0; d<up->vdim_do; d++) {
     assert(rng_do->lower[up->cdim_do+d] == rng_tar->lower[up->cdim_tar+d]);


### PR DESCRIPTION
We are trying to establish (i.e. assess, and fix if needed) particle and energy conservation in GK IWL clopen simulations, in 2x at first and hopefully 3x after.

Here we:
- Restrict the ranges over which z boundary fluxes are computed in IWL sims so they are only calculated in the SOL (assuming fluxes through the twist-shift boundary are conservative).
- Fix a small error that prevented (non vol integrated) boundary flux diagnostics from being written out correctly for 2x and 3x if running in parallel.
- Enable the conservation diagnostics for IWL sims.
- Change the treatment of x_LCFS in geo so that it demands that it is at a cell boundary and doesn't shift it (because it has to be consistent with the user's input file).

Via these changes we have been able to check conservation in 2x and 3x sims using rt_gk_d3d_iwl as a testbed.

Here's rt_gk_d3d_iwl_2x:
![Screenshot 2025-05-21 at 9 44 17 AM](https://github.com/user-attachments/assets/a112c7dd-61b7-4431-85bb-767630ffcfba)
particle balance looks good. Energy balance
![Screenshot 2025-05-21 at 9 47 46 AM](https://github.com/user-attachments/assets/3f8fcbe3-cbb3-4359-9355-a2593af5ac78)
Looks ok. The figure on the left doesn't inspire confidence because the error is as large as the boundary flux losses, but in relative to the energy content and the time step (right figure) it seems comparable or even better than turbulent LAPD sims.

Unfortunately rt_gk_d3d_3x (with resolution increased to 24x16x12x10x6 because it's unstable at lower res) doesn't conserve particles:
![Screenshot 2025-05-21 at 11 26 25 AM](https://github.com/user-attachments/assets/c816dfc6-3957-4e53-8354-5d40fd8f7339)
Some possibilities we could explore to fix this (in a separate branch):
- The way we are enforcing twist-shift-dicity of phi or the biasing at the limiter corner could make the numerical fluxes discontinuous.
- Fluxes through the twist-shift boundary are not actually continuous (although I tried this sim with a periodic instead of a twist-shift core, and got similar results at lower res).






