### PR TITLE
Fix calculation of temperature in fluid neutrals

### DIFF
--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_1x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_1x_ser_p1.c
@@ -22,6 +22,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_1x_ser_p1(int count, struc
   const double *rhouz = &moms[6]; 
   const double *totE  = &moms[8]; 
 
+  double rhoSq[2] = {0.0}; 
+  binop_mul_1d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[2] = {0.0}; 
+  binop_mul_1d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[2] = {0.0}; 
   binop_mul_1d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -31,16 +37,16 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_1x_ser_p1(int count, struc
   double rhouzSq[2] = {0.0}; 
   binop_mul_1d_ser_p1(rhouz, rhouz, rhouzSq); 
  
-  double rho_temp[2]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  double rhoSq_temp[2]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
 
-  double rho_inv[2] = {0.0}; 
-  ser_1x_p1_inv(rho, rho_inv); 
+  double rhoSq_inv[2] = {0.0}; 
+  ser_1x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[2] = {0.0}; 
  
-  binop_mul_1d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_1d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
  
   gkyl_mat_set(&rhs_temp,0,0,temp[0]); 
   gkyl_mat_set(&rhs_temp,1,0,temp[1]); 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_1x_ser_p2.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_1x_ser_p2.c
@@ -22,6 +22,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_1x_ser_p2(int count, struc
   const double *rhouz = &moms[9]; 
   const double *totE  = &moms[12]; 
 
+  double rhoSq[3] = {0.0}; 
+  binop_mul_1d_ser_p2(rho, rho, rhoSq); 
+ 
+  double rho_totE[3] = {0.0}; 
+  binop_mul_1d_ser_p2(rho, totE, rho_totE); 
+ 
   double rhouxSq[3] = {0.0}; 
   binop_mul_1d_ser_p2(rhoux, rhoux, rhouxSq); 
  
@@ -31,14 +37,14 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_1x_ser_p2(int count, struc
   double rhouzSq[3] = {0.0}; 
   binop_mul_1d_ser_p2(rhouz, rhouz, rhouzSq); 
  
-  double rho_temp[3]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  double rhoSq_temp[3]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
 
-  gkyl_mat_set(&rhs_temp,0,0,rho_temp[0]); 
-  gkyl_mat_set(&rhs_temp,1,0,rho_temp[1]); 
-  gkyl_mat_set(&rhs_temp,2,0,rho_temp[2]); 
+  gkyl_mat_set(&rhs_temp,0,0,rhoSq_temp[0]); 
+  gkyl_mat_set(&rhs_temp,1,0,rhoSq_temp[1]); 
+  gkyl_mat_set(&rhs_temp,2,0,rhoSq_temp[2]); 
  
   gkyl_mat_set(&A_temp,0,0,0.0); 
  

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_2x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_2x_ser_p1.c
@@ -22,6 +22,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_2x_ser_p1(int count, struc
   const double *rhouz = &moms[12]; 
   const double *totE  = &moms[16]; 
 
+  double rhoSq[4] = {0.0}; 
+  binop_mul_2d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[4] = {0.0}; 
+  binop_mul_2d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[4] = {0.0}; 
   binop_mul_2d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -31,18 +37,18 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_2x_ser_p1(int count, struc
   double rhouzSq[4] = {0.0}; 
   binop_mul_2d_ser_p1(rhouz, rhouz, rhouzSq); 
  
-  double rho_temp[4]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
-  rho_temp[3] = (gas_gamma - 1.0)*(mass * totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
+  double rhoSq_temp[4]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  rhoSq_temp[3] = mass*(gas_gamma-1.0)*(rho_totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
 
-  double rho_inv[4] = {0.0}; 
-  ser_2x_p1_inv(rho, rho_inv); 
+  double rhoSq_inv[4] = {0.0}; 
+  ser_2x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[4] = {0.0}; 
  
-  binop_mul_2d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_2d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
  
   gkyl_mat_set(&rhs_temp,0,0,temp[0]); 
   gkyl_mat_set(&rhs_temp,1,0,temp[1]); 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_3x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_temp_3x_ser_p1.c
@@ -22,6 +22,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_3x_ser_p1(int count, struc
   const double *rhouz = &moms[24]; 
   const double *totE  = &moms[32]; 
 
+  double rhoSq[8] = {0.0}; 
+  binop_mul_3d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[8] = {0.0}; 
+  binop_mul_3d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[8] = {0.0}; 
   binop_mul_3d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -31,22 +37,22 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_temp_set_prob_3x_ser_p1(int count, struc
   double rhouzSq[8] = {0.0}; 
   binop_mul_3d_ser_p1(rhouz, rhouz, rhouzSq); 
  
-  double rho_temp[8]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
-  rho_temp[3] = (gas_gamma - 1.0)*(mass * totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
-  rho_temp[4] = (gas_gamma - 1.0)*(mass * totE[4] - 0.5*(rhouxSq[4] + rhouySq[4] + rhouzSq[4])); 
-  rho_temp[5] = (gas_gamma - 1.0)*(mass * totE[5] - 0.5*(rhouxSq[5] + rhouySq[5] + rhouzSq[5])); 
-  rho_temp[6] = (gas_gamma - 1.0)*(mass * totE[6] - 0.5*(rhouxSq[6] + rhouySq[6] + rhouzSq[6])); 
-  rho_temp[7] = (gas_gamma - 1.0)*(mass * totE[7] - 0.5*(rhouxSq[7] + rhouySq[7] + rhouzSq[7])); 
+  double rhoSq_temp[8]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  rhoSq_temp[3] = mass*(gas_gamma-1.0)*(rho_totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
+  rhoSq_temp[4] = mass*(gas_gamma-1.0)*(rho_totE[4] - 0.5*(rhouxSq[4] + rhouySq[4] + rhouzSq[4])); 
+  rhoSq_temp[5] = mass*(gas_gamma-1.0)*(rho_totE[5] - 0.5*(rhouxSq[5] + rhouySq[5] + rhouzSq[5])); 
+  rhoSq_temp[6] = mass*(gas_gamma-1.0)*(rho_totE[6] - 0.5*(rhouxSq[6] + rhouySq[6] + rhouzSq[6])); 
+  rhoSq_temp[7] = mass*(gas_gamma-1.0)*(rho_totE[7] - 0.5*(rhouxSq[7] + rhouySq[7] + rhouzSq[7])); 
 
-  double rho_inv[8] = {0.0}; 
-  ser_3x_p1_inv(rho, rho_inv); 
+  double rhoSq_inv[8] = {0.0}; 
+  ser_3x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[8] = {0.0}; 
  
-  binop_mul_3d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_3d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
  
   gkyl_mat_set(&rhs_temp,0,0,temp[0]); 
   gkyl_mat_set(&rhs_temp,1,0,temp[1]); 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_1x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_1x_ser_p1.c
@@ -28,6 +28,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_1x_ser_p1(int count
   const double *rhouz = &moms[6]; 
   const double *totE  = &moms[8]; 
 
+  double rhoSq[2] = {0.0}; 
+  binop_mul_1d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[2] = {0.0}; 
+  binop_mul_1d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[2] = {0.0}; 
   binop_mul_1d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -48,14 +54,16 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_1x_ser_p1(int count
   binop_mul_1d_ser_p1(rho_inv, rhouy, uy); 
   binop_mul_1d_ser_p1(rho_inv, rhouz, uz); 
  
-  double rho_temp[2]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  double rhoSq_temp[2]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
 
+  double rhoSq_inv[2] = {0.0}; 
+  ser_1x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[2] = {0.0}; 
  
-  binop_mul_1d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_1d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
   gkyl_mat_set(&rhs_ux,0,0,ux[0]); 
   gkyl_mat_set(&rhs_uy,0,0,uy[0]); 
   gkyl_mat_set(&rhs_uz,0,0,uz[0]); 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_1x_ser_p2.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_1x_ser_p2.c
@@ -31,6 +31,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_1x_ser_p2(int count
   const double *rhouz = &moms[9]; 
   const double *totE  = &moms[12]; 
 
+  double rhoSq[3] = {0.0}; 
+  binop_mul_1d_ser_p2(rho, rho, rhoSq); 
+ 
+  double rho_totE[3] = {0.0}; 
+  binop_mul_1d_ser_p2(rho, totE, rho_totE); 
+ 
   double rhouxSq[3] = {0.0}; 
   binop_mul_1d_ser_p2(rhoux, rhoux, rhouxSq); 
  
@@ -40,78 +46,78 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_1x_ser_p2(int count
   double rhouzSq[3] = {0.0}; 
   binop_mul_1d_ser_p2(rhouz, rhouz, rhouzSq); 
  
-  double rho_temp[3]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  double rhoSq_temp[3]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
 
   gkyl_mat_set(&rhs_ux,0,0,rhoux[0]); 
   gkyl_mat_set(&rhs_uy,0,0,rhouy[0]); 
   gkyl_mat_set(&rhs_uz,0,0,rhouz[0]); 
-  gkyl_mat_set(&rhs_temp,0,0,rho_temp[0]); 
+  gkyl_mat_set(&rhs_temp,0,0,rhoSq_temp[0]); 
   gkyl_mat_set(&rhs_ux,1,0,rhoux[1]); 
   gkyl_mat_set(&rhs_uy,1,0,rhouy[1]); 
   gkyl_mat_set(&rhs_uz,1,0,rhouz[1]); 
-  gkyl_mat_set(&rhs_temp,1,0,rho_temp[1]); 
+  gkyl_mat_set(&rhs_temp,1,0,rhoSq_temp[1]); 
   gkyl_mat_set(&rhs_ux,2,0,rhoux[2]); 
   gkyl_mat_set(&rhs_uy,2,0,rhouy[2]); 
   gkyl_mat_set(&rhs_uz,2,0,rhouz[2]); 
-  gkyl_mat_set(&rhs_temp,2,0,rho_temp[2]); 
+  gkyl_mat_set(&rhs_temp,2,0,rhoSq_temp[2]); 
  
   double tmp_rho = 0.0; 
   tmp_rho = 0.7071067811865475*rho[0]; 
   gkyl_mat_set(&A_ux,0,0,tmp_rho); 
   gkyl_mat_set(&A_uy,0,0,tmp_rho); 
   gkyl_mat_set(&A_uz,0,0,tmp_rho); 
-  gkyl_mat_set(&A_temp,0,0,tmp_rho); 
+  gkyl_mat_set(&A_temp,0,0,0.0); 
  
   tmp_rho = 0.7071067811865475*rho[1]; 
   gkyl_mat_set(&A_ux,0,1,tmp_rho); 
   gkyl_mat_set(&A_uy,0,1,tmp_rho); 
   gkyl_mat_set(&A_uz,0,1,tmp_rho); 
-  gkyl_mat_set(&A_temp,0,1,tmp_rho); 
+  gkyl_mat_set(&A_temp,0,1,0.0); 
  
   tmp_rho = 0.7071067811865475*rho[2]; 
   gkyl_mat_set(&A_ux,0,2,tmp_rho); 
   gkyl_mat_set(&A_uy,0,2,tmp_rho); 
   gkyl_mat_set(&A_uz,0,2,tmp_rho); 
-  gkyl_mat_set(&A_temp,0,2,tmp_rho); 
+  gkyl_mat_set(&A_temp,0,2,0.0); 
  
   tmp_rho = 0.7071067811865475*rho[1]; 
   gkyl_mat_set(&A_ux,1,0,tmp_rho); 
   gkyl_mat_set(&A_uy,1,0,tmp_rho); 
   gkyl_mat_set(&A_uz,1,0,tmp_rho); 
-  gkyl_mat_set(&A_temp,1,0,tmp_rho); 
+  gkyl_mat_set(&A_temp,1,0,0.0); 
  
   tmp_rho = 0.6324555320336759*rho[2]+0.7071067811865475*rho[0]; 
   gkyl_mat_set(&A_ux,1,1,tmp_rho); 
   gkyl_mat_set(&A_uy,1,1,tmp_rho); 
   gkyl_mat_set(&A_uz,1,1,tmp_rho); 
-  gkyl_mat_set(&A_temp,1,1,tmp_rho); 
+  gkyl_mat_set(&A_temp,1,1,0.0); 
  
   tmp_rho = 0.6324555320336759*rho[1]; 
   gkyl_mat_set(&A_ux,1,2,tmp_rho); 
   gkyl_mat_set(&A_uy,1,2,tmp_rho); 
   gkyl_mat_set(&A_uz,1,2,tmp_rho); 
-  gkyl_mat_set(&A_temp,1,2,tmp_rho); 
+  gkyl_mat_set(&A_temp,1,2,0.0); 
  
   tmp_rho = 0.7071067811865475*rho[2]; 
   gkyl_mat_set(&A_ux,2,0,tmp_rho); 
   gkyl_mat_set(&A_uy,2,0,tmp_rho); 
   gkyl_mat_set(&A_uz,2,0,tmp_rho); 
-  gkyl_mat_set(&A_temp,2,0,tmp_rho); 
+  gkyl_mat_set(&A_temp,2,0,0.0); 
  
   tmp_rho = 0.6324555320336759*rho[1]; 
   gkyl_mat_set(&A_ux,2,1,tmp_rho); 
   gkyl_mat_set(&A_uy,2,1,tmp_rho); 
   gkyl_mat_set(&A_uz,2,1,tmp_rho); 
-  gkyl_mat_set(&A_temp,2,1,tmp_rho); 
+  gkyl_mat_set(&A_temp,2,1,0.0); 
  
   tmp_rho = 0.45175395145262565*rho[2]+0.7071067811865475*rho[0]; 
   gkyl_mat_set(&A_ux,2,2,tmp_rho); 
   gkyl_mat_set(&A_uy,2,2,tmp_rho); 
   gkyl_mat_set(&A_uz,2,2,tmp_rho); 
-  gkyl_mat_set(&A_temp,2,2,tmp_rho); 
+  gkyl_mat_set(&A_temp,2,2,0.0); 
  
 } 
 GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_get_sol_1x_ser_p2(int count, struct gkyl_nmat *xsol, 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_2x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_2x_ser_p1.c
@@ -28,6 +28,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_2x_ser_p1(int count
   const double *rhouz = &moms[12]; 
   const double *totE  = &moms[16]; 
 
+  double rhoSq[4] = {0.0}; 
+  binop_mul_2d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[4] = {0.0}; 
+  binop_mul_2d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[4] = {0.0}; 
   binop_mul_2d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -48,16 +54,18 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_2x_ser_p1(int count
   binop_mul_2d_ser_p1(rho_inv, rhouy, uy); 
   binop_mul_2d_ser_p1(rho_inv, rhouz, uz); 
  
-  double rho_temp[4]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
-  rho_temp[3] = (gas_gamma - 1.0)*(mass * totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
+  double rhoSq_temp[4]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  rhoSq_temp[3] = mass*(gas_gamma-1.0)*(rho_totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
 
+  double rhoSq_inv[4] = {0.0}; 
+  ser_2x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[4] = {0.0}; 
  
-  binop_mul_2d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_2d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
   gkyl_mat_set(&rhs_ux,0,0,ux[0]); 
   gkyl_mat_set(&rhs_uy,0,0,uy[0]); 
   gkyl_mat_set(&rhs_uz,0,0,uz[0]); 

--- a/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_3x_ser_p1.c
+++ b/gyrokinetic/ker/gk_neut_fluid_prim_vars/gk_neut_fluid_prim_vars_udrift_temp_3x_ser_p1.c
@@ -28,6 +28,12 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_3x_ser_p1(int count
   const double *rhouz = &moms[24]; 
   const double *totE  = &moms[32]; 
 
+  double rhoSq[8] = {0.0}; 
+  binop_mul_3d_ser_p1(rho, rho, rhoSq); 
+ 
+  double rho_totE[8] = {0.0}; 
+  binop_mul_3d_ser_p1(rho, totE, rho_totE); 
+ 
   double rhouxSq[8] = {0.0}; 
   binop_mul_3d_ser_p1(rhoux, rhoux, rhouxSq); 
  
@@ -48,20 +54,22 @@ GKYL_CU_DH void gk_neut_fluid_prim_vars_udrift_temp_set_prob_3x_ser_p1(int count
   binop_mul_3d_ser_p1(rho_inv, rhouy, uy); 
   binop_mul_3d_ser_p1(rho_inv, rhouz, uz); 
  
-  double rho_temp[8]; 
-  rho_temp[0] = (gas_gamma - 1.0)*(mass * totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
-  rho_temp[1] = (gas_gamma - 1.0)*(mass * totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
-  rho_temp[2] = (gas_gamma - 1.0)*(mass * totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
-  rho_temp[3] = (gas_gamma - 1.0)*(mass * totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
-  rho_temp[4] = (gas_gamma - 1.0)*(mass * totE[4] - 0.5*(rhouxSq[4] + rhouySq[4] + rhouzSq[4])); 
-  rho_temp[5] = (gas_gamma - 1.0)*(mass * totE[5] - 0.5*(rhouxSq[5] + rhouySq[5] + rhouzSq[5])); 
-  rho_temp[6] = (gas_gamma - 1.0)*(mass * totE[6] - 0.5*(rhouxSq[6] + rhouySq[6] + rhouzSq[6])); 
-  rho_temp[7] = (gas_gamma - 1.0)*(mass * totE[7] - 0.5*(rhouxSq[7] + rhouySq[7] + rhouzSq[7])); 
+  double rhoSq_temp[8]; 
+  rhoSq_temp[0] = mass*(gas_gamma-1.0)*(rho_totE[0] - 0.5*(rhouxSq[0] + rhouySq[0] + rhouzSq[0])); 
+  rhoSq_temp[1] = mass*(gas_gamma-1.0)*(rho_totE[1] - 0.5*(rhouxSq[1] + rhouySq[1] + rhouzSq[1])); 
+  rhoSq_temp[2] = mass*(gas_gamma-1.0)*(rho_totE[2] - 0.5*(rhouxSq[2] + rhouySq[2] + rhouzSq[2])); 
+  rhoSq_temp[3] = mass*(gas_gamma-1.0)*(rho_totE[3] - 0.5*(rhouxSq[3] + rhouySq[3] + rhouzSq[3])); 
+  rhoSq_temp[4] = mass*(gas_gamma-1.0)*(rho_totE[4] - 0.5*(rhouxSq[4] + rhouySq[4] + rhouzSq[4])); 
+  rhoSq_temp[5] = mass*(gas_gamma-1.0)*(rho_totE[5] - 0.5*(rhouxSq[5] + rhouySq[5] + rhouzSq[5])); 
+  rhoSq_temp[6] = mass*(gas_gamma-1.0)*(rho_totE[6] - 0.5*(rhouxSq[6] + rhouySq[6] + rhouzSq[6])); 
+  rhoSq_temp[7] = mass*(gas_gamma-1.0)*(rho_totE[7] - 0.5*(rhouxSq[7] + rhouySq[7] + rhouzSq[7])); 
 
+  double rhoSq_inv[8] = {0.0}; 
+  ser_3x_p1_inv(rhoSq, rhoSq_inv); 
   // Calculate expansions of temperature. 
   double temp[8] = {0.0}; 
  
-  binop_mul_3d_ser_p1(rho_inv, rho_temp, temp); 
+  binop_mul_3d_ser_p1(rhoSq_inv, rhoSq_temp, temp); 
   gkyl_mat_set(&rhs_ux,0,0,ux[0]); 
   gkyl_mat_set(&rhs_uy,0,0,uy[0]); 
   gkyl_mat_set(&rhs_uz,0,0,uz[0]); 


### PR DESCRIPTION
The native moments in fluid neutrals are:
- mass density (rho = m * n)
- momentum density (rho*u)
- kinetic energy density (E)

Where
E = 0.5 * rho * u^2 + p/(gamma - 1)

and gamma is the adiabatic index.

There was an error in the calculation of the temperature (T= p/n) which only surfaced when u \neq 0 (but so far we had only done sims with u=0). The correct calculation of temperature should have been

T = (gamma - 1) * (E - 0.5 * rho * u^2) / n

and for ease of implementation we compute it as 

T = m * (gamma - 1) * (rho * E - 0.5 * (rho * u)^2) / rho^2

This goes with [PR 92 of gkylcas](https://github.com/ammarhakim/gkylcas/pull/92)