### PR TITLE
Optional additional arguments for C input files

### DIFF
--- a/regression/rt_arg_parse.h
+++ b/regression/rt_arg_parse.h
@@ -31,6 +31,7 @@ struct gkyl_app_args {
   bool skip_limiters; // should we skip limiters?
   bool is_restart; // is this a restarted sim?
   int restart_frame; // frame to restart from
+  char opt_args[1024]; // optional arguments
 };
 
 static int
@@ -93,7 +94,7 @@ parse_app_args(int argc, char **argv)
   args.basis_type = GKYL_BASIS_MODAL_SERENDIPITY;
 
   int c;
-  while ((c = getopt(argc, argv, "+hjgmMt:s:i:b:x:y:z:u:v:w:r:c:d:e:")) != -1) {
+  while ((c = getopt(argc, argv, "+hjgmMt:s:i:b:x:y:z:u:v:w:r:c:d:e:o:")) != -1) {
     switch (c)
     {
       case 'h':
@@ -110,6 +111,7 @@ parse_app_args(int argc, char **argv)
         printf(" -l     Turn off limiters\n");
         printf(" -rN    Restart the simulation from frame N\n");
         printf(" -m     Turn on memory allocation/deallocation tracing\n");
+        printf(" -o     Optional arguments (as string, requires parsing)\n");
         printf("\n");
         printf(" Grid resolution in configuration space:\n");
         printf(" -xNX -yNY -zNZ\n");
@@ -199,6 +201,10 @@ parse_app_args(int argc, char **argv)
         args.mp_recon = get_mp_recon_type(optarg);
         assert(args.mp_recon != -1);
         break;        
+
+      case 'o':
+        strcpy(args.opt_args, optarg);
+        break;
 
       case '?':
         break;


### PR DESCRIPTION
This adds an `opt_args` option to `regression/rt_arg_parse.h` similar to that in `gkyl.c`, so that anyone can pass additional command line arguments to C input files (e.g. to do launch batches of simulations).

For example, one could launch a simulation that externally sets the input power, which is proportional to the particle source rate `ndot_src` like 
```
./sim_executable -o ndot_src=1.2e22
```
requesting the source rate $\dot{n}_{src}=1.2\times10^{22} ~ \mathrm{m}^{-3}/\mathrm{s}$. Inside the input file this could be read and stored in the context as follows:
```
  struct my_sim_ctx ctx = create_ctx(); // context for init functions

  // Extract variables from command line arguments.
  sscanf(app_args.opt_args, "ndot_src=%lf", &ctx.ndot_src);
```

