### PR TITLE
Write GK twistshfit for plotting 3x2v data with pgkyl and debugging

### DIFF
--- a/core/unit/ctest_rect_grid.c
+++ b/core/unit/ctest_rect_grid.c
@@ -199,7 +199,7 @@ void test_grid_io()
 
   FILE *fp = 0;
   with_file (fp, "ctest_rect_grid.dat", "w")
-    gkyl_rect_grid_write(&grid, fp);
+    gkyl_rect_grid_write(&grid, 0, fp);
 
   struct gkyl_rect_grid grid2;
   with_file (fp, "ctest_rect_grid.dat", "r")

--- a/core/zero/array_rio.c
+++ b/core/zero/array_rio.c
@@ -75,7 +75,7 @@ gkyl_grid_sub_array_header_write_fp(const struct gkyl_rect_grid *grid,
   // Version 0 format is used for rest of the header
   uint64_t real_type = gkyl_array_data_type[hdr->etype];
   fwrite(&real_type, sizeof(uint64_t), 1, fp);
-  gkyl_rect_grid_write(grid, fp);
+  gkyl_rect_grid_write(grid, 0, fp);
 
   fwrite(&hdr->esznc, sizeof(uint64_t), 1, fp);
   fwrite(&hdr->tot_cells, sizeof(uint64_t), 1, fp);

--- a/core/zero/gkyl_rect_grid.h
+++ b/core/zero/gkyl_rect_grid.h
@@ -121,13 +121,14 @@ gkyl_rect_grid_coord_idx(const struct gkyl_rect_grid *grid,
 bool gkyl_rect_grid_cmp(const struct gkyl_rect_grid *grid1, struct gkyl_rect_grid *grid2);
 
 /**
- * Write grid data to file. File must be opened by caller of this
- * function. Data is written in binary format.
+ * Write grid data to given file pointer. If file pointer is not stdout or
+ * stderr, data is written to previously opened file in binary format.
  *
  * @param grid Grid object to write
+ * @param nm Name of grid (for fp=stdout or stderr);
  * @param fp File handle to write to.
  */
-void gkyl_rect_grid_write(const struct gkyl_rect_grid *grid, FILE *fp);
+void gkyl_rect_grid_write(const struct gkyl_rect_grid *grid, const char *nm, FILE *fp);
 
 /**
  * Read data from file and initialize grid. File must be opened by

--- a/core/zero/rect_grid.c
+++ b/core/zero/rect_grid.c
@@ -132,18 +132,48 @@ gkyl_rect_grid_find_cell(const struct gkyl_rect_grid *grid, const double *point,
 }
 
 void
-gkyl_rect_grid_write(const struct gkyl_rect_grid *grid, FILE *fp)
+gkyl_rect_grid_write(const struct gkyl_rect_grid *grid, const char *nm, FILE *fp)
 {
-  // dimension and shape are written as 64 bit integers
-  uint64_t ndim = grid->ndim;
-  uint64_t cells[GKYL_MAX_DIM];
-  for (int d=0; d<grid->ndim; ++d)
-    cells[d] = grid->cells[d];
+  if (fp == stdout || fp == stderr) {
+    fprintf(fp, "%s = { ndim = %d, ", nm, grid->ndim);
 
-  fwrite(&ndim, sizeof(uint64_t), 1, fp);
-  fwrite(cells, sizeof(uint64_t), grid->ndim, fp);
-  fwrite(grid->lower, sizeof(double), grid->ndim, fp);
-  fwrite(grid->upper, sizeof(double), grid->ndim, fp);
+    fprintf(fp, " lower = { ");
+    for (int d=0; d<grid->ndim; ++d)
+      fprintf(fp, "%.9e%c ", grid->lower[d], d==grid->ndim-1 ? ' ' : ',');
+    fprintf(fp, "}, ");
+
+    fprintf(fp, "upper = { ");
+    for (int d=0; d<grid->ndim; ++d)
+      fprintf(fp, "%.9e%c ", grid->upper[d] , d==grid->ndim-1 ? ' ' : ',');
+    fprintf(fp, "}, ");
+
+    fprintf(fp, "cells = { ");
+    for (int d=0; d<grid->ndim; ++d)
+      fprintf(fp, "%d%c ", grid->cells[d] , d==grid->ndim-1 ? ' ' : ',');
+    fprintf(fp, "}, ");
+
+    fprintf(fp, "dx = { ");
+    for (int d=0; d<grid->ndim; ++d)
+      fprintf(fp, "%.9e%c ", grid->upper[d] , d==grid->ndim-1 ? ' ' : ',');
+    fprintf(fp, "}, ");
+
+    fprintf(fp, " cellVolume = %.9e, ", grid->cellVolume );
+    
+    fprintf(fp, " }\n");
+    fflush(fp);
+  }
+  else {
+    // Dimension and shape are written as 64 bit integers.
+    uint64_t ndim = grid->ndim;
+    uint64_t cells[GKYL_MAX_DIM];
+    for (int d=0; d<grid->ndim; ++d)
+      cells[d] = grid->cells[d];
+  
+    fwrite(&ndim, sizeof(uint64_t), 1, fp);
+    fwrite(cells, sizeof(uint64_t), grid->ndim, fp);
+    fwrite(grid->lower, sizeof(double), grid->ndim, fp);
+    fwrite(grid->upper, sizeof(double), grid->ndim, fp);
+  }
 }
 
 bool

--- a/gyrokinetic/apps/gk_field_2x3x.c
+++ b/gyrokinetic/apps/gk_field_2x3x.c
@@ -13,6 +13,75 @@
 #include <time.h>
 
 static void
+gk_field_2x3x_write_twistshift(struct gkyl_gyrokinetic_app *app, struct gk_field *f)
+{
+  // Write the discretized shift (for TS BCs) to file.
+  int comm_rank, comm_size;
+  gkyl_comm_get_rank(app->comm, &comm_rank);
+  gkyl_comm_get_size(app->comm, &comm_size);
+
+  const char *vars[] = {"x","y","z"};
+  const char *edge[] = {"lower","upper"};
+  const char *fmt = "%s-bc_%s%s_twistshift.gkyl";
+
+  struct gk_species *gks = &app->species[0];
+  for (int i = 0; i < 2*app->cdim; i++) {
+    if (gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_IWL ||
+        gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
+
+      int dir = gks->info.bcs[i].dir;
+      int edi = gks->info.bcs[i].edge;
+      if (comm_rank == 0 && edi == GKYL_LOWER_EDGE) {
+        struct gkyl_bc_twistshift *bc_ts = f->bc_ts_lo;
+        
+        struct gkyl_rect_grid shear_grid;
+        struct gkyl_range shear_r;
+        struct gkyl_basis shift_b;
+        struct gkyl_array *shift_dg = gkyl_bc_twistshift_get_shift_objects(bc_ts, &shear_grid, &shear_r, &shift_b);
+
+        // Twistshift updater stores the shift on a restricted range (the core) but a full
+        // grid. Create a restricted grid for I/O.
+        struct gkyl_rect_grid shear_grid_core;
+        double lower[1], upper[1];
+        int cells[] = {shear_r.volume};
+        if (app->gk_geom->geqdsk_sign_convention == 0) {
+          // x increases towards SOL.
+          lower[0] = shear_grid.lower[0];
+          upper[0] = shear_grid.lower[0] + shear_grid.dx[0]*cells[0];
+          gkyl_rect_grid_init(&shear_grid_core, shear_grid.ndim, lower, upper, cells);
+        }
+        else {
+          // x increases towards SOL.
+          lower[0] = shear_grid.upper[0] - shear_grid.dx[0]*cells[0];
+          upper[0] = shear_grid.upper[0];
+          gkyl_rect_grid_init(&shear_grid_core, shear_grid.ndim, lower, upper, cells);
+        }
+
+        // Package metadata for shift file.
+        struct gkyl_msgpack_map_elem io_meta_shift_dg[] = {
+          { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = shift_b.poly_order },
+          { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = shift_b.id }
+        };
+        int io_meta_shift_dg_len = sizeof(io_meta_shift_dg)/sizeof(io_meta_shift_dg[0]);
+        int io_meta_shift_len[] = {app->io_meta_basic_len, io_meta_shift_dg_len};
+        const struct gkyl_msgpack_map_elem* io_meta_shift[] = {app->io_meta_basic, io_meta_shift_dg};
+        struct gkyl_msgpack_data *mt_shift = gkyl_msgpack_create_union(sizeof(io_meta_shift_len)/sizeof(int),
+          io_meta_shift_len, io_meta_shift);
+
+        int sz = gkyl_calc_strlen(fmt, app->name, vars[dir], edge[edi]);
+        char fileNm[sz+1]; // ensures no buffer overflow
+        sprintf(fileNm, fmt, app->name, vars[dir], edge[edi]);
+
+        gkyl_grid_sub_array_write(&shear_grid_core, &shear_r, mt_shift, shift_dg, fileNm);
+
+        gkyl_array_release(shift_dg);
+        gkyl_msgpack_data_release(mt_shift);
+      }
+    }
+  }
+}
+
+static void
 gk_field_2x3x_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field *f)
 {
   // Parallel direction index (handle 2x and 3x cases).
@@ -32,7 +101,7 @@ gk_field_2x3x_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struc
   if (app->cdim == 3) {
     // TS BC updater for up to low TS for the lower edge
     // this sets ghost_L = T_LU(ghost_L)
-    struct gkyl_bc_twistshift_inp T_LU_lo = {
+    struct gkyl_bc_twistshift_inp ts_lo = {
       .bc_dir = par_dir,
       .shift_dir = 1, // y shift.
       .shear_dir = 0, // shift varies with x.
@@ -47,12 +116,15 @@ gk_field_2x3x_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struc
       .use_gpu = app->use_gpu,
     };
     // Add the forward TS updater to f
-    f->bc_T_LU_lo = gkyl_bc_twistshift_new(&T_LU_lo);
+    f->bc_ts_lo = gkyl_bc_twistshift_new(&ts_lo);
   }
 
   // Add the SSFG updater for lower and upper application.
   f->ssfg_z_lo = gkyl_skin_surf_from_ghost_new(par_dir,  GKYL_LOWER_EDGE,
     app->basis, &app->lower_skin_par_core,  &app->lower_ghost_par_core, app->use_gpu);
+
+  // Write the discrete shift to file.
+  gk_field_2x3x_write_twistshift(app, f);
 }
 
 static void
@@ -67,7 +139,7 @@ gk_field_enforce_parallel_bc_enabled(const gkyl_gyrokinetic_app *app, struct gk_
   
   // Update the lower z ghosts with twist-and-shift if we are in 3x2v
   if (app->cdim == 3) {
-    gkyl_bc_twistshift_advance(field->bc_T_LU_lo, finout, finout);
+    gkyl_bc_twistshift_advance(field->bc_ts_lo, finout, finout);
   }
 
   // Sync ghost cells between MPI processes.
@@ -159,7 +231,7 @@ gk_field_fem_release_2x3x(const gkyl_gyrokinetic_app *app, struct gk_field *f)
   // Release TS BC and SSFG updater
   if (f->gkfield_id == GKYL_GK_FIELD_ES_IWL) {
     if (app->cdim == 3) {
-      gkyl_bc_twistshift_release(f->bc_T_LU_lo);
+      gkyl_bc_twistshift_release(f->bc_ts_lo);
     }
     gkyl_skin_surf_from_ghost_release(f->ssfg_z_lo);
   }

--- a/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
@@ -1282,7 +1282,7 @@ struct gk_field {
   void (*calc_energy_dt_func)(gkyl_gyrokinetic_app *app, const struct gk_field *field, double dt, double *energy_reduced);
 
   // Objects used in IWL simulations and TS BCs.
-  struct gkyl_bc_twistshift *bc_T_LU_lo; // TS BC updater.
+  struct gkyl_bc_twistshift *bc_ts_lo; // TS BC updater.
   // Objects used by the skin surface to ghost (SSFG) operator.
   struct gkyl_skin_surf_from_ghost *ssfg_z_lo;
   

--- a/gyrokinetic/zero/bc_twistshift.c
+++ b/gyrokinetic/zero/bc_twistshift.c
@@ -6,6 +6,7 @@
 #include <gkyl_util.h>
 #include <gkyl_eval_on_nodes.h>
 #include <gkyl_array_ops.h>
+#include <gkyl_array_rio.h>
 
 // Notes:
 //   a) Hard-coded parameters:
@@ -1977,7 +1978,18 @@ gkyl_bc_twistshift_advance(struct gkyl_bc_twistshift *up, struct gkyl_array *fdo
   }
 }
 
-void gkyl_bc_twistshift_release(struct gkyl_bc_twistshift *up) {
+struct gkyl_array*
+gkyl_bc_twistshift_get_shift_objects(struct gkyl_bc_twistshift *up, struct gkyl_rect_grid *shear_grid,
+  struct gkyl_range *shear_r, struct gkyl_basis *shift_b)
+{
+  *shear_grid = up->shear_grid;
+  *shear_r    = up->shear_r   ;
+  *shift_b    = up->shift_b   ;
+  return gkyl_array_acquire(up->shift_dg);
+};
+
+void
+gkyl_bc_twistshift_release(struct gkyl_bc_twistshift *up) {
   // Release memory associated with this updater.
   if (!up->use_gpu) {
     gkyl_free(up->num_do_cum);

--- a/gyrokinetic/zero/gkyl_bc_twistshift.h
+++ b/gyrokinetic/zero/gkyl_bc_twistshift.h
@@ -46,6 +46,20 @@ struct gkyl_bc_twistshift* gkyl_bc_twistshift_new(const struct gkyl_bc_twistshif
 void gkyl_bc_twistshift_advance(struct gkyl_bc_twistshift *up, struct gkyl_array *fdo, struct gkyl_array *ftar);
 
 /**
+ * Return pointers to the discretized shift, its range, and grid and basis.
+ *
+ * Pointer to shift_dg needs to be released with gkyl_array_release.
+ *
+ * @param up Twist-shift BC updater object.
+ * @param shear_grid Grid on which shift is defined.
+ * @param shear_r Range for the shift.
+ * @param shift_b Basis shift_dg coefficients are expanded on.
+ * @return Discretized shift.
+ */
+struct gkyl_array* gkyl_bc_twistshift_get_shift_objects(struct gkyl_bc_twistshift *up,
+  struct gkyl_rect_grid *shear_grid, struct gkyl_range *shear_r, struct gkyl_basis *shift_b);
+
+/**
  * Free memory associated with bc_twistshift updater.
  *
  * @param up BC updater.


### PR DESCRIPTION
Add a method in gk_field to write out the discrete shift for twist-shift BCs. We can use this for plotting 3x2v data that uses TS BCs in pgkyl and for development/debugging.

We also modified the rect_grid_write method so it can write out grid info to stdout/stderr like the gkyl_range_write method.