### PR TITLE
Update the neutral recycling regression test; with a resolution of 22…

### DIFF
--- a/gyrokinetic/creg/rt_gk_neut_recycle_1x3v_p1.c
+++ b/gyrokinetic/creg/rt_gk_neut_recycle_1x3v_p1.c
@@ -15,33 +15,24 @@ struct sheath_ctx
 {
   int cdim, vdim; // Dimensionality.
   
-  // Mathematical constants (dimensionless).
-  double pi;
-
   // Physical constants (using non-normalized physical units).
-  double epsilon0; // Permittivity of free space.
   double mass_elc; // Electron mass.
   double charge_elc; // Electron charge.
   double mass_ion; // Proton mass.
   double charge_ion; // Proton charge.
+  double mass_neut; // Neutral mass.
 
   double Te; // Electron temperature.
   double Ti; // Ion temperature.
-  double T0; // Neutral temperature.
+  double Tn; // Neutral temperature.
   double n0; // Reference number density (1 / m^3).
 
-  double nu_frac; // Collision frequency fraction.
-
   double rec_frac; // Recycling fraction for neutral BCs.
+  double Tn_recycle; // Neutral recycling temperature.
 
   double k_perp_rho_s; // Product of perpendicular wavenumber and ion-sound gyroradius.
  
   double B0; // Reference magnetic field strength (Tesla).
-
-  double log_lambda_elc; // Electron Coulomb logarithm.
-  double log_lambda_ion; // Ion Coulomb logarithm.
-  double nu_elc; // Electron collision frequency.
-  double nu_ion; // Ion collision frequency.
 
   double c_s; // Sound speed.
   double vte; // Electron thermal velocity.
@@ -55,22 +46,17 @@ struct sheath_ctx
   double n_src; // Source number density.
   double T_src; // Source temperature.
 
-  double c_s_src; // Source sound speed.
-  double n_peak; // Peak number density.
-
-
-  // Simulation parameters.
-  int Nz; // Cell count (configuration space: z-direction).
-  int Nvpar; // Cell count (velocity space: parallel velocity direction).
-  int Nmu; // Cell count (velocity space: magnetic moment direction).
+  int Nz; // Number of cells along magnetic field.
+  int Nvpar; // Number of cells in vpar.
+  int Nmu; // Number of cells in mu.
+  int Nv; // Number of cells in neutral v.
   int cells[GKYL_MAX_DIM]; // Number of cells in all directions.
-  double Lz; // Domain size (configuration space: z-direction).
-  double vmax_neut; 
-  double vpar_max_elc; // Domain boundary (electron velocity space: parallel velocity direction).
-  double mu_max_elc; // Domain boundary (electron velocity space: magnetic moment direction).
-  double vpar_max_ion; // Domain boundary (ion velocity space: parallel velocity direction).
-  double mu_max_ion; // Domain boundary (ion velocity space: magnetic moment direction).
-  double v_max_neut; // Domain boundary (ion velocity space: parallel velocity direction).
+  double Lz; // Domain size along z.
+  double vpar_max_elc; // Maximum electron vpar.
+  double mu_max_elc; // Maximum electron mu.
+  double vpar_max_ion; // Maximum ion vpar.
+  double mu_max_ion; // Maximum ion mu.
+  double v_max_neut; // Maximum neutral velocity.
 
   double t_end; // Final simulation time.
   int num_frames; // Number of output frames.
@@ -82,114 +68,91 @@ struct sheath_ctx
 struct sheath_ctx
 create_ctx(void)
 {
-  // Mathematical constants (dimensionless).
-  double pi = M_PI;
-
   int cdim = 1, vdim = 2; // Dimensionality.
 
   // Physical constants (using non-normalized physical units).
-  double epsilon0 = GKYL_EPSILON0; // Permittivity of free space.
   double eV = GKYL_ELEMENTARY_CHARGE; // Elementary charge.
   double mass_elc = GKYL_ELECTRON_MASS; // Electron mass.
   double mass_ion = GKYL_PROTON_MASS; // Proton mass.
+  double mass_neut = mass_ion; // Neutral mass.
   double charge_elc = -eV; // Electron charge.
   double charge_ion =  eV; // Proton charge.
 
   double Te = 30.0 * eV; // Electron temperature.
   double Ti = 60.0 * eV; // Ion temperature.
-  double T0 = 10.0 * eV; // Neutral temperature
+  double Tn = 60.0 * eV; // Neutral temperature
   double n0 = 5.0e18; //  Reference number density (1 / m^3).
 
-  double nu_frac = 0.1; // Collision frequency fraction.
-
   double rec_frac = 1.0; // Recycling coefficient for neutral BCs.
+  double Tn_recycle = 10.0 * eV; // Neutral recycling temperature
 
   double k_perp_rho_s = 0.2; // Product of perpendicular wavenumber and ion-sound gyroradius.
 
   // Derived physical quantities (using non-normalized physical units).
   double B0 = 0.5; // Reference magnetic field strength (Tesla).
 
-  // Coulomb logarithms.
-  double log_lambda_elc = 6.6 - 0.5 * log(n0 / 1.0e20) + 1.5 * log(Te / charge_ion);
-  double log_lambda_ion = 6.6 - 0.5 * log(n0 / 1.0e20) + 1.5 * log(Ti / charge_ion);
-
-  // Collision frequencies.
-  double nu_elc = nu_frac * log_lambda_elc * pow(charge_ion,4) * n0 /
-    (6.0 * sqrt(2.0) * pow(M_PI,3.0/2.0) * pow(epsilon0,2) * sqrt(mass_elc) * pow(Te,3.0/2.0));
-  double nu_ion = nu_frac * log_lambda_ion * pow(charge_ion,4) * n0 /
-    (12.0 * pow(M_PI,3.0/2.0) * pow(epsilon0,2) * sqrt(mass_ion) * pow(Ti,3.0/2.0));
-  
-  double c_s = sqrt(Te / mass_ion); // Sound speed.
   double vte = sqrt(Te / mass_elc); // Electron thermal velocity.
   double vti = sqrt(Ti / mass_ion); // Ion thermal velocity.
-  double vtn = sqrt(T0 / mass_ion); // Neutral thermal velocity.
+  double vtn = sqrt(Tn / mass_neut); // Neutral thermal velocity.
+
+  double c_s = sqrt(Te / mass_ion); // Sound speed.
   double omega_ci = fabs(charge_ion / mass_ion); // Ion cyclotron frequency.
   double rho_s = c_s / omega_ci; // Ion-sound gyroradius.
 
   double k_perp = k_perp_rho_s / rho_s; // Perpendicular wavenumber (for Poisson solver).
 
-  double n_src = 2.870523e21; // Source number density.
-  double T_src = 2.0 * Te; // Source temperature.
+  double n_src = pow(n0,2.0)*8e-21; // Source number density.
+  double T_src = 10.0*eV; // Source temperature.
 
-  double c_s_src = sqrt((5.0 / 3.0) * T_src / mass_ion); // Source sound speed.
-  double n_peak = 4.0 * sqrt(5.0) / 3.0 / c_s_src * 0.5 * n_src; // Peak number density.
+  int Nz = 224; // Number of cells along magnetic field.
+  int Nvpar = 16; // Number of cells in vpar.
+  int Nmu = 4; // Number of cells in mu.
+  int Nv = 16; // Number of cells in neutral v.
 
-  // Simulation parameters
-  int Nz = 64; // Cell count (configuration space: z-direction).
-  int Nvpar = 16; // Cell count (velocity space: parallel velocity direction).
-  int Nmu = 8; // Cell count (velocity space: magnetic moment direction).
-  double Lz = 40.0; // Domain size (configuration space: z-direction).
-  double vmax_neut = 4.0 * vtn; 
-  double vpar_max_elc = 4.0 * vte; // Domain boundary (electron velocity space: parallel velocity direction).
-  double mu_max_elc = (3.0 / 2.0) * 0.5 * mass_elc * pow(4.0 * vte,2) / (2.0 * B0); // Domain boundary (electron velocity space: magnetic moment direction).
-  double vpar_max_ion = 4.0 * vti; // Domain boundary (ion velocity space: parallel velocity direction).
-  double mu_max_ion = (3.0 / 2.0) * 0.5 * mass_ion * pow(4.0 * vti,2) / (2.0 * B0); // Domain boundary (ion velocity space: magnetic moment direction).
-  double v_max_neut = 4.0 * vtn; // Domain boundary (ion velocity space: parallel velocity direction).
+  double Lz = 40.0; // Domain size along z.
+  double vpar_max_elc = 4.0*vte; // Maximum electron vpar.
+  double mu_max_elc = 12.0*mass_elc*pow(vte,2)/(2.0*B0); // Maximum electron mu.
+  double vpar_max_ion = 4.0 * vti; // Maximum ion vpar.
+  double mu_max_ion = 12.0*mass_ion*pow(vti,2)/(2.0*B0); // Maximum ion mu.
+  double v_max_neut = 4.0 * vtn; // Maximum neutral velocity.
  
-  double t_end = 10e-6; // Final simulation time.
+  double t_end = .00625*Lz/c_s; // Final simulation time.
   int num_frames = 1; // Number of output frames.
   int int_diag_calc_num = num_frames*100;
   double dt_failure_tol = 1.0e-4; // Minimum allowable fraction of initial time-step.
   int num_failures_max = 20; // Maximum allowable number of consecutive small time-steps.
   
   struct sheath_ctx ctx = {
-    .pi = pi,
     .cdim = cdim,
     .vdim = vdim,
-    .epsilon0 = epsilon0,
     .mass_elc = mass_elc,
     .charge_elc = charge_elc,
     .mass_ion = mass_ion,
     .charge_ion = charge_ion,
+    .mass_neut = mass_neut,
     .Te = Te,
     .Ti = Ti,
-    .T0 = T0,
+    .Tn = Tn,
     .n0 = n0,
-    .nu_frac = nu_frac,
     .rec_frac = rec_frac,
+    .Tn_recycle = Tn_recycle,
     .k_perp_rho_s = k_perp_rho_s,
     .B0 = B0,
-    .log_lambda_elc = log_lambda_elc,
-    .nu_elc = nu_elc,
-    .log_lambda_ion = log_lambda_ion,
-    .nu_ion = nu_ion,
-    .c_s = c_s,
     .vte = vte,
     .vti = vti,
     .vtn = vtn,
+    .c_s = c_s,
     .omega_ci = omega_ci,
     .rho_s = rho_s,
     .k_perp = k_perp,
     .n_src = n_src,
     .T_src = T_src,
-    .c_s_src = c_s_src,
-    .n_peak = n_peak,
     .Nz = Nz,
     .Nvpar = Nvpar,
     .Nmu = Nmu,
+    .Nv = Nv,
     .cells = {Nz, Nvpar, Nmu},
     .Lz = Lz,
-    .vmax_neut = vmax_neut,
     .vpar_max_elc = vpar_max_elc,
     .mu_max_elc = mu_max_elc,
     .vpar_max_ion = vpar_max_ion,
@@ -208,20 +171,19 @@ create_ctx(void)
 void
 evalSourceDensityInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Neutral source rate.
   struct sheath_ctx *app = ctx;
   double z = xn[0];
 
-  double n_src = app->n0;
-  double Lz = app->Lz;
+  double n_src = app->n_src;
 
-  double n = pow(n_src,2.0)*8e-21;
-  fout[0] = n;
+  fout[0] = n_src;
 }
 
 void
 evalSourceUdriftInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
-  // Set source drift velocity.
+  // Neutral source drift velocity.
   fout[0] = 0.0; 
   fout[1] = 0.0;
   fout[2] = 0.0;
@@ -230,57 +192,59 @@ evalSourceUdriftInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_REST
 void
 evalSourceTempInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Neutral source temperature.
   struct sheath_ctx *app = ctx;
 
-  double T_src = app->T0;
+  double T_src = app->T_src;
 
-  // Set source temperature.
   fout[0] = T_src;
 }
 
 void
 evalDensityInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Electron/ion density.
   struct sheath_ctx *app = ctx;
   double z = xn[0];
-
-  double n_peak = app->n_peak;
-  double Lz = app->Lz;
 
   double n = app->n0;
   fout[0] = n;
 }
 
+static double
+sech(double x)
+{
+  // Hyperbolic secant.
+  return 1.0/cosh(x);
+}
+
 void
 evalDensityNeutInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Neutral density.
   struct sheath_ctx *app = ctx;
   double z = xn[0];
   double n0 = app->n0;
   double Lz = app->Lz;
-  double n = 0.0;
+  double den = 0.0;
 
-  //Set number density.
+  double z0 = 0.2;
+  double flr = 1e-6;
+
+  // Set number density.
   if (z <= 0) {
-    n = n0*(pow(1.0/cosh(-(Lz/2. + z)/0.2),2.0) + 1.e-6);
+    den = n0*(pow(sech((-Lz/2-z)/z0),2) + flr);
   }
   else {
-    n = n0*(pow(1.0/cosh((-Lz/2. + z)/0.2),2.0) + 1.e-6);
+    den = n0*(pow(sech((Lz/2-z)/z0),2) + flr);
   }
-  fout[0] = n; 
-}
-
-void
-evalUnitDensity(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
-{
-  struct sheath_ctx *app = ctx;
-  fout[0] = 1.0; 
+  fout[0] = den;
 }
 
 void
 evalUparInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
-  // Set parallel velocity.
+  // Electron/ion parallel drift speed.
   struct sheath_ctx *app = ctx;
   double z = xn[0]; 
   fout[0] = app->c_s*z/(app->Lz/2.);
@@ -289,6 +253,7 @@ evalUparInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fou
 void
 evalUdriftInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
+  // Neutral drift velocity.
   fout[0] = 0.0; 
   fout[1] = 0.0;
   fout[2] = 0.0;
@@ -297,53 +262,32 @@ evalUdriftInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT 
 void
 evalTempElcInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Electron temperature.
   struct sheath_ctx *app = ctx;
 
   double Te = app->Te;
 
-  // Set electron temperature.
   fout[0] = Te;
 }
 
 void
 evalTempIonInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
 {
+  // Ion temperature.
   struct sheath_ctx *app = ctx;
 
   double Ti = app->Ti;
 
-  // Set ion temperature.
   fout[0] = Ti;
 }
 
 void
 evalTempNeutInit(double t, const double * GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void *ctx)
 {
+  // Neutral temperature.
   struct sheath_ctx *app = ctx;
-  double T = app->T0;
-  fout[0] = T;
-}
-
-void
-evalNuElcInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
-{
-  struct sheath_ctx *app = ctx;
-
-  double nu_elc = app->nu_elc;
-
-  // Set electron collision frequency.
-  fout[0] = nu_elc;
-}
-
-void
-evalNuIonInit(double t, const double* GKYL_RESTRICT xn, double* GKYL_RESTRICT fout, void* ctx)
-{
-  struct sheath_ctx *app = ctx;
-
-  double nu_ion = app->nu_ion;
-
-  // Set ion collision frequency.
-  fout[0] = nu_ion;
+  double Tn = app->Tn;
+  fout[0] = Tn/6.0;
 }
 
 static inline void
@@ -352,7 +296,7 @@ mapc2p(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT xp, void*
   // Set physical coordinates (X, Y, Z) from computational coordinates (x, y, z).
   double x = zc[0], y = zc[1], z = zc[2];
 
-  xp[0] = x*cos(y); xp[1] = x*sin(y); xp[2] = z;
+  xp[0] = x; xp[1] = y; xp[2] = z;
 }
 
 void
@@ -362,7 +306,6 @@ bfield_func(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT fout
 
   double B0 = app->B0;
 
-  // zc are computational coords. 
   // Set Cartesian components of magnetic field.
   fout[0] = 0.0;
   fout[1] = 0.0;
@@ -406,7 +349,7 @@ main(int argc, char **argv)
     .num_species = 1,
     .in_species = { "ion" },
     .recycling_frac = ctx.rec_frac,
-    .emission_temp = ctx.T0,
+    .emission_temp = ctx.Tn_recycle,
   };
 
   // Electron species.
@@ -470,11 +413,11 @@ main(int argc, char **argv)
   };
 
   struct gkyl_gyrokinetic_neut_species neut = {
-    .name = "neut", .mass = ctx.mass_ion,
+    .name = "neut", .mass = ctx.mass_neut,
     .vdim = ctx.vdim+1,
-    .lower = { -ctx.v_max_neut, -ctx.v_max_neut, -ctx.v_max_neut/64.0 },
-    .upper = {  ctx.v_max_neut,  ctx.v_max_neut,  ctx.v_max_neut/64.0 },
-    .cells = { cells_v[0], cells_v[0], cells_v[0]},
+    .lower = { -ctx.v_max_neut, -ctx.v_max_neut, -ctx.v_max_neut },
+    .upper = {  ctx.v_max_neut,  ctx.v_max_neut,  ctx.v_max_neut },
+    .cells = { ctx.Nv, ctx.Nv, ctx.Nv, },
 
     .projection = {
       .proj_id = GKYL_PROJ_MAXWELLIAN_PRIM, 
@@ -517,7 +460,7 @@ main(int argc, char **argv)
           .ion_mass = ctx.mass_ion,
           .elc_mass = ctx.mass_elc,
         },
-	      { .react_id = GKYL_REACT_CX,
+        { .react_id = GKYL_REACT_CX,
           .type_self = GKYL_SELF_PARTNER,
           .ion_id = GKYL_ION_H,
           .ion_nm = "ion",
@@ -539,9 +482,9 @@ main(int argc, char **argv)
 
   // Field.
   struct gkyl_gyrokinetic_field field = {
-    .poisson_bcs = {},
     .kperpSq = ctx.k_perp * ctx.k_perp,
     .is_static = true,
+    .zero_init_field = true,
   };
 
   // Gyrokinetic app.
@@ -559,7 +502,7 @@ main(int argc, char **argv)
 
     .geometry = {
       .geometry_id = GKYL_MAPC2P,
-      .world = {0.01, 0.0},
+      .world = {0.0, 0.0},
       .mapc2p = mapc2p,
       .c2p_ctx = &ctx,
       .bfield_func = bfield_func,


### PR DESCRIPTION
…4x16x8 it reproduces the neutral temperature in figure 3b of T. N. Bernard, et al. PoP 29, 052501 (2022) even just run to 3/10 of Lz/cs (the original test was ran to 3 Lz/cs). Reduced t_end so it runs in 40 s.