### PR TITLE
Set the moment correction option when using a Maxwellian Gaussian projection

### DIFF
--- a/gyrokinetic/apps/gk_species_projection.c
+++ b/gyrokinetic/apps/gk_species_projection.c
@@ -331,7 +331,8 @@ init_maxwellian_gaussian(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
   gkyl_array_set_offset(proj->prim_moms, 0.0, proj->gaussian_profile, 1*app->basis.num_basis);
   // Temperature
   assert(inp.temp_max > 0);
-  double temp = inp.total_num_particles == 0 ? inp.temp_max/2.0 : 2./3. * inp.total_kin_energy/inp.total_num_particles;
+  double vdim_phys = s->vdim == 1? 1.0 : 3.0;
+  double temp = inp.total_num_particles == 0 ? inp.temp_max/2.0 : 2./vdim_phys * inp.total_kin_energy/inp.total_num_particles;
   temp = temp > inp.temp_max ? inp.temp_max : temp; // saturate to max temperature.
   gkyl_array_shiftc(proj->prim_moms, temp/s->info.mass, 2*app->basis.num_basis);
   // Moment correction


### PR DESCRIPTION
This was causing a seg fault when using the max-gauss proj for species IC on GPU as the programm flow is slightly different from the source program flow. Basically it was failing at
```
zero/gk_maxwellian_correct.c:97
```
because the correct mom updater was not initialized. Now the max-gauss projection is setting the flag correctly and will avoid trying to correct the moment. I am not clear how this resolves also the hack done in PR #818, not sure it does.