### PR TITLE
Add use_gpu attribute to gkyl_deflate_zsurf structure and fix gpu updater memory release

### DIFF
--- a/zero/deflate_zsurf.c
+++ b/zero/deflate_zsurf.c
@@ -16,6 +16,7 @@ gkyl_deflate_zsurf_new(const struct gkyl_basis *cbasis, const struct gkyl_basis 
   } 
 #endif 
   gkyl_deflate_zsurf *up = gkyl_malloc(sizeof(*up));
+  up->use_gpu = use_gpu;
   up->num_basis = cbasis->num_basis;
   up->num_deflated_basis = deflated_cbasis->num_basis;
   up->cdim = cbasis->ndim;
@@ -61,5 +62,9 @@ gkyl_deflate_zsurf_advance(const gkyl_deflate_zsurf *up, int zidx,
 
 void gkyl_deflate_zsurf_release(gkyl_deflate_zsurf* up) 
 {
+#ifdef GKYL_HAVE_CUDA
+  if (up->use_gpu)
+    gkyl_cu_free(up->on_dev);
+#endif
   gkyl_free(up);
 }

--- a/zero/gkyl_deflate_zsurf_priv.h
+++ b/zero/gkyl_deflate_zsurf_priv.h
@@ -42,6 +42,7 @@ struct gkyl_deflate_zsurf {
   deflate_zsurf_kernel kernel;
   uint32_t flags;
   struct gkyl_deflate_zsurf *on_dev; // pointer to itself or device data
+  bool use_gpu;
 };
 
 GKYL_CU_D


### PR DESCRIPTION
This PR addresses memory issues revealed by the [Compute Sanitizer](https://docs.nersc.gov/tools/debug/compute-sanitizer/).

By running:
```
compute-sanitizer --tool memcheck --leak-check full ./g0 -g -s1
```
on Perlmutter, we see that **the deflate zsurf updater is not properly deallocated on GPU.**

<details>
<summary>Click to show Compute Sanitizer error output</summary>

```
========= COMPUTE-SANITIZER
up_cu:0x7f13b9e54000  basis:0x1644658
in kernel: up:0x7f13b9e54000  basis:0x7f1ad3fffb48
up_cu:0x7f1a91d32e00  basis:0x1644658
in kernel: up:0x7f1a91d32e00  basis:0x7f1ad3fffb48
up_cu:0x7f178528fc00  basis:0x7f13b78026e8
in kernel: up:0x7f178528fc00  basis:0x7f1ad3fffb48
up_cu:0x7f17895fc400  basis:0x1644658
in kernel: up:0x7f17895fc400  basis:0x7f1ad3fffb48
up_cu:0x7f178d9e1e00  basis:0x7f13b7837f98
in kernel: up:0x7f178d9e1e00  basis:0x7f1ad3fffb48
Taking time-step 1 at t = 0 ... dt = 2.50788e-09

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Species RHS calc took 11.9435 secs
Species collisions RHS calc took 1.54208 secs
Field RHS calc took 50.3217 secs
Species collisional moments took 87.3998 secs
Total updates took 45.4899 secs
Number of write calls 4
IO time took 0.125361 secs 
========= Leaked 40 bytes at 0x7f1aa8b51000
=========     Saved host backtrace up to driver entry point at allocation time
=========     Host Frame: [0x291fae]
=========                in /usr/lib64/libcuda.so.1
=========     Host Frame:libcudart_static_5382377d5c772c9d197c0cda9fd9742ee6ad893c [0xc2f07bd]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:libcudart_static_f74e2f2bcf2cf49bd1a61332e1d15bd1e748f9cf [0xc2bb442]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:cudaMalloc [0xc2ffd14]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_cu_malloc_ [0x6a5ebc]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflate_zsurf_cu_dev_new [0xc1f3ec8]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflate_zsurf_new [0x3865ec]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflated_fem_poisson_new [0x39ed30]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gk_field_new [0x6dae5c]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_gyrokinetic_app_new_solver [0x7291b6]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_gyrokinetic_app_new [0x72989b]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:main [0x7526]
=========                in /pscratch/sd/a/ah1032/gkyl_debug/rt_gk_sheath/wk/./g0
=========     Host Frame:__libc_start_main [0x351fc]
=========                in /lib64/libc.so.6
=========     Host Frame:_start in ../sysdeps/x86_64/start.S:120 [0x4779]
=========                in /pscratch/sd/a/ah1032/gkyl_debug/rt_gk_sheath/wk/./g0
========= 
========= Leaked 40 bytes at 0x7f1aa8b51200
=========     Saved host backtrace up to driver entry point at allocation time
=========     Host Frame: [0x291fae]
=========                in /usr/lib64/libcuda.so.1
=========     Host Frame:libcudart_static_5382377d5c772c9d197c0cda9fd9742ee6ad893c [0xc2f07bd]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:libcudart_static_f74e2f2bcf2cf49bd1a61332e1d15bd1e748f9cf [0xc2bb442]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:cudaMalloc [0xc2ffd14]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_cu_malloc_ [0x6a5ebc]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflate_zsurf_cu_dev_new [0xc1f3ec8]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflate_zsurf_new [0x3865ec]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_deflated_fem_poisson_new [0x39ed64]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gk_field_new [0x6dae5c]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_gyrokinetic_app_new_solver [0x7291b6]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:gkyl_gyrokinetic_app_new [0x72989b]
=========                in /global/homes/a/ah1032/gkyl_main/gkylsoft/gkylzero/lib/libgkylzero.so
=========     Host Frame:main [0x7526]
=========                in /pscratch/sd/a/ah1032/gkyl_debug/rt_gk_sheath/wk/./g0
=========     Host Frame:__libc_start_main [0x351fc]
=========                in /lib64/libc.so.6
=========     Host Frame:_start in ../sysdeps/x86_64/start.S:120 [0x4779]
=========                in /pscratch/sd/a/ah1032/gkyl_debug/rt_gk_sheath/wk/./g0
========= 
========= LEAK SUMMARY: 80 bytes leaked in 2 allocations
========= ERROR SUMMARY: 2 errors
```

</details>

The branch implements the GPU deallocation of the updater and add a boolean attribute `use_gpu` as it is done in many other updaters.

The branch is compute-sanitizer clean in the following regression tests:

<details>
<summary>rt_gk_sheath_3x2v_p1</summary>

```
ah1032@login07:/pscratch/sd/a/ah1032/gkyl_debug/rt_gk_sheath/wk> compute-sanitizer --tool memcheck --leak-check full ./g0 -g -s1 | tee csmc.log
========= COMPUTE-SANITIZER
Taking time-step 1 at t = 0 ... dt = 2.50788e-09

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Species RHS calc took 1.33195 secs
Species collisions RHS calc took 1.12588 secs
Field RHS calc took 5.55929 secs
Species collisional moments took 11.0933 secs
Total updates took 11.3703 secs
Number of write calls 4
IO time took 0.131651 secs 
========= LEAK SUMMARY: 0 bytes leaked in 0 allocations
========= ERROR SUMMARY: 0 errors
```

</details>

<details>
<summary>rt_vlasov_weibel_2x2v_p2</summary>

```
ah1032@login07:/pscratch/sd/a/ah1032/gkyl_debug/rt_vlasov_weibel/wk> compute-sanitizer --tool memcheck --leak-check full ./g0 -g -s1 | tee csmc.log
========= COMPUTE-SANITIZER
Taking time-step 1 at t = 0 ... dt = 0.0666432

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Species RHS calc took 1.33624 secs
Species collisions RHS calc took 0 secs
Field RHS calc took 0.0452827 secs
Species collisional moments took 0 secs
Total updates took 7.61817 secs
Number of write calls 1
IO time took 0.045448 secs 
========= LEAK SUMMARY: 0 bytes leaked in 0 allocations
========= ERROR SUMMARY: 0 errors
```

</details>

<details>
<summary>rt_pkpm_neut_sodshock_p2</summary>

```
ah1032@login07:/pscratch/sd/a/ah1032/gkyl_debug/rt_pkpm/wk> compute-sanitizer --tool memcheck --leak-check full ./g0 -g -s1 | tee csmc.log
========= COMPUTE-SANITIZER
Taking time-step 1 at t = 0 ... dt = 3.3142e-05

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Species RHS calc took 0.992771 secs
Species collisions RHS calc took 0.034522 secs
Fluid species RHD calc took 0.00916028 secs
Field RHS calc took 0.00665237 secs
Species PKPM vars took 9.26046 secs
Species collisional moments took 4.04395 secs
EM variables (bvar) calc took 4.1474 secs
Current evaluation and accumulate took 0.000335708 secs
Total updates took 10.299 secs
Number of write calls 1
IO time took 3.17242 secs 
========= LEAK SUMMARY: 0 bytes leaked in 0 allocations
========= ERROR SUMMARY: 0 errors
```

</details>
