### PR TITLE
Added note that scale_factor must be nonzero

### DIFF
--- a/gyrokinetic/apps/gkyl_gyrokinetic.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic.h
@@ -77,7 +77,7 @@ struct gkyl_phase_diagnostics_inp {
 struct gkyl_gyrokinetic_collisionless {
   enum gkyl_gk_collisionless_type type; // Type of collisionless terms.
   bool write_diagnostics; // Whether to output diagnostics.
-  double scale_factor; // Factor multiplying collisionless terms. NOTE: Trying to disable collisionless terms entirely by setting to 0 will NOT work; set to negligible nonzero value or set type to GKYL_GK_COLLISIONLESS_NONE instead.
+  double scale_factor; // Factor multiplying collisionless terms (should be > 0).
 };
 
 // Parameters for species collisions


### PR DESCRIPTION
For multirate timestepping, one may generally want to effectively disable the collisionless terms during certain phases. Currently, in the regression tests (such as `rt_gk_mirror_boltz_elc_poa_1x2v_p1.c`), this is done by setting the scale_factor value to a small value (0.01).

```
struct gkyl_gyrokinetic_collisionless collisionless_inp = {
    .type = GKYL_GK_COLLISIONLESS_ES,
    .scale_factor = pparams->alpha,
};
```

It seems almost inevitable that someone trying to replicate this unit test is at some point going to want to disable certain collisionless terms entirely during certain phases to speed these phases up. Using the unit tests as reference, they'd set alpha to 0. At the moment, doing so would result in `scale_factor` stealthily being set to 1.0 under the hood (see #896).

As a band-aid fix, we can add comments to at least specify such behaviour as undefined behaviour, although a more structured solution might be desired in the future. 