### PR TITLE
Fixes for the Lua wrapping of the embedded boundary.

### DIFF
--- a/moments/luareg/rt_cold_mom_beach.lua
+++ b/moments/luareg/rt_cold_mom_beach.lua
@@ -1,0 +1,127 @@
+-- Propagation into a plasma wave beach test for the 5-moment equations.
+-- Input parameters match the initial conditions found in entry JE8 of Ammar's Simulation Journal (https://ammar-hakim.org/sj/je/je8/je8-plasmabeach.html), adapted from Section III. A. of the article:
+-- D. N. Smithe (2007), "Finite-difference time-domain simulation of fusion plasmas at radiofrequency time scales",
+-- Physics of Plasmas, Volume 14 (5): 056104.
+-- https://pubs.aip.org/aip/pop/article/14/5/056104/929539/Finite-difference-time-domain-simulation-of-fusion
+
+local Moments = G0.Moments
+local Cold = G0.Moments.Eq.ColdFluid
+
+-- Mathematical constants (dimensionless).
+pi = math.pi
+
+-- Physical constants (using non-normalized physical units).
+gas_gamma = 5.0 / 3.0 -- Adiabatic index.
+epsilon0 = 8.854187817620389850536563031710750260608e-12 -- Permittivity of free space.
+mu0 = 12.56637061435917295385057353311801153679e-7 -- Permeability of free space.
+mass_elc = 9.10938215e-31 -- Electron mass.
+charge_elc = -1.602176487e-19 -- Electron charge.
+
+J0 = 1.0e-12 -- Reference current density (Amps / m^3).
+
+-- Derived physical quantities (using non-normalized physical units).
+light_speed = 1.0 / math.sqrt(mu0 * epsilon0) -- Speed of light.
+
+-- Simulation parameters.
+Nx = 128 -- Cell count (x-direction).
+Lx = 1.0 -- Domain size (x-direction).
+Lx100 = Lx / 100.0 -- Domain size over 100 (x-direction).
+x_last_edge = Lx - Lx / Nx -- Location of center of last upper cell (low density side).
+cfl_frac = 0.95 -- CFL coefficient.
+t_end = 5.0e-9 -- Final simulation time.
+num_frames = 1 -- Number of output frames.
+field_energy_calcs = GKYL_MAX_INT -- Number of times to calculate field energy.
+integrated_mom_calcs = GKYL_MAX_INT -- Number of times to calculate integrated moments.
+dt_failure_tol = 1.0e-4 -- Minimum allowable fraction of initial time-step.
+num_failures_max = 20 -- Maximum allowable number of consecutive small time-steps.
+
+deltaT = Lx100 / light_speed -- Arbitrary constant, with units of time.
+factor = deltaT * deltaT * charge_elc * charge_elc / (mass_elc * epsilon0) -- Numerical factor for calculation of electron number density.
+omega_drive = pi / 10.0 / deltaT -- Drive current angular frequency.
+
+momentApp = Moments.App.new {
+
+  tEnd = t_end,
+  nFrame = num_frames,
+  fieldEnergyCalcs = field_energy_calcs,
+  integratedMomentCalcs = integrated_mom_calcs,
+  dtFailureTol = dt_failure_tol,
+  numFailuresMax = num_failures_max,
+  lower = { 0.0 },
+  upper = { Lx },
+  cells = { Nx },
+  cflFrac = cfl_frac,
+
+  -- Decomposition for configuration space.
+  decompCuts = { 1 }, -- Cuts in each coodinate direction (x-direction only).
+
+  -- Boundary conditions for configuration space.
+  periodicDirs = { }, -- Periodic directions (none).
+
+  -- Electrons.
+  elc = Moments.Species.new {
+    charge = charge_elc, mass = mass_elc,
+    equation = Cold.new { gasGamma = gas_gamma },
+
+    -- Initial conditions function.
+    init = function (t, xn)
+      local x = xn[1]
+
+      local omegaPdt = 25.0 * (1.0 - x) * (1.0 - x) * (1.0 - x) * (1.0 - x) * (1.0 - x) -- Plasma frequency profile.
+      local ne = omegaPdt * omegaPdt / factor -- Electron number density.
+    
+      local rhoe = mass_elc * ne -- Electron mass density.
+      local mome_x = 0.0 -- Electron momentum density (x-direction).
+      local mome_y = 0.0 -- Electron momentum density (y-direction).
+      local mome_z = 0.0 -- Electron momentum density (z-direction).
+      local Ee_tot = ne * (-charge_elc) / (gas_gamma - 1.0) -- Electron total energy density.
+ 
+      return rhoe, mome_x, mome_y, mome_z, Ee_tot
+    end,
+
+    evolve = true, -- Evolve species?
+    bcx = { G0.SpeciesBc.bcCopy, G0.SpeciesBc.bcCopy } -- Copy boundary conditions (x-direction).
+  },
+
+  -- Field.
+  field = Moments.Field.new {
+    epsilon0 = epsilon0, mu0 = mu0,
+
+    -- Initial conditions function.
+    init = function (t, xn)
+      local Ex = 0.0 -- Total electric field (x-direction).
+      local Ey = 0.0 -- Total electric field (y-direction).
+      local Ez = 0.0 -- Total electric field (z-direction).
+
+      local Bx = 0.0 -- Total magnetic field (x-direction).
+      local By = 0.0 -- Total magnetic field (y-direction).
+      local Bz = 0.0 -- Total magnetic field (z-direction).
+
+      return Ex, Ey, Ez, Bx, By, Bz, 0.0, 0.0
+    end,
+
+    -- Applied current function.
+    appliedCurrent = function (t, xn)
+      local x = xn[1]
+
+      local app_x = 0.0 -- Applied current (x-direction).
+      local app_y = 0.0
+      local app_z = 0.0 -- Applied current (z-direction).
+
+      if x > x_last_edge then
+        app_y = -J0 * math.sin(omega_drive * t) -- Applied current (y-direction, right).
+      else
+        app_y = 0.0 -- Applied current (y-direction, left).
+      end
+
+      return app_x, app_y, app_z
+    end,
+    evolveAppliedCurrent = true, -- Evolve applied current.
+
+    evolve = true, -- Evolve field?
+    bcx = { G0.FieldBc.bcCopy, G0.FieldBc.bcCopy } -- Copy boundary conditions (x-direction).
+  }
+}
+
+-- Run application.
+momentApp:run()

--- a/moments/zero/wv_advect.c
+++ b/moments/zero/wv_advect.c
@@ -307,5 +307,7 @@ gkyl_wv_advect_inew(const struct gkyl_wv_advect_inp* inp)
   advect->eqn.ref_count = gkyl_ref_count_init(gkyl_advect_free);
   advect->eqn.on_dev = &advect->eqn; // On the CPU, the equation object points to itself.
 
+  advect->eqn.embed_geo = NULL;
+
   return &advect->eqn;
 }

--- a/moments/zero/wv_burgers.c
+++ b/moments/zero/wv_burgers.c
@@ -294,5 +294,7 @@ gkyl_wv_burgers_inew(const struct gkyl_wv_burgers_inp* inp)
   burgers->eqn.ref_count = gkyl_ref_count_init(gkyl_burgers_free);
   burgers->eqn.on_dev = &burgers->eqn; // On the CPU, the equation object points to itself.
 
+  burgers->eqn.embed_geo = NULL;
+
   return &burgers->eqn;
 }

--- a/moments/zero/wv_coldfluid.c
+++ b/moments/zero/wv_coldfluid.c
@@ -245,5 +245,7 @@ gkyl_wv_coldfluid_new(void)
 
   coldfluid->eqn.ref_count = gkyl_ref_count_init(coldfluid_free);
 
+  coldfluid->eqn.embed_geo = NULL;
+
   return &coldfluid->eqn;
 }

--- a/moments/zero/wv_euler_mixture.c
+++ b/moments/zero/wv_euler_mixture.c
@@ -617,6 +617,8 @@ gkyl_wv_euler_mixture_inew(const struct gkyl_wv_euler_mixture_inp* inp)
   euler_mixture->eqn.ref_count = gkyl_ref_count_init(gkyl_euler_mixture_free);
   euler_mixture->eqn.on_dev = &euler_mixture->eqn; // On the CPU, the equation object points ot itself.
 
+  euler_mixture->eqn.embed_geo = NULL;
+
   return &euler_mixture->eqn;
 }
 

--- a/moments/zero/wv_euler_rgfm.c
+++ b/moments/zero/wv_euler_rgfm.c
@@ -459,6 +459,8 @@ gkyl_wv_euler_rgfm_inew(const struct gkyl_wv_euler_rgfm_inp* inp)
   euler_rgfm->eqn.ref_count = gkyl_ref_count_init(gkyl_euler_rgfm_free);
   euler_rgfm->eqn.on_dev = &euler_rgfm->eqn; // On the CPU, the equation object points ot itself.
 
+  euler_rgfm->eqn.embed_geo = NULL;
+
   return &euler_rgfm->eqn;
 }
 

--- a/moments/zero/wv_gr_euler.c
+++ b/moments/zero/wv_gr_euler.c
@@ -1796,6 +1796,8 @@ gkyl_wv_gr_euler_inew(const struct gkyl_wv_gr_euler_inp* inp)
   gr_euler->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_euler_free);
   gr_euler->eqn.on_dev = &gr_euler->eqn; // On the CPU, the equation object points to itself.
 
+  gr_euler->eqn.embed_geo = NULL;
+
   return &gr_euler->eqn;
 }
 

--- a/moments/zero/wv_gr_euler_tetrad.c
+++ b/moments/zero/wv_gr_euler_tetrad.c
@@ -1859,6 +1859,8 @@ gkyl_wv_gr_euler_tetrad_inew(const struct gkyl_wv_gr_euler_tetrad_inp* inp)
   gr_euler_tetrad->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_euler_tetrad_free);
   gr_euler_tetrad->eqn.on_dev = &gr_euler_tetrad->eqn; // On the CPU, the equation object points to itself.
 
+  gr_euler_tetrad->eqn.embed_geo = NULL;
+
   return &gr_euler_tetrad->eqn;
 }
 

--- a/moments/zero/wv_gr_maxwell.c
+++ b/moments/zero/wv_gr_maxwell.c
@@ -580,6 +580,8 @@ gkyl_wv_gr_maxwell_inew(const struct gkyl_wv_gr_maxwell_inp* inp)
   gr_maxwell->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_maxwell_free);
   gr_maxwell->eqn.on_dev = &gr_maxwell->eqn; // On the CPU, the equation object points to itself.
 
+  gr_maxwell->eqn.embed_geo = NULL;
+
   return &gr_maxwell->eqn;
 }
 

--- a/moments/zero/wv_gr_maxwell_tetrad.c
+++ b/moments/zero/wv_gr_maxwell_tetrad.c
@@ -613,6 +613,8 @@ gkyl_wv_gr_maxwell_tetrad_inew(const struct gkyl_wv_gr_maxwell_tetrad_inp* inp)
   gr_maxwell_tetrad->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_maxwell_tetrad_free);
   gr_maxwell_tetrad->eqn.on_dev = &gr_maxwell_tetrad->eqn; // On the CPU, the equation object points to itself.
 
+  gr_maxwell_tetrad->eqn.embed_geo = NULL;
+
   return &gr_maxwell_tetrad->eqn;
 }
 

--- a/moments/zero/wv_gr_medium.c
+++ b/moments/zero/wv_gr_medium.c
@@ -371,6 +371,8 @@ gkyl_wv_gr_medium_inew(const struct gkyl_wv_gr_medium_inp* inp)
   gr_medium->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_medium_free);
   gr_medium->eqn.on_dev = &gr_medium->eqn; // On the CPU, the equation object points to itself.
 
+  gr_medium->eqn.embed_geo = NULL;
+
   return &gr_medium->eqn;
 }
 

--- a/moments/zero/wv_gr_mhd.c
+++ b/moments/zero/wv_gr_mhd.c
@@ -2003,6 +2003,8 @@ gkyl_wv_gr_mhd_inew(const struct gkyl_wv_gr_mhd_inp* inp)
   gr_mhd->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_mhd_free);
   gr_mhd->eqn.on_dev = &gr_mhd->eqn; // On the CPU, the equation object points to itself.
 
+  gr_mhd->eqn.embed_geo = NULL;
+
   return &gr_mhd->eqn;
 }
 

--- a/moments/zero/wv_gr_mhd_tetrad.c
+++ b/moments/zero/wv_gr_mhd_tetrad.c
@@ -2123,6 +2123,8 @@ gkyl_wv_gr_mhd_tetrad_inew(const struct gkyl_wv_gr_mhd_tetrad_inp* inp)
   gr_mhd_tetrad->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_mhd_tetrad_free);
   gr_mhd_tetrad->eqn.on_dev = &gr_mhd_tetrad->eqn; // On the CPU, the equation object points to itself.
 
+  gr_mhd_tetrad->eqn.embed_geo = NULL;
+
   return &gr_mhd_tetrad->eqn;
 }
 

--- a/moments/zero/wv_gr_twofluid.c
+++ b/moments/zero/wv_gr_twofluid.c
@@ -2079,6 +2079,8 @@ gkyl_wv_gr_twofluid_inew(const struct gkyl_wv_gr_twofluid_inp* inp)
   gr_twofluid->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_twofluid_free);
   gr_twofluid->eqn.on_dev = &gr_twofluid->eqn; // On the CPU, the equation object points to itself.
 
+  gr_twofluid->eqn.embed_geo = NULL;
+
   return &gr_twofluid->eqn;
 }
 

--- a/moments/zero/wv_gr_ultra_rel_euler.c
+++ b/moments/zero/wv_gr_ultra_rel_euler.c
@@ -1791,6 +1791,8 @@ gkyl_wv_gr_ultra_rel_euler_inew(const struct gkyl_wv_gr_ultra_rel_euler_inp* inp
   gr_ultra_rel_euler->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_ultra_rel_euler_free);
   gr_ultra_rel_euler->eqn.on_dev = &gr_ultra_rel_euler->eqn; // On the CPU, the equation object points to itself.
 
+  gr_ultra_rel_euler->eqn.embed_geo = NULL;
+
   return &gr_ultra_rel_euler->eqn;
 }
 

--- a/moments/zero/wv_gr_ultra_rel_euler_tetrad.c
+++ b/moments/zero/wv_gr_ultra_rel_euler_tetrad.c
@@ -1856,6 +1856,8 @@ gkyl_wv_gr_ultra_rel_euler_tetrad_inew(const struct gkyl_wv_gr_ultra_rel_euler_t
   gr_ultra_rel_euler_tetrad->eqn.ref_count = gkyl_ref_count_init(gkyl_gr_ultra_rel_euler_tetrad_free);
   gr_ultra_rel_euler_tetrad->eqn.on_dev = &gr_ultra_rel_euler_tetrad->eqn; // On the CPU, the equation object points to itself.
 
+  gr_ultra_rel_euler_tetrad->eqn.embed_geo = NULL;
+
   return &gr_ultra_rel_euler_tetrad->eqn;
 }
 

--- a/moments/zero/wv_iso_euler.c
+++ b/moments/zero/wv_iso_euler.c
@@ -362,6 +362,8 @@ gkyl_wv_iso_euler_inew(const struct gkyl_wv_iso_euler_inp* inp)
   iso_euler->eqn.ref_count = gkyl_ref_count_init(gkyl_iso_euler_free);
   iso_euler->eqn.on_dev = &iso_euler->eqn; // On the CPU, the equation object points to itself.
 
+  iso_euler->eqn.embed_geo = NULL;
+
   return &iso_euler->eqn;
 }
 

--- a/moments/zero/wv_iso_euler_mixture.c
+++ b/moments/zero/wv_iso_euler_mixture.c
@@ -576,6 +576,8 @@ gkyl_wv_iso_euler_mixture_inew(const struct gkyl_wv_iso_euler_mixture_inp* inp)
   iso_euler_mixture->eqn.ref_count = gkyl_ref_count_init(gkyl_iso_euler_mixture_free);
   iso_euler_mixture->eqn.on_dev = &iso_euler_mixture->eqn; // On the CPU, the equation object points ot itself.
 
+  iso_euler_mixture->eqn.embed_geo = NULL;
+
   return &iso_euler_mixture->eqn;
 }
 

--- a/moments/zero/wv_mhd.c
+++ b/moments/zero/wv_mhd.c
@@ -853,6 +853,8 @@ gkyl_wv_mhd_new(const struct gkyl_wv_mhd_inp *inp)
 
   mhd->eqn.ref_count = gkyl_ref_count_init(mhd_free);
 
+  mhd->eqn.embed_geo = NULL;
+
   return &mhd->eqn;
 }
 

--- a/moments/zero/wv_reactive_euler.c
+++ b/moments/zero/wv_reactive_euler.c
@@ -465,6 +465,8 @@ gkyl_wv_reactive_euler_inew(const struct gkyl_wv_reactive_euler_inp* inp)
   reactive_euler->eqn.ref_count = gkyl_ref_count_init(gkyl_reactive_euler_free);
   reactive_euler->eqn.on_dev = &reactive_euler->eqn; // On the CPU, the equation object points to itself.
 
+  reactive_euler->eqn.embed_geo = NULL;
+
   return &reactive_euler->eqn;
 }
 


### PR DESCRIPTION
The Lua wrapper doesn't recognized an uninitialized embedded boundary object as null, which was causing an if statement to trigger improperly for wave objects that didn't get full integration of the embedded boundary. This results in a segfault occurring as it attempts to project a nonexistent mask function.

Fixed this by explicitly setting the embed_geo object to NULL in every non-integrated equation object. Also added a Lua regression test for wv_coldfluid since there was only a C test currently in the code.