### PR TITLE
Fix gk neut const sgn alpha

### DIFF
--- a/apps/gk_neut_species.c
+++ b/apps/gk_neut_species.c
@@ -1085,7 +1085,7 @@ gk_neut_species_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app, struc
   // 3. const_sgn_alpha (boolean for if sign(alpha_surf) is a constant, either +1 or -1)
   s->alpha_surf = mkarr(app->use_gpu, alpha_surf_sz, s->local_ext.volume);
   s->sgn_alpha_surf = mkarr(app->use_gpu, sgn_alpha_surf_sz, s->local_ext.volume);
-  s->const_sgn_alpha = mk_int_arr(app->use_gpu, cdim+vidm, s->local_ext.volume);
+  s->const_sgn_alpha = mk_int_arr(app->use_gpu, cdim+vdim, s->local_ext.volume);
 
   // Pre-compute alpha_surf, sgn_alpha_surf, const_sgn_alpha, and cot_vec since they are time-independent
   struct gkyl_dg_calc_canonical_pb_vars *calc_vars = gkyl_dg_calc_canonical_pb_vars_new(&s->grid, 


### PR DESCRIPTION
Read commit message / see file change.

In a 1x3v sim @tnbernard and @johnson452 are using to compare Canonical PB run from the Vlasov app or the GK app (but run on the `gk_neut_analytic_geom` branch, and providig the GK solver with the analytic metric), the final Maxwellian moments at 100 microsec were coming out junky from the GK app when run on GPU:
![Screenshot 2025-06-04 at 10 27 35 PM](https://github.com/user-attachments/assets/be399c48-004e-4431-a7b7-55d997d277f3)
with the proposed fix, the results are the same now:
<img width="1058" alt="Screenshot 2025-06-04 at 11 47 11 PM" src="https://github.com/user-attachments/assets/bb0ec08f-429d-4541-a3f2-f4eacc532be0" />

compute-sanitizer can help prevent and identify these errors