### PR TITLE
Update version of OpenMPI built so that eqdskreader tool works

### DIFF
--- a/install-deps/build-openmpi.sh
+++ b/install-deps/build-openmpi.sh
@@ -3,7 +3,7 @@
 source ./build-opts.sh
 
 # Install prefix
-PREFIX=$GKYLSOFT/openmpi-4.1.6
+PREFIX=$GKYLSOFT/openmpi-5.0.7
 # Location where dependency sources will be downloaded
 DEP_SOURCES=$GKYLSOFT/dep_src/
 
@@ -14,15 +14,15 @@ if [ "$DOWNLOAD_PKGS" = "yes" ]
 then
     echo "Downloading OpenMPI .."
     # delete old checkout and builds
-    rm -rf openmpi-4.1.6.tar* openmpi-4.1.6
-    curl -L https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz > openmpi-4.1.6.tar.gz
+    rm -rf openmpi-5.0.7.tar* openmpi-5.0.7
+    curl -L https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.7.tar.gz > openmpi-5.0.7.tar.gz
 fi
 
 if [ "$BUILD_PKGS" = "yes" ]
 then
     echo "Building OpenMPI .."
-    gunzip -c openmpi-4.1.6.tar.gz | tar xf -
-    cd openmpi-4.1.6
+    gunzip -c openmpi-5.0.7.tar.gz | tar xf -
+    cd openmpi-5.0.7
 
     ./configure --prefix=$PREFIX --enable-mpi-fortran=none CC=$CC CXX=$CXX
     make -j6 install 


### PR DESCRIPTION
When running Gkeyll with the version of OpenMPI that is currently built by default (v4.1.6), Gkeyll's native eqdskreader tool throws an MPI-related error message. I have tested this when building with v5.0.7 though, and the tool cooperates and generates the .gkyl files containing $\psi$, a necessity for informing our simulation grids.