### PR TITLE
Revert sign of bfield in gk iwl creg Miller

### DIFF
--- a/gyrokinetic/creg/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_d3d_iwl_2x2v_p1.c
@@ -381,9 +381,9 @@ void bfield_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *c
 
   // xc are computational coords. 
   // Set Cartesian components of magnetic field.
-  fout[0] = B_r * cos(phi) - Bt * sin(phi);
-  fout[1] = B_r * sin(phi) + Bt * cos(phi);
-  fout[2] = B_z;
+  fout[0] = -(B_r * cos(phi) - Bt * sin(phi));
+  fout[1] = -(B_r * sin(phi) + Bt * cos(phi));
+  fout[2] = -B_z;
 }
 
 struct gk_app_ctx

--- a/gyrokinetic/creg/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_d3d_iwl_3x2v_p1.c
@@ -417,9 +417,9 @@ void bfield_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *c
 
   // xc are computational coords. 
   // Set Cartesian components of magnetic field.
-  fout[0] = B_r * cos(phi) - Bt * sin(phi);
-  fout[1] = B_r * sin(phi) + Bt * cos(phi);
-  fout[2] = B_z;
+  fout[0] = -(B_r * cos(phi) - Bt * sin(phi));
+  fout[1] = -(B_r * sin(phi) + Bt * cos(phi));
+  fout[2] = -B_z;
 }
 
 void bc_shift_func_lo(double t, const double *xc, double* GKYL_RESTRICT fout, void *ctx)

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
@@ -304,9 +304,9 @@ void bfield_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *c
 
   // xc are computational coords. 
   // Set Cartesian components of magnetic field.
-  fout[0] = B_r * cos(phi) - Bt * sin(phi);
-  fout[1] = B_r * sin(phi) + Bt * cos(phi);
-  fout[2] = B_z;
+  fout[0] = -(B_r * cos(phi) - Bt * sin(phi));
+  fout[1] = -(B_r * sin(phi) + Bt * cos(phi));
+  fout[2] = -B_z;
 }
 
 

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
@@ -297,9 +297,9 @@ void bfield_func(double t, const double *xc, double* GKYL_RESTRICT fout, void *c
 
   // xc are computational coords. 
   // Set Cartesian components of magnetic field.
-  fout[0] = B_r * cos(phi) - Bt * sin(phi);
-  fout[1] = B_r * sin(phi) + Bt * cos(phi);
-  fout[2] = B_z;
+  fout[0] = -(B_r * cos(phi) - Bt * sin(phi));
+  fout[1] = -(B_r * sin(phi) + Bt * cos(phi));
+  fout[2] = -B_z;
 }
 
 void bc_shift_func_lo(double t, const double *xc, double* GKYL_RESTRICT fout, void *ctx)


### PR DESCRIPTION
We revert the sign of the bfield_func since we observed that it is not consistent anymore with the gk geometry definition. This fix was tested in production runs and runs well now.