### PR TITLE
SUPERHOT FIX: valgrind sanitize a few unit tests

### DIFF
--- a/gyrokinetic/unit/ctest_asdex.c
+++ b/gyrokinetic/unit/ctest_asdex.c
@@ -209,6 +209,7 @@ test_fixed_z()
 
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
@@ -282,6 +283,7 @@ test_shaped_plate()
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   //write_geometry(up, cgrid, cbasis, clocal, "asdex");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
@@ -354,6 +356,7 @@ test_lower()
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   //write_geometry(up, cgrid, cbasis, clocal, "asdexlo");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
@@ -426,6 +429,7 @@ test_middle()
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   //write_geometry(up, cgrid, cbasis, clocal, "asdexmid");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
@@ -498,6 +502,7 @@ test_upper()
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   //write_geometry(up, cgrid, cbasis, clocal, "asdexup");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;

--- a/gyrokinetic/unit/ctest_bc_twistshift.c
+++ b/gyrokinetic/unit/ctest_bc_twistshift.c
@@ -807,6 +807,7 @@ test_bc_twistshift_3x2v_fig6_wcells(const int *cells, enum gkyl_edge_loc edge,
   gkyl_dg_updater_moment_gyrokinetic_release(mcalc);
   gkyl_array_release(marr);
   gkyl_gk_geometry_release(gk_geom);
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(buff_per);
   test_bc_twistshift_array_meta_release(mt);
@@ -1602,6 +1603,7 @@ test_bc_twistshift_3x2v_fig11_wcells(const int *cells, enum gkyl_edge_loc edge,
   gkyl_dg_updater_moment_gyrokinetic_release(mcalc);
   gkyl_array_release(marr);
   gkyl_gk_geometry_release(gk_geom);
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(buff_per);
   test_bc_twistshift_array_meta_release(mt);

--- a/gyrokinetic/unit/ctest_correct_maxwellian_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_correct_maxwellian_gyrokinetic.c
@@ -324,7 +324,8 @@ void test_1x1v(int poly_order, bool use_gpu)
   }
  
   // Release memory for moment data object
-  gkyl_gk_geometry_release(gk_geom);  
+  gkyl_gk_geometry_release(gk_geom); 
+  gkyl_position_map_release(pmap); 
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(m0_in);
   gkyl_array_release(m1_in);
@@ -583,6 +584,7 @@ void test_1x2v(int poly_order, bool use_gpu)
 
   // Release memory for moment data object
   gkyl_gk_geometry_release(gk_geom);  
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(m0_in);
   gkyl_array_release(m1_in);
@@ -843,6 +845,7 @@ void test_2x2v(int poly_order, bool use_gpu)
 
   // Release memory for moment data object
   gkyl_gk_geometry_release(gk_geom);  
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(m0_in);
   gkyl_array_release(m1_in);

--- a/gyrokinetic/unit/ctest_dg_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_dg_gyrokinetic.c
@@ -123,6 +123,7 @@ test_dg_gyrokinetic()
   TEST_CHECK( gyrokinetic->conf_range.volume == 512 );
 
   gkyl_gk_geometry_release(gk_geom);  
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_dg_eqn_release(eqn);
 }

--- a/gyrokinetic/unit/ctest_dg_gyrokinetic_kern_tm.c
+++ b/gyrokinetic/unit/ctest_dg_gyrokinetic_kern_tm.c
@@ -155,6 +155,7 @@ test_3x2v_p1(bool use_gpu)
 
   // clean up
   gkyl_gk_geometry_release(gk_geom);  
+  gkyl_position_map_release(pmap);
   gkyl_velocity_map_release(gvm);
   gkyl_array_release(fin);
   gkyl_array_release(rhs);

--- a/gyrokinetic/unit/ctest_dg_interpolate.c
+++ b/gyrokinetic/unit/ctest_dg_interpolate.c
@@ -888,6 +888,7 @@ static struct gk_geometry* init_gk_geo(int poly_order, struct gkyl_rect_grid con
     gk_geom = gkyl_gk_geometry_acquire(gk_geom_dev);
     gkyl_gk_geometry_release(gk_geom_dev);
   }
+  gkyl_position_map_release(pmap);
   return gk_geom;
 }
 

--- a/gyrokinetic/unit/ctest_dg_rad_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_dg_rad_gyrokinetic.c
@@ -437,6 +437,7 @@ test_1x(int poly_order, bool use_gpu, double te, int atomic_z,
   }
 
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
   gkyl_gk_geometry_release(gk_geom);
 }
 
@@ -779,6 +780,7 @@ test_2x(int poly_order, bool use_gpu, double te)
   }
 
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
   gkyl_gk_geometry_release(gk_geom);
 }
 

--- a/gyrokinetic/unit/ctest_gk_geometry_mapc2p.c
+++ b/gyrokinetic/unit/ctest_gk_geometry_mapc2p.c
@@ -320,6 +320,7 @@ test_3x_p1()
   gkyl_array_release(gij_nodal);
   gkyl_nodal_ops_release(n2m);
   gkyl_gk_geometry_release(gk_geom);
+  gkyl_position_map_release(pmap);
 }
 
 void

--- a/gyrokinetic/unit/ctest_gk_geometry_mirror.c
+++ b/gyrokinetic/unit/ctest_gk_geometry_mirror.c
@@ -147,6 +147,7 @@ test_load_geometry()
   struct gk_geometry* up = gkyl_gk_geometry_mirror_new(&geometry_inp); 
   //write_geometry(up, cgrid, clocal, "whamlores");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;

--- a/gyrokinetic/unit/ctest_gk_geometry_tok.c
+++ b/gyrokinetic/unit/ctest_gk_geometry_tok.c
@@ -157,6 +157,7 @@ test_elliptical()
 
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
@@ -607,6 +608,7 @@ test_3x_p1_straight_cylinder()
   gkyl_array_release(mc2nu_pos_nodal);
   gkyl_array_release(normals_nodal);
   gkyl_nodal_ops_release(n2m);
+  gkyl_position_map_release(pmap);
   gkyl_gk_geometry_release(gk_geom);
 }
 

--- a/gyrokinetic/unit/ctest_integrated_moms.c
+++ b/gyrokinetic/unit/ctest_integrated_moms.c
@@ -298,6 +298,7 @@ test_2x_option(bool use_gpu)
 
   gkyl_dg_updater_moment_gyrokinetic_release(mcalc);
   gkyl_gk_geometry_release(gk_geom);
+  gkyl_position_map_release(pmap);
 }
 
 void test_2x() { test_2x_option(false); }

--- a/gyrokinetic/unit/ctest_loss_cone_mask_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_loss_cone_mask_gyrokinetic.c
@@ -397,6 +397,7 @@ test_1x2v_gk(int poly_order, bool use_gpu)
   gkyl_loss_cone_mask_gyrokinetic_release(proj_mask);
   gkyl_velocity_map_release(gvm);
   gkyl_gk_geometry_release(gk_geom);
+  gkyl_position_map_release(pmap);
 
 #ifdef GKYL_HAVE_CUDA
   if (use_gpu) {

--- a/gyrokinetic/unit/ctest_ltx_miller.c
+++ b/gyrokinetic/unit/ctest_ltx_miller.c
@@ -147,6 +147,7 @@ test_ltx_miller()
   struct gk_geometry* up = gkyl_gk_geometry_tok_new(&geometry_inp); 
   write_geometry(up, cgrid, cbasis, clocal, "ltx_miller");
   gkyl_gk_geometry_release(up);
+  gkyl_position_map_release(pmap);
 
   end = clock();
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;

--- a/gyrokinetic/unit/ctest_mom_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_mom_gyrokinetic.c
@@ -160,6 +160,7 @@ test_mom_gyrokinetic()
   gkyl_mom_type_release(m2);
   gkyl_mom_type_release(m3par);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 }
 
 void distf_1x1v(double t, const double *xn, double* restrict fout, void *ctx)
@@ -437,6 +438,7 @@ test_1x1v(int polyOrder, bool use_gpu)
   gkyl_proj_on_basis_release(projDistf);
   gkyl_array_release(distf); gkyl_array_release(distf_ho);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 }
 
 void
@@ -670,6 +672,7 @@ test_1x2v(int poly_order, bool use_gpu)
   gkyl_proj_on_basis_release(projDistf);
   gkyl_array_release(distf); gkyl_array_release(distf_ho);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 }
 
 void
@@ -982,6 +985,7 @@ test_2x2v(int poly_order, bool use_gpu)
   gkyl_proj_on_basis_release(projDistf);
   gkyl_array_release(distf); gkyl_array_release(distf_ho);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 }
 
 void test_1x1v_p1() { test_1x1v(1, false); } 

--- a/gyrokinetic/unit/ctest_positivity_shift_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_positivity_shift_gyrokinetic.c
@@ -301,6 +301,7 @@ test_1x2v(int poly_order, bool use_gpu)
   gkyl_positivity_shift_gyrokinetic_release(pos_shift);
   gkyl_gk_geometry_release(gk_geom);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 }
 
 void test_1x2v_ho()

--- a/gyrokinetic/unit/ctest_proj_gk_bimaxwellian_on_basis.c
+++ b/gyrokinetic/unit/ctest_proj_gk_bimaxwellian_on_basis.c
@@ -205,6 +205,7 @@ test_1x2v_gk(int poly_order, bool use_gpu)
 
   // release memory for moment data object
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
   gkyl_gk_geometry_release(gk_geom);
   gkyl_array_release(prim_moms);
   gkyl_proj_on_basis_release(proj_prim_moms);
@@ -214,7 +215,6 @@ test_1x2v_gk(int poly_order, bool use_gpu)
     gkyl_array_release(distf_cu);
   }
   gkyl_gk_maxwellian_proj_on_basis_release(proj_max);
-  gkyl_velocity_map_release(gvm);
 }
 
 void test_1x2v_p1_gk() { test_1x2v_gk(1, false); }

--- a/gyrokinetic/unit/ctest_proj_gk_maxwellian_on_basis.c
+++ b/gyrokinetic/unit/ctest_proj_gk_maxwellian_on_basis.c
@@ -283,6 +283,7 @@ test_1x2v_gk(int poly_order, bool use_gpu)
   }
   gkyl_gk_maxwellian_proj_on_basis_release(proj_max);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 
 #ifdef GKYL_HAVE_CUDA
   if (use_gpu) {
@@ -608,6 +609,7 @@ test_3x2v_gk(int poly_order, bool use_gpu)
   }
   gkyl_gk_maxwellian_proj_on_basis_release(proj_max);
   gkyl_velocity_map_release(gvm);
+  gkyl_position_map_release(pmap);
 
   gkyl_array_release(moms);
   if (use_gpu) 

--- a/gyrokinetic/zero/position_map.c
+++ b/gyrokinetic/zero/position_map.c
@@ -31,11 +31,7 @@ gkyl_position_map_null_new()
 {
   struct gkyl_position_map *gpm = gkyl_malloc(sizeof(*gpm));
   gpm->id = GKYL_PMAP_USER_INPUT;
-  for (int i = 0; i < 3; i++){
-    gpm->maps[i] = gkyl_position_map_identity;
-    gpm->map_derivs[i] = gkyl_position_map_identity_slope;
-    gpm->ctxs[i] = 0;
-  }
+
   gpm->use_map_derivs = true;
   gpm->to_optimize = false;
   gpm->mc2nu = gkyl_array_new(GKYL_DOUBLE, 1, 1);
@@ -44,6 +40,16 @@ gkyl_position_map_null_new()
   gpm->bmag_ctx = gkyl_malloc(sizeof(struct gkyl_bmag_ctx));
   gpm->bmag_ctx->bmag = gkyl_array_new(GKYL_DOUBLE, 1, 1);
   gpm->ref_count = gkyl_ref_count_init(gkyl_position_map_free);
+  
+  for (int i = 0; i < 3; i++){
+    gpm->maps[i] = gkyl_position_map_identity;
+    gpm->map_derivs[i] = gkyl_position_map_identity_slope;
+    gpm->ctxs[i] = 0;
+    gpm->constB_ctx->maps_backup[i] = gkyl_position_map_identity;
+    gpm->constB_ctx->ctxs_backup[i] = 0;
+    gpm->xpt_ctx->maps_backup[i] = gkyl_position_map_identity;
+    gpm->xpt_ctx->ctxs_backup[i] = 0;
+  }
   return gpm;
 }
 


### PR DESCRIPTION
The update to the position map was not valgrind clean with respect to the position map. This is amended here. I fixed another small valgrind issue, but several GK unit tests are not valgrind clean to begin with, but it's not the position map now.