### PR TITLE
Fix gk neut source write

### DIFF
--- a/apps/gk_neut_species_source.c
+++ b/apps/gk_neut_species_source.c
@@ -132,10 +132,10 @@ gk_neut_species_source_write_mom(gkyl_gyrokinetic_app* app, struct gk_neut_speci
 
       const char *fmt = "%s-%s_source_%s_%d.gkyl";
       int sz = gkyl_calc_strlen(fmt, app->name, gkns->info.name,
-        gkns->info.diag_moments[m], frame);
+        gkyl_distribution_moments_strs[gkns->info.source.diagnostics.diag_moments[m]], frame);
       char fileNm[sz+1]; // ensures no buffer overflow
       snprintf(fileNm, sizeof fileNm, fmt, app->name, gkns->info.name,
-        gkns->info.diag_moments[m], frame);
+        gkyl_distribution_moments_strs[gkns->info.source.diagnostics.diag_moments[m]], frame);
 
       gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt,
         gkns->src.moms[m].marr_host, fileNm);


### PR DESCRIPTION
Error in the gk_neut_species source write moms function had an error with the string and some reg tests failed. This is now fixed.