### PR TITLE
Fix boundary  flux bug in MB

### DIFF
--- a/gyrokinetic/apps/gyrokinetic_multib_update_ssp_rk3.c
+++ b/gyrokinetic/apps/gyrokinetic_multib_update_ssp_rk3.c
@@ -209,12 +209,12 @@ gyrokinetic_multib_update_ssp_rk3(struct gkyl_gyrokinetic_multib_app* app, doubl
             for (int i=0; i<ns_charged; ++i) {
 	      struct gk_species *gks = &sbapp->species[i]; 
 	      gk_species_combine(gks, gks->f1, 3.0/4.0, gks->f, 1.0/4.0, gks->fnew, &gks->local_ext);
-              gk_species_bflux_accumulate(sbapp, &gks->bflux, gks->bflux.f1, 1.0/4.0, gks->bflux.fnew);
+              gk_species_bflux_set(sbapp, &gks->bflux, gks->bflux.f1, 1.0/4.0, gks->bflux.fnew);
 	    }
             for (int i=0; i<ns_neut; ++i) {
 	      struct gk_neut_species *gkns = &sbapp->neut_species[i]; 
 	      gk_neut_species_combine(gkns, gkns->f1, 3.0/4.0, gkns->f, 1.0/4.0, gkns->fnew, &gkns->local_ext);
-              gk_neut_species_bflux_accumulate(sbapp, &gkns->bflux, gkns->bflux.f1, 1.0/4.0, gkns->bflux.fnew);
+              gk_neut_species_bflux_set(sbapp, &gkns->bflux, gkns->bflux.f1, 1.0/4.0, gkns->bflux.fnew);
             }
           }
           app->stat.time_stepper_arithmetic_tm += gkyl_time_diff_now_sec(wst);
@@ -301,8 +301,7 @@ gyrokinetic_multib_update_ssp_rk3(struct gkyl_gyrokinetic_multib_app* app, doubl
 	      gk_species_combine(gks, gks->f1, 1.0/3.0, gks->f, 2.0/3.0, gks->fnew, &gks->local_ext);
 	      gk_species_copy_range(gks, gks->f, gks->f1, &gks->local_ext);
               // Step boundary fluxes.
-              gk_species_bflux_accumulate(sbapp, &gks->bflux, gks->bflux.f1, 2.0/3.0, gks->bflux.fnew);
-              gk_species_bflux_copy(sbapp, &gks->bflux, gks->bflux.f, gks->bflux.f1);
+              gk_species_bflux_set(sbapp, &gks->bflux, gks->bflux.f, 2.0/3.0, gks->bflux.fnew);
               gk_species_bflux_calc_voltime_integrated_mom(sbapp, gks, &gks->bflux, tcurr);
 	    }
             for (int i=0; i<ns_neut; ++i) {
@@ -310,8 +309,7 @@ gyrokinetic_multib_update_ssp_rk3(struct gkyl_gyrokinetic_multib_app* app, doubl
 	      gk_neut_species_combine(gkns, gkns->f1, 1.0/3.0, gkns->f, 2.0/3.0, gkns->fnew, &gkns->local_ext);
 	      gk_neut_species_copy_range(gkns, gkns->f, gkns->f1, &gkns->local_ext);
               // Step boundary fluxes.
-              gk_neut_species_bflux_accumulate(sbapp, &gkns->bflux, gkns->bflux.f1, 2.0/3.0, gkns->bflux.fnew);
-              gk_neut_species_bflux_copy(sbapp, &gkns->bflux, gkns->bflux.f, gkns->bflux.f1);
+              gk_neut_species_bflux_set(sbapp, &gkns->bflux, gkns->bflux.f, 2.0/3.0, gkns->bflux.fnew);
               gk_neut_species_bflux_calc_voltime_integrated_mom(sbapp, gkns, &gkns->bflux, tcurr);
             }
           }

--- a/gyrokinetic/creg/rt_gk_multib_slab_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_multib_slab_2x2v_p1.c
@@ -459,6 +459,13 @@ main(int argc, char **argv)
         .temp = evalSourceTempInit,
         .ctx_temp = &ctx,
       }, 
+      .diagnostics = {
+        .num_diag_moments = 4,
+        .diag_moments = { GKYL_F_MOMENT_M0, GKYL_F_MOMENT_M1, GKYL_F_MOMENT_M2PAR, GKYL_F_MOMENT_M2PERP },
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+//        .time_integrated = true,
+      }
     },
 
   };
@@ -503,6 +510,14 @@ main(int argc, char **argv)
       .D_profile = diffusion_D_func,
       .D_profile_ctx = &ctx,
     }, 
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+    .time_rate_diagnostics = true,
+    .boundary_flux_diagnostics = {
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+//      .time_integrated = true,
+    },
 
     .num_diag_moments = 7,
     .diag_moments = { GKYL_F_MOMENT_M0, GKYL_F_MOMENT_M1, GKYL_F_MOMENT_M2, GKYL_F_MOMENT_M2PAR, GKYL_F_MOMENT_M2PERP, GKYL_F_MOMENT_M3PAR, GKYL_F_MOMENT_M3PERP },
@@ -544,6 +559,13 @@ main(int argc, char **argv)
         .temp = evalSourceTempInit,
         .ctx_temp = &ctx,
       }, 
+      .diagnostics = {
+        .num_diag_moments = 4,
+        .diag_moments = { GKYL_F_MOMENT_M0, GKYL_F_MOMENT_M1, GKYL_F_MOMENT_M2PAR, GKYL_F_MOMENT_M2PERP },
+        .num_integrated_diag_moments = 1,
+        .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+//        .time_integrated = true,
+      }
     },
 
   };
@@ -592,6 +614,14 @@ main(int argc, char **argv)
   
     .num_diag_moments = 7,
     .diag_moments = { GKYL_F_MOMENT_M0, GKYL_F_MOMENT_M1, GKYL_F_MOMENT_M2, GKYL_F_MOMENT_M2PAR, GKYL_F_MOMENT_M2PERP, GKYL_F_MOMENT_M3PAR, GKYL_F_MOMENT_M3PERP },
+    .num_integrated_diag_moments = 1,
+    .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+    .time_rate_diagnostics = true,
+    .boundary_flux_diagnostics = {
+      .num_integrated_diag_moments = 1,
+      .integrated_diag_moments = { GKYL_F_MOMENT_HAMILTONIAN },
+//      .time_integrated = true,
+    },
 
     .duplicate_across_blocks = true,
     .blocks = ion_blocks,


### PR DESCRIPTION
Fix a bug that was introduced in MB along with the boundary flux changes. I think there were just some typos in the multib  rk3 update. Pattern matching with the SB rk3 update has resolved the issue and now the diagnostics reflect that MB conserves particles. To be clear, this was just an issue  with the boundary flux calls, so it didn't actually break conservation and simulation results (in the absence of adaptive sources) were unaffected by the bug. This fix is important for the correct behavior of adaptive sourcing in MB and also for being able to check conservation. 

Here is particle conservation relative error from the current main branch on 11/7 for rt_gk_multib_slab_2x2v_p1.c:
<img width="826" height="669" alt="image" src="https://github.com/user-attachments/assets/5e9cbaa3-2727-4c21-a448-ea301c8b3f70" />

Here it is from this branch:
<img width="741" height="443" alt="image" src="https://github.com/user-attachments/assets/2a9cd3c1-2aee-459b-b0ac-0b38eb6eb30e" />


Here it is from before (commit f4ee715b720920fe9c94db6788c93f4eb1a5554a) the fluid neutrals PR where the bug was introduced
<img width="742" height="443" alt="image" src="https://github.com/user-attachments/assets/e7854219-de84-4131-acc7-1087114bc4a6" />