### PR TITLE
Drift Sign Correction for Fpol <0

### DIFF
--- a/zero/calc_metric.c
+++ b/zero/calc_metric.c
@@ -151,6 +151,10 @@ void gkyl_calc_metric_advance_rz(
               double *bmag_n = gkyl_array_fetch(bmag_nodal, gkyl_range_idx(nrange, cidx));
               double dphidtheta = (jFld_n[0]*jFld_n[0]*bmag_n[0]*bmag_n[0] - dxdz[0][2]*dxdz[0][2] - dxdz[1][2]*dxdz[1][2])/R/R;
               dphidtheta = sqrt(dphidtheta);
+              // recover sign from exact dphidtheta = F(psi)/R/\grad(psi)Add commentMore actions
+              if (ddtheta_n[2] < 0) {
+                dphidtheta = -dphidtheta;
+              }
 
               double *gFld_n= gkyl_array_fetch(gFld_nodal, gkyl_range_idx(nrange, cidx));
               gFld_n[0] = dxdz[0][0]*dxdz[0][0] + R*R*dxdz[2][0]*dxdz[2][0] + dxdz[1][0]*dxdz[1][0]; 


### PR DESCRIPTION
This bug was uncovered and fixed in quadgeo: When fpol<0 in the efit file corresponding to Bphi out of page (which I have only seen in the asdex efit so far) the sign of dphidtheta was not correct. This doesn't cause any crashes or anything, but the toroidal field is in the wrong direction so it affects the direction of drifts.

Below I have included a plot of asdex turbulence simulations in main (left) and on quadgeo (right). In quadgeo the drift direction is correct and in main it is wrong, so you can see the turbulence in xz (psi-theta) plane is flipped. I have also included a plot of the domain on which these simulations are run.

![image](https://github.com/user-attachments/assets/a3cc229f-9abb-47d0-910d-db0c2f3fccc0)
![asdexnodes](https://github.com/user-attachments/assets/eef2f30e-7229-46b7-a598-9830ed33caa9)

