### PR TITLE
Reduce nu_sr in BGK and LBO

### DIFF
--- a/gyrokinetic/apps/gk_species_bgk.c
+++ b/gyrokinetic/apps/gk_species_bgk.c
@@ -252,12 +252,9 @@ gk_species_bgk_init(struct gkyl_gyrokinetic_app *app, struct gk_species *gks, st
       bgk->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->basis, app->poly_order+1,
         1.0, 1.0, 1.0, app->use_gpu);
 
-      // We define nu_ss = 0.5*nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s),
-      // with delta_ss = 1, beta = 0. This gives a nu_ss that is arguably 2X
-      // smaller than it should be, but we argue that it is high-energy
-      // particles that set the resistivity and those are in reality less
-      // collisional (because nu should be proportional to 1/v^3). And it makes
-      // the code 2X faster in the collisional regime.
+      // We define nu_ss = nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s), with delta_ss = 2,
+      // beta = 0. This gives a nu_ss that is arguably 2X smaller than it should be, but it's
+      // cheaper and yields an electron isotropization rate that agrees better with the FPO's.
       bgk->norm_nu_fac_self = nu_frac * gkyl_calc_Morse_alpha_E_const(
         gks->info.collisions.den_ref, gks->info.collisions.den_ref, 
         gks->info.mass, gks->info.mass, gks->info.charge, gks->info.charge,
@@ -311,7 +308,7 @@ gk_species_bgk_cross_init(struct gkyl_gyrokinetic_app *app, struct gk_species *g
   if (bgk->collision_id == GKYL_BGK_COLLISIONS) {
     if (gks->bgk.num_cross_collisions) {
       bgk->betaGreenep1 = 1.0; // Greene's beta factor + 1.
-      bgk->delta_sr = 1.0; // delta_sr free parameter.
+      bgk->delta_sr = 2.0; // delta_sr free parameter.
         
       // Set pointers to species we cross-collide with.
       int my_idx_in_other[GKYL_MAX_SPECIES];

--- a/gyrokinetic/apps/gk_species_lbo.c
+++ b/gyrokinetic/apps/gk_species_lbo.c
@@ -269,12 +269,9 @@ gk_species_lbo_init(struct gkyl_gyrokinetic_app *app, struct gk_species *gks, st
       lbo->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->basis, app->poly_order+1,
         1.0, 1.0, 1.0, app->use_gpu);
 
-      // We define nu_ss = 0.5*nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s),
-      // with delta_ss = 1, beta = 0. This gives a nu_ss that is arguably 2X
-      // smaller than it should be, but we argue that it is high-energy
-      // particles that set the resistivity and those are in reality less
-      // collisional (because nu should be proportional to 1/v^3). And it makes
-      // the code 2X faster in the collisional regime.
+      // We define nu_ss = nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s), with delta_ss = 2, 
+      // beta = 0. This gives a nu_ss that is arguably 2X smaller than it should be, but it's
+      // cheaper and yields an electron isotropization rate that agrees better with the FPO's.
       lbo->norm_nu_fac_self = nu_frac * gkyl_calc_Morse_alpha_E_const(
         gks->info.collisions.den_ref, gks->info.collisions.den_ref, 
         gks->info.mass, gks->info.mass, gks->info.charge, gks->info.charge,
@@ -346,7 +343,7 @@ gk_species_lbo_cross_init(struct gkyl_gyrokinetic_app *app, struct gk_species *g
   if (lbo->collision_id == GKYL_LBO_COLLISIONS) {
     if (gks->lbo.num_cross_collisions) {
       lbo->betaGreenep1 = 1.0; // Greene's beta factor + 1.
-      lbo->delta_sr = 1.0; // delta_sr free parameter.
+      lbo->delta_sr = 2.0; // delta_sr free parameter.
         
       // Set pointers to species we cross-collide with.
       int my_idx_in_other[GKYL_MAX_SPECIES];


### PR DESCRIPTION
Now that the cross-species collision frequency is computed from (see PR #866 )
<img width="197" height="63" alt="Screenshot 2025-11-16 at 5 27 29 PM" src="https://github.com/user-attachments/assets/08dc8b79-d8a5-4d86-b5da-71b01fcf5317" />
and after some experimentation (in which @dingyunl helped), @gwhammett realized that delta_sr = 2 for cross-species collisions would slow down electron isotropization so it agrees better with the FPO's, while keeping the cross-species relaxation the same. We've made this change here, and here are the results:

LBO
-----
<img width="936" height="369" alt="Screenshot 2025-11-16 at 5 28 54 PM" src="https://github.com/user-attachments/assets/be81a36b-91a0-4d81-94dd-da7115b56a34" />

<img width="891" height="336" alt="Screenshot 2025-11-16 at 5 29 03 PM" src="https://github.com/user-attachments/assets/e94ef2de-5744-4cea-b9d3-87715890f0f5" />

BGK
-----
<img width="927" height="355" alt="Screenshot 2025-11-16 at 5 29 24 PM" src="https://github.com/user-attachments/assets/7e000ade-476a-4610-8cd7-10197282f564" />

<img width="943" height="362" alt="Screenshot 2025-11-16 at 5 29 31 PM" src="https://github.com/user-attachments/assets/f2f1f739-58e3-4797-8e7a-4863df398026" />

This will also make collisional cases a tiny bit cheaper because $nu_{ee}+nu_{ei}$ will be smaller now.