### PR TITLE
Disable AVX512 instruction sets

### DIFF
--- a/configure
+++ b/configure
@@ -42,7 +42,9 @@ NOTE: At present, the configure script DOES NOT check if you have
 specified valid paths. YOU are responsible for setting them correctly!
 
 CC                         C compiler to use. Default is system cc
-ARCH_FLAGS                 Architecture flags to use. Default '-march=native'
+ARCH_FLAGS                 Architecture flags to use. Default '-march=native'.
+													 To disable AVX-512 instructions, which valgrind does
+													 not support, use '-march=skylake'.
 CUDA_ARCH                  CUDA architecture flag to specify compute capability. 
                            Use CUDA_ARCH=70 for V100, CUDA_ARCH=80 for A100, etc. 
                            Default is CUDA_ARCH=70.

--- a/install-deps/build-openblas.sh
+++ b/install-deps/build-openblas.sh
@@ -24,8 +24,8 @@ then
     gunzip -f OpenBLAS-0.3.30.tar.gz
     tar xvf OpenBLAS-0.3.30.tar
     cd OpenBLAS-0.3.30
-    make USE_OPENMP=0 NUM_THREADS=1 NO_FORTRAN=1 -j 32
-    make USE_OPENMP=0 NUM_THREADS=1 NO_FORTRAN=1 install PREFIX=$PREFIX -j 32
+    make USE_OPENMP=0 NUM_THREADS=1 NO_FORTRAN=1 NO_AVX512=1 -j 32
+    make USE_OPENMP=0 NUM_THREADS=1 NO_FORTRAN=1 NO_AVX512=1 install PREFIX=$PREFIX -j 32
 
     # soft-link 
     ln -sfn $PREFIX $GKYLSOFT/OpenBLAS


### PR DESCRIPTION
The branch name says it all. AVX512 is not compatible with Valgrind, and it often gives me issues. Particularly, the OpenBLAS installation defaults to YES avx512, and Valgrind doesn't know what to do with these instructions. By default, I think we should turn it on for a robust installation process.

I also added a note to the ./configure script to specify that Skylake is the architecture that does not include AVX512, so that it's clear to specify that in the march settings.