### PR TITLE
1/2 factor missing in the field energy 1D factor

### DIFF
--- a/gyrokinetic/apps/gk_field_1x.c
+++ b/gyrokinetic/apps/gk_field_1x.c
@@ -135,7 +135,7 @@ gk_field_fem_new_1x(struct gkyl_gyrokinetic_app *app, struct gk_field *f)
       fem_parproj_bc, epsilon_global, 0, app->use_gpu);
   }
 
-  f->es_energy_fac_1d = polarization_weight*f->info.kperpSq + es_energy_fac_1d_adiabatic;
+  f->es_energy_fac_1d = 0.5*polarization_weight*f->info.kperpSq + es_energy_fac_1d_adiabatic;
 
   f->calc_em_energy = gkyl_array_integrate_new(&app->grid, &app->basis, 
     1, GKYL_ARRAY_INTEGRATE_OP_SQ, app->use_gpu);


### PR DESCRIPTION
This typo was already present before the gk field refactor #843. This typo was detected during the revival of the EM terms in the 1x2v Alfven test case. Below is a comparison of the energy conservation for the electrostatic version of the Alfven test case done with `main` before and after the fix.

This is the current version of main:
<img width="777" height="578" alt="image" src="https://github.com/user-attachments/assets/a5d32082-7508-4413-97a7-0e5e92f9ebc9" />

This is with the 1/2 factor correction of this PR:
<img width="777" height="578" alt="image" src="https://github.com/user-attachments/assets/41f68e03-67ec-4672-94f8-1531556701e4" />
 