### PR TITLE
Restart with a different geometry

### DIFF
--- a/apps/gk_neut_species.c
+++ b/apps/gk_neut_species.c
@@ -750,10 +750,6 @@ gk_neut_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_neu
 
     // Perform some basic checks.
     if (pdim_do == pdim) {
-      for (int d=0; d<pdim; d++) {
-        assert(grid_do.lower[d] == grid.lower[d]);
-        assert(grid_do.upper[d] == grid.upper[d]);
-      }
       // Check if the grid resolution is the same.
       for (int d=0; d<pdim; d++)
         same_res = same_res && (grid_do.cells[d] == grid.cells[d]);

--- a/apps/gk_neut_species.c
+++ b/apps/gk_neut_species.c
@@ -849,7 +849,7 @@ gk_neut_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_neu
   rstat.io_status = gkyl_comm_array_read(comm_do, &grid_do, &local_do, fdo_host, inp.file_name);
 
   bool scale_by_jacobgeo = false;
-  with_file(fp, inp.jacobgeo_inv_file_name, "r") {
+  with_file(fp, inp.jacobtot_inv_file_name, "r") {
     // Set up configuration space donor grid and basis
     struct gkyl_rect_grid conf_grid_do;
     gkyl_rect_grid_init(&conf_grid_do, cdim_do, grid_do.lower, grid_do.upper, grid_do.cells);
@@ -864,7 +864,7 @@ gk_neut_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_neu
     gkyl_cart_modal_serendip(&conf_basis_do, cdim_do, poly_order);
     // Array for Jacobian inverse
     struct gkyl_array *jacobgeo_inv_do_host = mkarr(false, conf_basis_do.num_basis, conf_local_ext_do.volume);
-    rstat.io_status = gkyl_comm_array_read(comm_do, &conf_grid_do, &conf_local_do, jacobgeo_inv_do_host, inp.jacobgeo_inv_file_name);
+    rstat.io_status = gkyl_comm_array_read(comm_do, &conf_grid_do, &conf_local_do, jacobgeo_inv_do_host, inp.jacobtot_inv_file_name);
     gkyl_dg_mul_conf_phase_op_range(&conf_basis_do, &basis_do, fdo_host, jacobgeo_inv_do_host, fdo_host, &conf_local_ext_do, &local_ext_do);
     gkyl_array_release(jacobgeo_inv_do_host);
     gkyl_rect_decomp_release(conf_decomp_do);

--- a/apps/gk_species.c
+++ b/apps/gk_species.c
@@ -1256,10 +1256,6 @@ gk_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_species 
 
     // Perform some basic checks.
     if (pdim_do == pdim) {
-      for (int d=0; d<pdim; d++) {
-        assert(grid_do.lower[d] == grid.lower[d]);
-        assert(grid_do.upper[d] == grid.upper[d]);
-      }
       // Check if the grid resolution is the same.
       for (int d=0; d<pdim; d++)
         same_res = same_res && (grid_do.cells[d] == grid.cells[d]);
@@ -1362,8 +1358,8 @@ gk_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_species 
   struct gkyl_app_restart_status rstat;
   rstat.io_status = gkyl_comm_array_read(comm_do, &grid_do, &local_do, fdo_host, inp.file_name);
 
-  bool scale_by_jacobgeo = false;
-  with_file(fp, inp.jacobgeo_inv_file_name, "r") {
+  bool scale_by_jacobtot = false;
+  with_file(fp, inp.jacobtot_inv_file_name, "r") {
     // Set up configuration space donor grid and basis
     struct gkyl_rect_grid conf_grid_do;
     gkyl_rect_grid_init(&conf_grid_do, cdim_do, grid_do.lower, grid_do.upper, grid_do.cells);
@@ -1377,12 +1373,12 @@ gk_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_species 
     struct gkyl_basis conf_basis_do;
     gkyl_cart_modal_serendip(&conf_basis_do, cdim_do, poly_order);
     // Array for Jacobian inverse
-    struct gkyl_array *jacobgeo_inv_do_host = mkarr(false, conf_basis_do.num_basis, conf_local_ext_do.volume);
-    rstat.io_status = gkyl_comm_array_read(comm_do, &conf_grid_do, &conf_local_do, jacobgeo_inv_do_host, inp.jacobgeo_inv_file_name);
-    gkyl_dg_mul_conf_phase_op_range(&conf_basis_do, &basis_do, fdo_host, jacobgeo_inv_do_host, fdo_host, &conf_local_ext_do, &local_ext_do);
-    gkyl_array_release(jacobgeo_inv_do_host);
+    struct gkyl_array *jacobtot_inv_do_host = mkarr(false, conf_basis_do.num_basis, conf_local_ext_do.volume);
+    rstat.io_status = gkyl_comm_array_read(comm_do, &conf_grid_do, &conf_local_do, jacobtot_inv_do_host, inp.jacobtot_inv_file_name);
+    gkyl_dg_mul_conf_phase_op_range(&conf_basis_do, &basis_do, fdo_host, jacobtot_inv_do_host, fdo_host, &conf_local_ext_do, &local_ext_do);
+    gkyl_array_release(jacobtot_inv_do_host);
     gkyl_rect_decomp_release(conf_decomp_do);
-    scale_by_jacobgeo = true;
+    scale_by_jacobtot = true;
   }
 
   if (app->use_gpu) {
@@ -1432,8 +1428,8 @@ gk_species_file_import_init(struct gkyl_gyrokinetic_app *app, struct gk_species 
   }
 
   // Multiply f by the Jacobian.
-  if (scale_by_jacobgeo)
-    gkyl_dg_mul_conf_phase_op_range(&app->basis, &gks->basis, gks->f, app->gk_geom->jacobgeo, gks->f, &app->local, &gks->local);
+  if (scale_by_jacobtot)
+    gkyl_dg_mul_conf_phase_op_range(&app->basis, &gks->basis, gks->f, app->gk_geom->jacobtot, gks->f, &app->local, &gks->local);
 
   gkyl_rect_decomp_release(decomp_do);
   gkyl_comm_release(comm_do);

--- a/apps/gkyl_gyrokinetic.h
+++ b/apps/gkyl_gyrokinetic.h
@@ -232,7 +232,7 @@ struct gkyl_gyrokinetic_ic_import {
   // and to modify that distribution such that f = alpha(x)*f_in+beta(x,v).
   enum gkyl_ic_import_type type;
   char file_name[128]; // Name of file that contains IC, J*f_in.
-  char jacobgeo_inv_file_name[128]; // Name of file that contains 1/Jacobian. Used to get f from Jf.
+  char jacobtot_inv_file_name[128]; // Name of file that contains 1/Jacobian. Used to get f from Jf.
   void *conf_scale_ctx;
   void (*conf_scale)(double t, const double *xn, double *fout, void *ctx); // alpha(x).
   struct gkyl_gyrokinetic_projection phase_add; // beta(x,v).

--- a/regression/rt_gk_wham_1xIC_2x2v_p1.c
+++ b/regression/rt_gk_wham_1xIC_2x2v_p1.c
@@ -901,7 +901,7 @@ int main(int argc, char **argv)
       .init_from_file = {
         .type = GKYL_IC_IMPORT_F,
         .file_name = "gk_wham_1x2v_p1-elc_0.gkyl",
-        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
+        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobtot_inv.gkyl",
       },
       .mapc2p = {
         .mapping = mapc2p_vel_elc,
@@ -954,7 +954,7 @@ int main(int argc, char **argv)
       .init_from_file = {
         .type = GKYL_IC_IMPORT_F,
         .file_name = "gk_wham_1x2v_p1-ion_0.gkyl",
-        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
+        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobtot_inv.gkyl",
       },
       .scale_with_polarization = true,
       .collisions =  {

--- a/regression/rt_gk_wham_1xIC_2x2v_p1.c
+++ b/regression/rt_gk_wham_1xIC_2x2v_p1.c
@@ -901,7 +901,7 @@ int main(int argc, char **argv)
       .init_from_file = {
         .type = GKYL_IC_IMPORT_F,
         .file_name = "gk_wham_1x2v_p1-elc_0.gkyl",
-        // .jacobgeo_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
+        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
       },
       .mapc2p = {
         .mapping = mapc2p_vel_elc,
@@ -954,7 +954,7 @@ int main(int argc, char **argv)
       .init_from_file = {
         .type = GKYL_IC_IMPORT_F,
         .file_name = "gk_wham_1x2v_p1-ion_0.gkyl",
-        // .jacobgeo_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
+        // .jacobtot_inv_file_name = "gk_wham_1x2v_p1-jacobgeo_inv.gkyl",
       },
       .scale_with_polarization = true,
       .collisions =  {


### PR DESCRIPTION
This PR wants to relax the assumptions when performing a restart from file using the structure
```
.init_from_file = {
  .type = GKYL_IC_IMPORT_F,
  .file_name = "restart-ion.gkyl",
  .jacobgeo_inv_file_name = "restart-jacobgeo_inv.gkyl",
},
```
The current state of g0 prevents any restart if the bounds of the grid are changed. It could however be useful to start a simulation in a new geometry with a turbulent state that was previously obtained. E.g. when changing from negative triangularity (NT) to positive triangularity (PT), the simulation domain length in the binormal coordinate is changed because it is normalized to the safety factor which changes between both configurations.

This PR simply remove the assert that impeach the restart with different grid bounds. A restart can now be done with any kind of file that has the same resolution. 
We also use this occasion to replace the `jacobgeo` scaling by a scaling by `jacobtot`. This scaling may be important if the metric changes and one should provide a `jacobgeo_inv` file within the `init_from_file` structure.

One has to pay attention to one major caveat:
The integrated moments may not be conserved as they will change with the change of the grid volume. One could implement a scaling of the distribution function to maintain the number of particle constant.

Tell me in the comments below ⬇️  if you'd like to see me implementing this and don't forget to subscribe and hit the bell 🤑 