### PR TITLE
Fix gk_species_damping.c

### DIFF
--- a/gyrokinetic/apps/gk_species_damping.c
+++ b/gyrokinetic/apps/gk_species_damping.c
@@ -152,6 +152,7 @@ gk_species_damping_init(struct gkyl_gyrokinetic_app *app, struct gk_species *gks
         .vel_map = gks->vel_map,
         .bmag = app->gk_geom->geo_int.bmag,
         .bmag_max = damp->bmag_max,
+        .bmag_max_loc = damp->bmag_max_coord,
         .mass = gks->info.mass,
         .charge = gks->info.charge,
         .num_quad = num_quad,


### PR DESCRIPTION
The regression test `rt_gk_mirror_boltz_elc_damped_1x2v_p1` is failing on main. There was a forgotton variable which needed to be passed to the loss cone updater. It's a one line fix and the regression test runs now. This test is also valgrind clean.