### PR TITLE
Fix uninitialized value in GK field app

### DIFF
--- a/apps/gk_field.c
+++ b/apps/gk_field.c
@@ -337,9 +337,13 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
     if (app->use_gpu) {
       f->em_energy_red_new = gkyl_cu_malloc(sizeof(double[1]));
       f->em_energy_red_old = gkyl_cu_malloc(sizeof(double[1]));
+      gkyl_cu_memset(f->em_energy_red_new, 0, sizeof(double[1]));
+      gkyl_cu_memset(f->em_energy_red_old, 0, sizeof(double[1]));
     } else {
       f->em_energy_red_new = gkyl_malloc(sizeof(double[1]));
       f->em_energy_red_old = gkyl_malloc(sizeof(double[1]));
+      memset(f->em_energy_red_new, 0, sizeof(double[1]));
+      memset(f->em_energy_red_old, 0, sizeof(double[1]));
     }
     f->integ_energy_dot = gkyl_dynvec_new(GKYL_DOUBLE, 1);
     f->is_first_energy_dot_write_call = true;


### PR DESCRIPTION
Previous we had noticed that there was a valgrind error in closing the `field_energy_dot` file. It attribute it to the `fclose` in `with_file`:

```
mana@perlmutter:login32:~/perlmutter/gkeyll/code/g0-cpu/gkylzero> valgrind --leak-check=full --max-stackframe=2458976 ./build/regression/rt_gk_sheath_1x2v_p1 -s1
==1429448== Memcheck, a memory error detector
==1429448== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1429448== Using Valgrind-3.20.0 and LibVEX; rerun with -h for copyright info
==1429448== Command: ./build/regression/rt_gk_sheath_1x2v_p1 -s1
==1429448==
==1429448== Syscall param write(buf) points to uninitialised byte(s)
==1429448==    at 0xB2DC213: write (in /lib64/libc-2.31.so)
==1429448==    by 0xB267EFC: _IO_file_write@@GLIBC_2.2.5 (in /lib64/libc-2.31.so)
==1429448==    by 0xB26715E: new_do_write (in /lib64/libc-2.31.so)
==1429448==    by 0xB2690B8: _IO_do_write@@GLIBC_2.2.5 (in /lib64/libc-2.31.so)
==1429448==    by 0xB26896F: _IO_file_close_it@@GLIBC_2.2.5 (in /lib64/libc-2.31.so)
==1429448==    by 0xB25A2AB: fclose@@GLIBC_2.2.5 (in /lib64/libc-2.31.so)
==1429448==    by 0x953E178: fclose (darshan-stdio.c:463)
==1429448==    by 0x4B782FB: gkyl_dynvec_write_mode (dynvec.c:183)
==1429448==    by 0x4C24C44: gkyl_gyrokinetic_app_write_field_energy (gyrokinetic.c:1211)
==1429448==    by 0x402D27: write_data (rt_gk_sheath_1x2v_p1.c:424)
==1429448==    by 0x401FB7: main (rt_gk_sheath_1x2v_p1.c:673)
==1429448==  Address 0xf8fd16d is 61 bytes inside a block of size 8,192 alloc'd
==1429448==    at 0x4838744: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1429448==    by 0xB25A07B: _IO_file_doallocate (in /lib64/libc-2.31.so)
==1429448==    by 0xB26A538: _IO_doallocbuf (in /lib64/libc-2.31.so)
==1429448==    by 0xB267A22: _IO_file_seekoff@@GLIBC_2.2.5 (in /lib64/libc-2.31.so)
==1429448==    by 0xB263DBC: fseek (in /lib64/libc-2.31.so)
==1429448==    by 0x9541C10: fseek (darshan-stdio.c:910)
==1429448==    by 0x4B781DB: gkyl_dynvec_write_mode (dynvec.c:184)
==1429448==    by 0x4C24C44: gkyl_gyrokinetic_app_write_field_energy (gyrokinetic.c:1211)
==1429448==    by 0x402D27: write_data (rt_gk_sheath_1x2v_p1.c:424)
==1429448==    by 0x401FB7: main (rt_gk_sheath_1x2v_p1.c:673)
```

But it was really because at t=0 we haven't computed the rate of change of the field energy, and there was an uninitialized value. This PR makes this error disappear by initializing a couple of dynamically allocated doubles to 0 at t=0.