### PR TITLE
Fix of a cuda memcheck error in the selection of array integrate kernel

### DIFF
--- a/zero/gkyl_array_integrate_priv.h
+++ b/zero/gkyl_array_integrate_priv.h
@@ -51,6 +51,7 @@ static const array_integrate_sq_weighted_kern_list gkyl_array_integrate_sq_weigh
 
 GKYL_CU_D
 static const array_integrate_sq_weighted_kern_list gkyl_array_integrate_sq_weighted_ker_list_gkhyb[] = {
+  {NULL, NULL},
   {gkyl_array_integrate_op_sq_weighted_1x1v_gkhyb_p1, NULL},
   {gkyl_array_integrate_op_sq_weighted_1x2v_gkhyb_p1, NULL},
   {gkyl_array_integrate_op_sq_weighted_2x2v_gkhyb_p1, NULL},


### PR DESCRIPTION
Thanks to the [Compute Sanitizer tool](https://docs.nersc.gov/tools/debug/compute-sanitizer/), we found that the kernel selection in the array integrate updater was incorrect due to improper indexing.

This PR adds `NULL` pointers at the beginning of the kernel function lists used in the array integrate updater, corresponding to the case `ndim = 1`. This case is not physically relevant for our purposes, as we only support simulations from 1x1v to 3x2v. However, since the kernel selection uses `ndim - 1` as the index, the lists must contain at least 5 elements to safely handle `ndim = 2` through `ndim = 5`.

This change ensures correct indexing and prevents out-of-bounds memory access during kernel assignment.

Note: main is almost but not perfectly clean yet. 2 errors are remaining that are related to memory deallocation. This will be addressed in a future PR.