### PR TITLE
Important fix and add assert adaptive source

### DIFF
--- a/apps/gk_species_projection.c
+++ b/apps/gk_species_projection.c
@@ -345,7 +345,8 @@ gk_species_projection_calc(gkyl_gyrokinetic_app *app, struct gk_species *s,
     gkyl_array_copy(f, s->lte.f_lte);
   }
   
-  if (proj->proj_id == GKYL_PROJ_MAXWELLIAN_PRIM || proj->proj_id == GKYL_PROJ_BIMAXWELLIAN) {
+  if (proj->proj_id == GKYL_PROJ_MAXWELLIAN_PRIM || proj->proj_id == GKYL_PROJ_BIMAXWELLIAN
+    || proj->proj_id == GKYL_PROJ_MAXWELLIAN_GAUSSIAN) {
     // Correct all the moments of the projected Maxwellian (or bi-Maxwellian) distribution function.
     if (proj->correct_all_moms) {
       struct gkyl_gk_maxwellian_correct_status status_corr;

--- a/apps/gk_species_source.c
+++ b/apps/gk_species_source.c
@@ -366,6 +366,9 @@ gk_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
     if(src->num_adapt_sources > 0){
       src->adapt_func = gk_species_source_adapt_dynamic;
       for (int k = 0; k < src->num_adapt_sources; ++k) {
+        // Adaptive source must be a Maxwellian Gaussian projection.
+        assert(src->proj_source[k].proj_id == GKYL_PROJ_MAXWELLIAN_GAUSSIAN);
+
         struct gk_adapt_source *adapt_src = &src->adapt[k];
 
         adapt_src->adapt_particle = s->info.source.adapt[k].adapt_particle;

--- a/apps/gk_species_source.c
+++ b/apps/gk_species_source.c
@@ -267,9 +267,11 @@ gk_species_source_adapt_dynamic(gkyl_gyrokinetic_app *app, struct gk_species *s,
     temperature_new = fmax(temperature_new, s->info.source.projection[k].temp_min);
 
     // Update the density and temperature moments of the source
+    gkyl_array_clear(src->proj_source[k].prim_moms, 0.0);
     gkyl_array_set_offset(src->proj_source[k].prim_moms, particle_src_new, src->proj_source[k].gaussian_profile, 0*app->basis.num_basis);
     gkyl_array_set_offset(src->proj_source[k].prim_moms, 0.0, src->proj_source[k].gaussian_profile, 1*app->basis.num_basis);
-    gkyl_array_shiftc(src->proj_source[k].prim_moms, temperature_new / s->info.mass, 2*app->basis.num_basis);
+    double dg_norm = pow(sqrt(2.0), app->cdim);
+    gkyl_array_shiftc(src->proj_source[k].prim_moms, dg_norm * temperature_new / s->info.mass, 2*app->basis.num_basis);
 
     // Refresh the current values of particle, energy and temperature (can be used for control).
     adapt_src->particle_src_curr = particle_src_new;


### PR DESCRIPTION
Fix of a bug in the adaptation routine of the source.

The update of the prim_mom array is done wrong and temperature is added constantly instead of being set in the call
```
    gkyl_array_shiftc(src->proj_source[k].prim_moms, temperature_new / s->info.mass, 2*app->basis.num_basis);
```

To fix it, we just need to clear the prim_mom array before manipulating it.

Also there was a missing DG coefficient factor.

This branch also add an assert to prevent the use of other projection with the adaptive sourcing.