### PR TITLE
BUGFIX: Position map constant B mapping

### DIFF
--- a/gyrokinetic/zero/gkyl_position_map_priv.h
+++ b/gyrokinetic/zero/gkyl_position_map_priv.h
@@ -655,7 +655,7 @@ position_map_constB_z_numeric(double t, const double *xn, double *fout, void *ct
         return;
       }
       else {
-        printf("Warning: Unexpected interval evaluation state in position_map_constB_z_numeric. Using theta directly.\n");
+        fprintf(stderr, "Warning: Unexpected interval evaluation state in position_map_constB_z_numeric. Using theta directly.\n");
         fout[0] = theta;
         return;
       }


### PR DESCRIPTION
There was a bug in the region detection where it would get stuck if one side is too close to the z which the function is trying to evaluate. I added an else{} statement to the if statement, as well as some elseif statements for finding if we are too close to the boundary.

Here is an example of a simulation which was hanging before that is now producing a good grid. This is mc2nu_deflated.gkyl
<img width="1246" height="956" alt="image" src="https://github.com/user-attachments/assets/79dbbdca-acef-4a2b-a346-c6b4dcb30e5d" />
