### PR TITLE
BUGFIX: wham_2xIC_3x2v regression test

### DIFF
--- a/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1.c
@@ -608,35 +608,11 @@ create_ctx(void)
   return ctx;
 }
 
-int main(int argc, char **argv)
+// Run the 2D simulation that generates the initial conditions.
+static void
+run_2x_sim(struct gk_mirror_ctx ctx, const struct gkyl_app_args app_args,
+  int *cells_x, int *cells_v, struct gkyl_comm *comm)
 {
-  struct gkyl_app_args app_args = parse_app_args(argc, argv);
-
-#ifdef GKYL_HAVE_MPI
-  if (app_args.use_mpi) MPI_Init(&argc, &argv);
-#endif
-
-  if (app_args.trace_mem) {
-    gkyl_cu_dev_mem_debug_set(true);
-    gkyl_mem_debug_set(true);
-  }
-
-  struct gk_mirror_ctx ctx = create_ctx(); // Context for init functions.
-
-  int cells_x[ctx.cdim], cells_v[ctx.vdim];
-  for (int d=0; d<ctx.cdim; d++)
-    cells_x[d] = APP_ARGS_CHOOSE(app_args.xcells[d], ctx.cells[d]);
-  for (int d=0; d<ctx.vdim; d++)
-    cells_v[d] = APP_ARGS_CHOOSE(app_args.vcells[d], ctx.cells[ctx.cdim+d]);
-
-  // Construct communicator for use in app.
-  struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, stderr);
-
-
-  // ...................................................... //
-  // 2D simulation to produce ICs.
-  // ...................................................... //
-
   struct gkyl_gyrokinetic_projection elc_ic = {
     .proj_id = GKYL_PROJ_BIMAXWELLIAN, 
     .ctx_density = &ctx,
@@ -848,7 +824,37 @@ int main(int argc, char **argv)
   };
 
   gkyl_gyrokinetic_run_simulation(&run_inp_2x);
+}
 
+// Run the 3D simulation using the final frame of the 2D sim as IC.
+static void
+run_3x_sim(struct gk_mirror_ctx ctx, const struct gkyl_app_args app_args,
+  int *cells_x, int *cells_v, struct gkyl_comm *comm)
+{
+  // Recreate projection ICs for use in boundary conditions.
+  struct gkyl_gyrokinetic_projection elc_ic = {
+    .proj_id = GKYL_PROJ_BIMAXWELLIAN, 
+    .ctx_density = &ctx,
+    .density = eval_density_elc,
+    .ctx_upar = &ctx,
+    .upar= eval_upar_elc,
+    .ctx_temppar = &ctx,
+    .temppar = eval_temp_par_elc,      
+    .ctx_tempperp = &ctx,
+    .tempperp = eval_temp_perp_elc,   
+  };
+
+  struct gkyl_gyrokinetic_projection ion_ic = {
+    .proj_id = GKYL_PROJ_BIMAXWELLIAN, 
+    .ctx_density = &ctx,
+    .density = eval_density_ion,
+    .ctx_upar = &ctx,
+    .upar= eval_upar_ion,
+    .ctx_temppar = &ctx,
+    .temppar = eval_temp_par_ion,      
+    .ctx_tempperp = &ctx,
+    .tempperp = eval_temp_perp_ion,   
+  };
 
   // ...................................................... //
   // 3D simulation using final frame of 2D sim as IC.
@@ -962,6 +968,15 @@ int main(int argc, char **argv)
   };
 
   // GK app
+  struct gkyl_mirror_geo_grid_inp grid_inp = {
+    .filename_psi = "gyrokinetic/data/unit/wham_hires.geqdsk_psi.gkyl",
+    .rclose = 0.2,
+    .zmin = -2.0,
+    .zmax =  2.0,
+    .include_axis = false,
+    .fl_coord = GKYL_GEOMETRY_MIRROR_GRID_GEN_SQRT_PSI_CART_Z,
+  };
+
   struct gkyl_gk app_inp_3x = {
     .name = "gk_wham_2xIC_3x2v_p1",
     .cdim = ctx.cdim,
@@ -1007,6 +1022,34 @@ int main(int argc, char **argv)
   };
 
   gkyl_gyrokinetic_run_simulation(&run_inp3x);
+}
+
+int main(int argc, char **argv)
+{
+  struct gkyl_app_args app_args = parse_app_args(argc, argv);
+
+#ifdef GKYL_HAVE_MPI
+  if (app_args.use_mpi) MPI_Init(&argc, &argv);
+#endif
+
+  if (app_args.trace_mem) {
+    gkyl_cu_dev_mem_debug_set(true);
+    gkyl_mem_debug_set(true);
+  }
+
+  struct gk_mirror_ctx ctx = create_ctx(); // Context for init functions.
+
+  int cells_x[ctx.cdim], cells_v[ctx.vdim];
+  for (int d=0; d<ctx.cdim; d++)
+    cells_x[d] = APP_ARGS_CHOOSE(app_args.xcells[d], ctx.cells[d]);
+  for (int d=0; d<ctx.vdim; d++)
+    cells_v[d] = APP_ARGS_CHOOSE(app_args.vcells[d], ctx.cells[ctx.cdim+d]);
+
+  // Construct communicator for use in app.
+  struct gkyl_comm *comm = gkyl_gyrokinetic_comms_new(app_args.use_mpi, app_args.use_gpu, stderr);
+
+  run_2x_sim(ctx, app_args, cells_x, cells_v, comm);
+  run_3x_sim(ctx, app_args, cells_x, cells_v, comm);
 
   gkyl_gyrokinetic_comms_release(comm);
 


### PR DESCRIPTION
Small change for this regression test. It was segfaulting on main and it seemed to be a stack overflow issue. 
``` bash
gdb ./build/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1
GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./build/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1...
(gdb) r
Starting program: /home/maxwell-rosen/gkeyll/build/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
warning: could not find '.gnu_debugaltlink' file for /lib/x86_64-linux-gnu/libcap.so.2

Program received signal SIGSEGV, Segmentation fault.
0x0000555555556e4b in parse_app_args (argc=1, argv=0x7fffffffd358) at creg/rt_arg_parse.h:87
87        struct gkyl_app_args args = {
(gdb) bt
#0  0x0000555555556e4b in parse_app_args (argc=1, argv=0x7fffffffd358) at creg/rt_arg_parse.h:87
#1  main (argc=1, argv=0x7fffffffd358) at creg/rt_gk_wham_2xIC_3x2v_p1.c:613
```

It's fixed now
``` bash
./build/gyrokinetic/creg/rt_gk_wham_2xIC_3x2v_p1

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Number of write calls 4
Timing:
  - Time loop:                         2.4466e-01 sec.
    * Forward Euler:                   2.3707e-01 sec. / 96.90 %.
      ^ Collision moments (charged):   5.6956e-03 sec. / 2.40 %.
      ^ Reaction moments (charged):    0.0000e+00 sec. / 0.00 %.
      ^ Collision moments (neutral):   0.0000e+00 sec. / 0.00 %.
      ^ Reaction moments (neutral):    0.0000e+00 sec. / 0.00 %.
      ^ Radiation moments:             0.0000e+00 sec. / 0.00 %.
      ^ Species gyroaverage:           3.9000e-07 sec. / 0.00 %.
      ^ Species LTE:                   0.0000e+00 sec. / 0.00 %.
      ^ Collisionless terms (charged): 1.1562e-01 sec. / 48.77 %.
      ^ Collision terms (charged):     1.0652e-01 sec. / 44.93 %.
      ^ Damping (charged):             0.0000e+00 sec. / 0.00 %.
      ^ df/dt multiplier (charged):    3.0360e-06 sec. / 0.00 %.
      ^ Diffusion (charged):           0.0000e+00 sec. / 0.00 %.
      ^ Radiation terms:               0.0000e+00 sec. / 0.00 %.
      ^ Reaction terms (charged):      0.0000e+00 sec. / 0.00 %.
      ^ Boundary fluxes (charged):     0.0000e+00 sec. / 0.00 %.
      ^ omega_cfl (charged):           3.3387e-03 sec. / 1.41 %.
      ^ Sources (charged):             2.2246e-03 sec. / 0.94 %.
      ^ Heating (charged):             0.0000e+00 sec. / 0.00 %.
      ^ Collisionless terms (neutral): 0.0000e+00 sec. / 0.00 %.
      ^ Species LTE (neutral):         0.0000e+00 sec. / 0.00 %.
      ^ Boundary fluxes (neutral):     0.0000e+00 sec. / 0.00 %.
      ^ Collision terms (neutral):     0.0000e+00 sec. / 0.00 %.
      ^ Reaction terms (neutral):      0.0000e+00 sec. / 0.00 %.
      ^ omega_cfl (neutral):           0.0000e+00 sec. / 0.00 %.
      ^ Sources (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Time step reduction:           2.1550e-06 sec. / 0.00 %.
      ^ Step f:                        2.4889e-03 sec. / 1.05 %.
      ^ Accounted for:                 99.50 %.
    * Field solves:                    4.1301e-03 sec. / 1.69 %.
      ^ Phi eqn RHS:                   3.2389e-03 sec. / 78.42 %.
      ^ Phi eqn solve:                 8.8584e-04 sec. / 21.45 %.
      ^ Accounted for:                 99.87 %.
    * Boundary conditions::            1.4526e-03 sec. / 0.59 %.
      ^ Species (charged):             2.1024e-03 sec. / 144.73 %.
      ^ Species (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 144.73 %.
    * Time rate diagnostics:           0.0000e+00 sec. / 0.00 %.
      ^ Charged species:               0.0000e+00 sec. / 0.00 %.
      ^ Phi:                           0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 100.00 %.
    * Positivity:                      0.0000e+00 sec. / 0.00 %.
      ^ Species (charged):             0.0000e+00 sec. / 0.00 %.
      ^ Species (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Quasineutrality:               0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 100.00 %.
    * Time stepper arithmetic:         3.7143e-03 sec. / 1.52 %.
    * Accounted for:                   100.70 %.
  - I/O:                               4.5413e-02 sec.
    * f write (charged):               6.9705e-03 sec. / 15.35 %.
    * Species diag calc (charged):     2.8788e-02 sec. / 63.39 %.
    * Species diag write (charged):    9.3151e-03 sec. / 20.51 %.
    * f write (neutral):               0.0000e+00 sec. / 0.00 %.
    * Species diag calc (neutral):     0.0000e+00 sec. / 0.00 %.
    * Species diag write (neutral):    0.0000e+00 sec. / 0.00 %.
    * Field write:                     1.7340e-04 sec. / 0.38 %.
    * Field diag calc:                 3.8421e-05 sec. / 0.08 %.
    * Field diag write:                6.9140e-05 sec. / 0.15 %.
    * Common write:                    5.8049e-05 sec. / 0.13 %.
    * Accounted for:                   100.00 %.

Number of update calls 1
Number of forward-Euler calls 3
Number of RK stage-2 failures 0
Number of RK stage-3 failures 0
Number of write calls 2
Timing:
  - Time loop:                         2.2322e+00 sec.
    * Forward Euler:                   2.1719e+00 sec. / 97.30 %.
      ^ Collision moments (charged):   2.2961e-02 sec. / 1.06 %.
      ^ Reaction moments (charged):    0.0000e+00 sec. / 0.00 %.
      ^ Collision moments (neutral):   0.0000e+00 sec. / 0.00 %.
      ^ Reaction moments (neutral):    0.0000e+00 sec. / 0.00 %.
      ^ Radiation moments:             0.0000e+00 sec. / 0.00 %.
      ^ Species gyroaverage:           3.2000e-07 sec. / 0.00 %.
      ^ Species LTE:                   0.0000e+00 sec. / 0.00 %.
      ^ Collisionless terms (charged): 1.3743e+00 sec. / 63.28 %.
      ^ Collision terms (charged):     7.1035e-01 sec. / 32.71 %.
      ^ Damping (charged):             0.0000e+00 sec. / 0.00 %.
      ^ df/dt multiplier (charged):    2.5150e-06 sec. / 0.00 %.
      ^ Diffusion (charged):           0.0000e+00 sec. / 0.00 %.
      ^ Radiation terms:               0.0000e+00 sec. / 0.00 %.
      ^ Reaction terms (charged):      0.0000e+00 sec. / 0.00 %.
      ^ Boundary fluxes (charged):     0.0000e+00 sec. / 0.00 %.
      ^ omega_cfl (charged):           1.0432e-02 sec. / 0.48 %.
      ^ Sources (charged):             1.6740e-06 sec. / 0.00 %.
      ^ Heating (charged):             0.0000e+00 sec. / 0.00 %.
      ^ Collisionless terms (neutral): 0.0000e+00 sec. / 0.00 %.
      ^ Species LTE (neutral):         0.0000e+00 sec. / 0.00 %.
      ^ Boundary fluxes (neutral):     0.0000e+00 sec. / 0.00 %.
      ^ Collision terms (neutral):     0.0000e+00 sec. / 0.00 %.
      ^ Reaction terms (neutral):      0.0000e+00 sec. / 0.00 %.
      ^ omega_cfl (neutral):           0.0000e+00 sec. / 0.00 %.
      ^ Sources (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Time step reduction:           2.0150e-06 sec. / 0.00 %.
      ^ Step f:                        3.8363e-02 sec. / 1.77 %.
      ^ Accounted for:                 99.29 %.
    * Field solves:                    1.0794e-02 sec. / 0.48 %.
      ^ Phi eqn RHS:                   1.0082e-02 sec. / 93.40 %.
      ^ Phi eqn solve:                 7.0823e-04 sec. / 6.56 %.
      ^ Accounted for:                 99.97 %.
    * Boundary conditions::            1.6023e-02 sec. / 0.72 %.
      ^ Species (charged):             2.3122e-02 sec. / 144.31 %.
      ^ Species (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 144.31 %.
    * Time rate diagnostics:           0.0000e+00 sec. / 0.00 %.
      ^ Charged species:               0.0000e+00 sec. / 0.00 %.
      ^ Phi:                           0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 100.00 %.
    * Positivity:                      0.0000e+00 sec. / 0.00 %.
      ^ Species (charged):             0.0000e+00 sec. / 0.00 %.
      ^ Species (neutral):             0.0000e+00 sec. / 0.00 %.
      ^ Quasineutrality:               0.0000e+00 sec. / 0.00 %.
      ^ Accounted for:                 100.00 %.
    * Time stepper arithmetic:         3.6489e-02 sec. / 1.63 %.
    * Accounted for:                   100.14 %.
  - I/O:                               7.3206e-02 sec.
    * f write (charged):               2.4874e-02 sec. / 33.98 %.
    * Species diag calc (charged):     4.6840e-02 sec. / 63.98 %.
    * Species diag write (charged):    1.2877e-03 sec. / 1.76 %.
    * f write (neutral):               0.0000e+00 sec. / 0.00 %.
    * Species diag calc (neutral):     0.0000e+00 sec. / 0.00 %.
    * Species diag write (neutral):    0.0000e+00 sec. / 0.00 %.
    * Field write:                     1.3265e-04 sec. / 0.18 %.
    * Field diag calc:                 2.6049e-05 sec. / 0.04 %.
    * Field diag write:                2.5278e-05 sec. / 0.03 %.
    * Common write:                    2.0078e-05 sec. / 0.03 %.
    * Accounted for:                   100.00 %.
 ```