### PR TITLE
BUGFIX: fix the phase space triggers in the gk_run method

### DIFF
--- a/gyrokinetic/apps/gkyl_gyrokinetic_run.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic_run.h
@@ -4,7 +4,7 @@
 struct gkyl_gyrokinetic_timings {
   double t_end; // End time for the simulation
   int num_frames; // Number of output frames. Output every (t_end/num_frames) time units.
-  int write_phase_freq; // Frequency (in multiples of num_frames) of writing phase-space data. e.g. 0.2 means write every 5 frames.
+  double write_phase_freq; // Frequency (in multiples of num_frames) of writing phase-space data. e.g. 0.2 means write every 5 frames.
   int int_diag_calc_num; // Number of integrated diagnostic calculations to do. 100*num_frames means 100 calculations per frame.
   double dt_failure_tol; // Tolerance for small time-step failures. Typical value is 1e-4
   int num_failures_max; // Maximum number of consecutive small time-step failures before aborting simulation. Typical value is 20.


### PR DESCRIPTION
Fix issue #880. I made a mistake when I implemented this feature. The write_phase_freq was cast as an int instead of double, so it was doing either 0 frames of all frames. Bug fixed. 1 word change.

Testing:
I changed rt_gk_sheath_1x2v to output 10 frames with write_phase_freq=0.2 and here is what we get
```
ls
gk_sheath_1x2v_p1-elc_0.gkyl                                   
gk_sheath_1x2v_p1-elc_10.gkyl                                 
gk_sheath_1x2v_p1-elc_5.gkyl
```