### PR TITLE
Remove the lower x bc enforcement for the field 

### DIFF
--- a/gyrokinetic/apps/gk_field.c
+++ b/gyrokinetic/apps/gk_field.c
@@ -127,23 +127,6 @@ gk_field_enforce_zbc_none(const gkyl_gyrokinetic_app *app, struct gk_field *fiel
 {
 }
 
-// Ensure that the value at the lower x boundary matches the Dirichlet boundary condition value.
-static void 
-gk_field_enforce_xbc(const gkyl_gyrokinetic_app *app, struct gk_field *field, struct gkyl_array *finout)
-{
-  gkyl_array_clear_range(finout, 0.0, &app->lower_skin[0]);
-  double dg_norm = pow(sqrt(2.0),app->basis.ndim);
-  struct gkyl_gyrokinetic_bc *bc_lo_x = gk_fetch_bc_with_dir_edge(field->info.poisson_bcs, 2*(app->cdim-1), 0, GKYL_LOWER_EDGE);
-  gkyl_array_shiftc_range(finout, dg_norm*bc_lo_x->value[0], 0, &app->lower_skin[0]);
-  // Update the lower x skin surface value to match the ghost cell at the node position.
-  gkyl_skin_surf_from_ghost_advance(field->ssfg_x_lo, finout);
-}
-
-static void
-gk_field_enforce_xbc_none(const gkyl_gyrokinetic_app *app, struct gk_field *field, struct gkyl_array *finout)
-{
-}
-
 // Initialize field object.
 struct gk_field* 
 gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
@@ -512,13 +495,10 @@ gk_field_new(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app)
 
   // Twist-and-shift boundary condition for phi and skin surface from ghost to impose phi periodicity at z=-pi.
   f->enforce_zbc = gk_field_enforce_zbc_none;
-  f->enforce_xbc = gk_field_enforce_xbc_none;
   if (f->gkfield_id == GKYL_GK_FIELD_ES_IWL) {
     gk_field_add_TSBC_and_SSFG_updaters(app,f);
     f->enforce_zbc = gk_field_enforce_zbc;
     struct gkyl_gyrokinetic_bc *bc_lo_x = gk_fetch_bc_with_dir_edge(f->info.poisson_bcs, 2*(app->cdim-1), 0, GKYL_LOWER_EDGE);
-    // if (bc_lo_x->type == GKYL_BC_GK_FIELD_DIRICHLET)
-      // f->enforce_xbc = gk_field_enforce_xbc;
   }
   
   return f;
@@ -691,10 +671,6 @@ gk_field_rhs(gkyl_gyrokinetic_app *app, struct gk_field *field)
 
       // Enforce a BC of the field in the parallel direction.
       field->enforce_zbc(app, field, field->phi_smooth);
-
-      // Correct the radial BC (needed if TSBC was applied).
-      field->enforce_xbc(app, field, field->phi_smooth);
-
     }
   }
   app->stat.field_phi_solve_tm += gkyl_time_diff_now_sec(wst);

--- a/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
@@ -1045,7 +1045,6 @@ struct gk_field {
   
   // Pointer to functions for the twist-and-shift BCs.
   void (*enforce_zbc) (const gkyl_gyrokinetic_app *app, struct gk_field *field, struct gkyl_array *finout);
-  void (*enforce_xbc) (const gkyl_gyrokinetic_app *app, struct gk_field *field, struct gkyl_array *finout);
 };
 
 // Gyrokinetic object: used as opaque pointer in user code.


### PR DESCRIPTION
We discovered that the current state of the main is not able to run a typical coarse production run of tcv turbulence simulation. The latest stable commit was identified (https://github.com/ammarhakim/gkeyll/commit/7e18b246f38f25bc7641bbbb10e21c8079e54409) which is just before putting the x_ssfg_lo updater and enforcing the BC of phi after applying TSBC. We indeed observed that the TSBC was breaking the 0 Dirichlet BC of phi (see DR https://github.com/ammarhakim/gkeyll/issues/698) but many production runs were done since then without suffering from any unphysical nor numerical issuses.
This is why we propose here to remove the lower x ssfg application and let the lower radial skin values of phi to be altered by the TSBC application.

#### More details:
The following files show how the same input file yield different dynamics. The current version of the main is showing a drop of time step size at ~16mus whereas an older commit shows a constant dt up to t>300mus.

[tcv_pt_coarse_main.log](https://github.com/user-attachments/files/22606962/tcv_pt_coarse_main.log)
[tcv_pt_coarse_commit_7e18b2.log](https://github.com/user-attachments/files/22606963/tcv_pt_coarse_commit_7e18b2.log)

The two C input files are the same except the change of BC table.
[gkeyll_main.c](https://github.com/user-attachments/files/22606971/gkeyll_main.c)
[gkeyll_commit_7e18b2.c](https://github.com/user-attachments/files/22606970/gkeyll_commit_7e18b2.c)

Removing the lower x ssfg updater solves this issue.