### PR TITLE
Remove self-species collisions from updates

### DIFF
--- a/gyrokinetic/apps/gk_species_lbo.c
+++ b/gyrokinetic/apps/gk_species_lbo.c
@@ -213,122 +213,129 @@ gk_species_lbo_init(struct gkyl_gyrokinetic_app *app, struct gk_species *gks, st
 {
   lbo->collision_id = gks->info.collisions.collision_id;
   lbo->write_diagnostics = gks->info.collisions.write_diagnostics;
+  lbo->do_not_add_to_dfdt = gks->info.collisions.do_not_add_to_dfdt;
 
   // Empty methods.
   lbo->moms_func = gklbo_moms_disabled;
   lbo->rhs_func = gklbo_rhs_disabled;
   lbo->write_mom_func = gklbo_write_mom_disabled;
 
-  if (lbo->collision_id == GKYL_LBO_COLLISIONS) {
-    lbo->num_cross_collisions = gks->info.collisions.num_cross_collisions;
-    
-    int cdim = app->cdim, vdim = gks->info.vdim;
+  if (lbo->collision_id != GKYL_LBO_COLLISIONS) {
+    return;
+  }
+
+  lbo->num_cross_collisions = gks->info.collisions.num_cross_collisions;
   
-    // Allocate self-species collision frequency and sum of collision frequencies.
-    lbo->self_nu = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
-    lbo->nu_sum = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+  int cdim = app->cdim, vdim = gks->info.vdim;
+
+  // Allocate self-species collision frequency and sum of collision frequencies.
+  lbo->self_nu = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+  lbo->nu_sum = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+
+  double nu_frac = gks->info.collisions.nu_frac ? gks->info.collisions.nu_frac : 1.0;
+
+  if (gks->info.collisions.self_nu) {
+    // Project user's self-species collision frequency.
+    lbo->norm_nu_self = false;
+
+    struct gkyl_array *self_nu_ho = mkarr(false, app->basis.num_basis, app->local_ext.volume);
+    gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(&app->grid, &app->basis,
+      app->poly_order+1, 1, gks->info.collisions.self_nu, gks->info.collisions.self_nu_ctx);
+    gkyl_proj_on_basis_advance(proj, 0.0, &app->local, self_nu_ho);
+    gkyl_proj_on_basis_release(proj);
+    gkyl_array_copy(lbo->self_nu, self_nu_ho);
+    gkyl_array_release(self_nu_ho);
+
+    gkyl_array_scale(lbo->self_nu, nu_frac);
+    gkyl_array_set(lbo->nu_sum, 1.0, lbo->self_nu);
+
+    // Set pointers to functions chosen at runtime.
+    lbo->self_nu_func = gklbo_self_nu_calc_constNu;
+  }
+  else {
+    // Self-collision frequency computed in time.
+    lbo->norm_nu_self = true;
+
+    double eps0 = gks->info.collisions.eps0 ? gks->info.collisions.eps0 : GKYL_EPSILON0;
+    double hbar = gks->info.collisions.hbar ? gks->info.collisions.hbar : GKYL_PLANCKS_CONSTANT_H/2/M_PI;
+    double eV = gks->info.collisions.eV ? gks->info.collisions.eV : GKYL_ELEMENTARY_CHARGE;
+    double bmag_ref = gks->info.collisions.bmag_ref ? gks->info.collisions.bmag_ref : app->bmag_ref;
+
+    // Compute a minimum representable temperature based on the smallest dv in the grid.
+    double dv_min[vdim];
+    gkyl_velocity_map_reduce_dv_range(gks->vel_map, GKYL_MIN, dv_min, gks->vel_map->local_vel);
+
+    double tpar_min = (gks->info.mass/6.0)*pow(dv_min[0],2);
+    double tperp_min = vdim>1 ? (bmag_ref/3.0)*dv_min[1] : tpar_min;
+    lbo->vtsq_min = (tpar_min + 2.0*tperp_min)/(3.0*gks->info.mass);
+
+    lbo->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->basis, app->poly_order+1,
+      1.0, 1.0, 1.0, app->use_gpu);
+
+    // We define nu_ss = nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s), with delta_ss = 2, 
+    // beta = 0. This gives a nu_ss that is arguably 2X smaller than it should be, but it's
+    // cheaper and yields an electron isotropization rate that agrees better with the FPO's.
+    lbo->norm_nu_fac_self = nu_frac * gkyl_calc_Morse_alpha_E_const(
+      gks->info.collisions.den_ref, gks->info.collisions.den_ref, 
+      gks->info.mass, gks->info.mass, gks->info.charge, gks->info.charge,
+      gks->info.collisions.temp_ref, gks->info.collisions.temp_ref, bmag_ref, eps0, hbar, eV);
+
+    // Set pointers to functions chosen at runtime.
+    lbo->self_nu_func = gklbo_self_nu_calc_normNu;
+  }
+
+  // Create moment calculator to get M0, M1, M2 for primitive moments.
+  gk_species_moment_init(app, gks, &lbo->moms, GKYL_F_MOMENT_M0M1M2, false);
+  lbo->nu_moms = mkarr(app->use_gpu, lbo->moms.marr->ncomp, lbo->moms.marr->size);
+
+  // Edge of velocity space corrections to momentum and energy.
+  lbo->bcorr_calc = gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(&gks->grid, 
+    &app->basis, &gks->basis, gks->info.mass, gks->vel_map, app->use_gpu);
   
-    double nu_frac = gks->info.collisions.nu_frac ? gks->info.collisions.nu_frac : 1.0;
-  
-    if (gks->info.collisions.self_nu) {
-      // Project user's self-species collision frequency.
-      lbo->norm_nu_self = false;
-  
-      struct gkyl_array *self_nu_ho = mkarr(false, app->basis.num_basis, app->local_ext.volume);
-      gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(&app->grid, &app->basis,
-        app->poly_order+1, 1, gks->info.collisions.self_nu, gks->info.collisions.self_nu_ctx);
-      gkyl_proj_on_basis_advance(proj, 0.0, &app->local, self_nu_ho);
-      gkyl_proj_on_basis_release(proj);
-      gkyl_array_copy(lbo->self_nu, self_nu_ho);
-      gkyl_array_release(self_nu_ho);
-  
-      gkyl_array_scale(lbo->self_nu, nu_frac);
-      gkyl_array_set(lbo->nu_sum, 1.0, lbo->self_nu);
-  
-      // Set pointers to functions chosen at runtime.
-      lbo->self_nu_func = gklbo_self_nu_calc_constNu;
+  // Primitive moment calculator.
+  lbo->coll_pcalc = gkyl_prim_lbo_gyrokinetic_calc_new(&gks->grid, 
+    &app->basis, &gks->basis, &app->local, app->use_gpu);
+
+  // Allocate boundary corrections for primitive mom calculation.
+  lbo->boundary_corrections = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);
+  lbo->nu_boundary_corrections = mkarr(app->use_gpu, lbo->boundary_corrections->ncomp, lbo->boundary_corrections->size);
+
+  // Primitive moments.
+  lbo->prim_moms = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);
+  lbo->nu_prim_moms = mkarr(app->use_gpu, lbo->prim_moms->ncomp, lbo->prim_moms->size);
+
+  // M2 of this species.
+  lbo->m2self = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+
+  // Host-side copy for I/O.
+  if (lbo->write_diagnostics) {
+    if (app->use_gpu) {
+      lbo->nu_sum_host = mkarr(false, lbo->nu_sum->ncomp, lbo->nu_sum->size);
+      lbo->nu_prim_moms_host = mkarr(false, lbo->nu_prim_moms->ncomp, lbo->nu_prim_moms->size);
     }
     else {
-      // Self-collision frequency computed in time.
-      lbo->norm_nu_self = true;
-  
-      double eps0 = gks->info.collisions.eps0 ? gks->info.collisions.eps0 : GKYL_EPSILON0;
-      double hbar = gks->info.collisions.hbar ? gks->info.collisions.hbar : GKYL_PLANCKS_CONSTANT_H/2/M_PI;
-      double eV = gks->info.collisions.eV ? gks->info.collisions.eV : GKYL_ELEMENTARY_CHARGE;
-      double bmag_ref = gks->info.collisions.bmag_ref ? gks->info.collisions.bmag_ref : app->bmag_ref;
-  
-      // Compute a minimum representable temperature based on the smallest dv in the grid.
-      double dv_min[vdim];
-      gkyl_velocity_map_reduce_dv_range(gks->vel_map, GKYL_MIN, dv_min, gks->vel_map->local_vel);
-  
-      double tpar_min = (gks->info.mass/6.0)*pow(dv_min[0],2);
-      double tperp_min = vdim>1 ? (bmag_ref/3.0)*dv_min[1] : tpar_min;
-      lbo->vtsq_min = (tpar_min + 2.0*tperp_min)/(3.0*gks->info.mass);
-  
-      lbo->spitzer_calc = gkyl_spitzer_coll_freq_new(&app->basis, app->poly_order+1,
-        1.0, 1.0, 1.0, app->use_gpu);
-
-      // We define nu_ss = nu_sr(r=s) = alpha_E/((delta_ss * (1+beta))*n_s), with delta_ss = 2, 
-      // beta = 0. This gives a nu_ss that is arguably 2X smaller than it should be, but it's
-      // cheaper and yields an electron isotropization rate that agrees better with the FPO's.
-      lbo->norm_nu_fac_self = nu_frac * gkyl_calc_Morse_alpha_E_const(
-        gks->info.collisions.den_ref, gks->info.collisions.den_ref, 
-        gks->info.mass, gks->info.mass, gks->info.charge, gks->info.charge,
-        gks->info.collisions.temp_ref, gks->info.collisions.temp_ref, bmag_ref, eps0, hbar, eV);
-  
-      // Set pointers to functions chosen at runtime.
-      lbo->self_nu_func = gklbo_self_nu_calc_normNu;
+      lbo->nu_sum_host = lbo->nu_sum;
+      lbo->nu_prim_moms_host = lbo->nu_prim_moms;
     }
-  
-    // Create moment calculator to get M0, M1, M2 for primitive moments.
-    gk_species_moment_init(app, gks, &lbo->moms, GKYL_F_MOMENT_M0M1M2, false);
-    lbo->nu_moms = mkarr(app->use_gpu, lbo->moms.marr->ncomp, lbo->moms.marr->size);
-  
-    // Edge of velocity space corrections to momentum and energy.
-    lbo->bcorr_calc = gkyl_mom_calc_bcorr_lbo_gyrokinetic_new(&gks->grid, 
-      &app->basis, &gks->basis, gks->info.mass, gks->vel_map, app->use_gpu);
-    
-    // Primitive moment calculator.
-    lbo->coll_pcalc = gkyl_prim_lbo_gyrokinetic_calc_new(&gks->grid, 
-      &app->basis, &gks->basis, &app->local, app->use_gpu);
-  
-    // Allocate boundary corrections for primitive mom calculation.
-    lbo->boundary_corrections = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);
-    lbo->nu_boundary_corrections = mkarr(app->use_gpu, lbo->boundary_corrections->ncomp, lbo->boundary_corrections->size);
-  
-    // Primitive moments.
-    lbo->prim_moms = mkarr(app->use_gpu, 2*app->basis.num_basis, app->local_ext.volume);
-    lbo->nu_prim_moms = mkarr(app->use_gpu, lbo->prim_moms->ncomp, lbo->prim_moms->size);
+  }
 
-    // M2 of this species.
-    lbo->m2self = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
-  
-    // Host-side copy for I/O.
-    if (lbo->write_diagnostics) {
-      if (app->use_gpu) {
-        lbo->nu_sum_host = mkarr(false, lbo->nu_sum->ncomp, lbo->nu_sum->size);
-        lbo->nu_prim_moms_host = mkarr(false, lbo->nu_prim_moms->ncomp, lbo->nu_prim_moms->size);
-      }
-      else {
-        lbo->nu_sum_host = lbo->nu_sum;
-        lbo->nu_prim_moms_host = lbo->nu_prim_moms;
-      }
-    }
-  
-    // LBO updater.
-    struct gkyl_dg_lbo_gyrokinetic_drag_auxfields drag_inp = { .nuSum = lbo->nu_sum, 
-      .nuPrimMomsSum = lbo->nu_prim_moms, .m2self = lbo->m2self };
-    struct gkyl_dg_lbo_gyrokinetic_diff_auxfields diff_inp = { .nuSum = lbo->nu_sum, 
-      .nuPrimMomsSum = lbo->nu_prim_moms, .m2self = lbo->m2self };
-    lbo->coll_slvr = gkyl_dg_updater_lbo_gyrokinetic_new(&gks->grid, 
-      &app->basis, &gks->basis, &app->local, &drag_inp, &diff_inp, gks->info.mass, 
-      app->gk_geom, gks->vel_map,  app->use_gpu);
+  // LBO updater.
+  struct gkyl_dg_lbo_gyrokinetic_drag_auxfields drag_inp = { .nuSum = lbo->nu_sum, 
+    .nuPrimMomsSum = lbo->nu_prim_moms, .m2self = lbo->m2self };
+  struct gkyl_dg_lbo_gyrokinetic_diff_auxfields diff_inp = { .nuSum = lbo->nu_sum, 
+    .nuPrimMomsSum = lbo->nu_prim_moms, .m2self = lbo->m2self };
+  lbo->coll_slvr = gkyl_dg_updater_lbo_gyrokinetic_new(&gks->grid, 
+    &app->basis, &gks->basis, &app->local, &drag_inp, &diff_inp, gks->info.mass, 
+    app->gk_geom, gks->vel_map,  app->use_gpu);
 
-    // Methods chosen at runtime.
-    lbo->moms_func = gklbo_moms_enabled;
-    lbo->rhs_func = gklbo_rhs_enabled;
-    if (lbo->write_diagnostics)
-      lbo->write_mom_func = gklbo_write_mom_enabled;
+  // Methods chosen at runtime.
+  lbo->moms_func = gklbo_moms_enabled;
+  lbo->rhs_func = gklbo_rhs_enabled;
+  if (lbo->write_diagnostics)
+    lbo->write_mom_func = gklbo_write_mom_enabled;
+
+  if (lbo->do_not_add_to_dfdt) {
+    lbo->rhs_func = gklbo_rhs_disabled;
   }
 }
 
@@ -339,122 +346,126 @@ gk_species_lbo_cross_init(struct gkyl_gyrokinetic_app *app, struct gk_species *g
   lbo->cross_nu_func = gklbo_cross_nu_calc_constNu;
   lbo->cross_moms_func = gklbo_cross_moms_disabled;
 
-  if (lbo->collision_id == GKYL_LBO_COLLISIONS) {
-    if (gks->lbo.num_cross_collisions) {
-      lbo->betaGreenep1 = 1.0; // Greene's beta factor + 1.
-      lbo->delta_sr = 2.0; // delta_sr free parameter.
-        
-      // Set pointers to species we cross-collide with.
-      int my_idx_in_other[GKYL_MAX_SPECIES];
-      for (int i=0; i<lbo->num_cross_collisions; ++i) {
-        lbo->collide_with[i] = gk_find_species(app, gks->info.collisions.collide_with[i]);
-        my_idx_in_other[i] = -1;
-        for (int j=0; j<lbo->collide_with[i]->lbo.num_cross_collisions; ++j) {
-          if (0 == strcmp(gks->info.name, lbo->collide_with[i]->info.collisions.collide_with[j])) {
-            my_idx_in_other[i] = j;
-            break;
-          }
-        }
-      }
+  if (lbo->collision_id != GKYL_LBO_COLLISIONS) {
+    return;
+  }
 
-      // Morse's alpha_E.
-      lbo->alpha_E = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
-      for (int i=0; i<lbo->num_cross_collisions; ++i) {
-        // Cross-species collision frequency, nu_sr.
-        lbo->cross_nu[i] = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
-        lbo->other_m[i] = lbo->collide_with[i]->info.mass;
-        lbo->other_prim_moms[i] = lbo->collide_with[i]->lbo.prim_moms;
-      }
+  if (gks->lbo.num_cross_collisions == 0) {
+    return;
+  }
 
-      double nu_frac = gks->info.collisions.nu_frac ? gks->info.collisions.nu_frac : 1.0;
-
-      // Compute the time-independent part of alpha_E.
-      double alpha_E_norm[GKYL_MAX_SPECIES] = {0.0};
-      for (int i=0; i<lbo->num_cross_collisions; ++i) {
-        double eps0 = gks->info.collisions.eps0 ? gks->info.collisions.eps0: GKYL_EPSILON0;
-        double hbar = gks->info.collisions.hbar ? gks->info.collisions.hbar: GKYL_PLANCKS_CONSTANT_H/2/M_PI;
-        double eV = gks->info.collisions.eV ? gks->info.collisions.eV: GKYL_ELEMENTARY_CHARGE;
-        double bmag_ref = gks->info.collisions.bmag_ref ? gks->info.collisions.bmag_ref : app->bmag_ref;
-        double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
-
-        alpha_E_norm[i] = nu_frac * gkyl_calc_Morse_alpha_E_const(
-          gks->info.collisions.den_ref, lbo->collide_with[i]->info.collisions.den_ref,
-          mass_self, mass_other, gks->info.charge, lbo->collide_with[i]->info.charge,
-          gks->info.collisions.temp_ref, lbo->collide_with[i]->info.collisions.temp_ref, bmag_ref, eps0, hbar, eV);
-      }
-
-      if (gks->info.collisions.cross_nu[0]) {
-        // Project user's cross-species collision frequency.
-        lbo->norm_nu_cross = false;
-
-        // Ensure the other species this collides with also provided self_nu and cross_nu.
-        for (int i=0; i<lbo->num_cross_collisions; ++i) {
-          assert(lbo->collide_with[i]->info.collisions.self_nu);
-          assert(lbo->collide_with[i]->info.collisions.cross_nu[my_idx_in_other[i]]);
-        }
-
-        struct gkyl_array *cross_nu_ho = mkarr(false, app->basis.num_basis, app->local_ext.volume);
-        for (int i=0; i<lbo->num_cross_collisions; ++i) {
-          gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(&app->grid, &app->basis,
-            app->poly_order+1, 1, gks->info.collisions.cross_nu[i], gks->info.collisions.cross_nu_ctx);
-          gkyl_proj_on_basis_advance(proj, 0.0, &app->local, cross_nu_ho);
-          gkyl_proj_on_basis_release(proj);
-          gkyl_array_copy(lbo->cross_nu[i], cross_nu_ho);
-
-          gkyl_array_scale(lbo->cross_nu[i], nu_frac);
-          gkyl_array_accumulate(lbo->nu_sum, 1.0, lbo->cross_nu[i]);
-
-          // Compute alpha_E using reference parameters.
-          assert(gks->info.collisions.den_ref);
-          assert(lbo->collide_with[i]->info.collisions.den_ref);
-          assert(gks->info.collisions.temp_ref);
-          assert(lbo->collide_with[i]->info.collisions.temp_ref);
-          double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
-          double den_s = gks->info.collisions.den_ref;
-          double den_r = lbo->collide_with[i]->info.collisions.den_ref;
-          double vtsq_s = gks->info.collisions.temp_ref/mass_self;
-          double vtsq_r = lbo->collide_with[i]->info.collisions.temp_ref/mass_other;
-
-          lbo->alpha_E_fac[i] = ( alpha_E_norm[i] * den_s * den_r / pow(sqrt(vtsq_s+vtsq_r),3.0) ) * pow(sqrt(2.0),app->cdim);
-        }
-        gkyl_array_release(cross_nu_ho);
-
-        // Set pointers to functions chosen at runtime.
-        lbo->cross_nu_func = gklbo_cross_nu_calc_constNu;
-        lbo->alpha_E_func = gklbo_alpha_E_constNu;
-      }
-      else {
-        // Cross-collision frequency computed in time.
-        lbo->norm_nu_cross = true;
-
-        // Ensure the other species this collides with didn't provide self_nu nor cross_nu.
-        for (int i=0; i<lbo->num_cross_collisions; ++i) {
-          assert(!(lbo->collide_with[i]->info.collisions.self_nu));
-          assert(!(lbo->collide_with[i]->info.collisions.cross_nu[my_idx_in_other[i]]));
-        }
-
-        for (int i=0; i<lbo->num_cross_collisions; ++i) {
-          double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
-
-          lbo->norm_nu_fac_cross[i] = alpha_E_norm[i]
-            * (mass_self+mass_other)/(lbo->delta_sr*lbo->betaGreenep1*mass_self);
-
-          lbo->alpha_E_fac[i] = (lbo->delta_sr*lbo->betaGreenep1*mass_self)/(mass_self+mass_other);
-        }
+  lbo->betaGreenep1 = 1.0; // Greene's beta factor + 1.
+  lbo->delta_sr = 2.0; // delta_sr free parameter.
     
-        // Set pointers to functions chosen at runtime.
-        lbo->cross_nu_func = gklbo_cross_nu_calc_normNu;
-        lbo->alpha_E_func = gklbo_alpha_E_normNu;
+  // Set pointers to species we cross-collide with.
+  int my_idx_in_other[GKYL_MAX_SPECIES];
+  for (int i=0; i<lbo->num_cross_collisions; ++i) {
+    lbo->collide_with[i] = gk_find_species(app, gks->info.collisions.collide_with[i]);
+    my_idx_in_other[i] = -1;
+    for (int j=0; j<lbo->collide_with[i]->lbo.num_cross_collisions; ++j) {
+      if (0 == strcmp(gks->info.name, lbo->collide_with[i]->info.collisions.collide_with[j])) {
+        my_idx_in_other[i] = j;
+        break;
       }
-
-      // Cross-primitive moment calculator.
-      lbo->cross_calc = gkyl_prim_lbo_gyrokinetic_cross_calc_new(&gks->grid, 
-        &app->basis, &gks->basis, &app->local, app->use_gpu);
-
-      // Methods chosen at runtime.
-      lbo->cross_moms_func = gklbo_cross_moms_enabled;
     }
   }
+
+  // Morse's alpha_E.
+  lbo->alpha_E = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+  for (int i=0; i<lbo->num_cross_collisions; ++i) {
+    // Cross-species collision frequency, nu_sr.
+    lbo->cross_nu[i] = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
+    lbo->other_m[i] = lbo->collide_with[i]->info.mass;
+    lbo->other_prim_moms[i] = lbo->collide_with[i]->lbo.prim_moms;
+  }
+
+  double nu_frac = gks->info.collisions.nu_frac ? gks->info.collisions.nu_frac : 1.0;
+
+  // Compute the time-independent part of alpha_E.
+  double alpha_E_norm[GKYL_MAX_SPECIES] = {0.0};
+  for (int i=0; i<lbo->num_cross_collisions; ++i) {
+    double eps0 = gks->info.collisions.eps0 ? gks->info.collisions.eps0: GKYL_EPSILON0;
+    double hbar = gks->info.collisions.hbar ? gks->info.collisions.hbar: GKYL_PLANCKS_CONSTANT_H/2/M_PI;
+    double eV = gks->info.collisions.eV ? gks->info.collisions.eV: GKYL_ELEMENTARY_CHARGE;
+    double bmag_ref = gks->info.collisions.bmag_ref ? gks->info.collisions.bmag_ref : app->bmag_ref;
+    double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
+
+    alpha_E_norm[i] = nu_frac * gkyl_calc_Morse_alpha_E_const(
+      gks->info.collisions.den_ref, lbo->collide_with[i]->info.collisions.den_ref,
+      mass_self, mass_other, gks->info.charge, lbo->collide_with[i]->info.charge,
+      gks->info.collisions.temp_ref, lbo->collide_with[i]->info.collisions.temp_ref, bmag_ref, eps0, hbar, eV);
+  }
+
+  if (gks->info.collisions.cross_nu[0]) {
+    // Project user's cross-species collision frequency.
+    lbo->norm_nu_cross = false;
+
+    // Ensure the other species this collides with also provided self_nu and cross_nu.
+    for (int i=0; i<lbo->num_cross_collisions; ++i) {
+      assert(lbo->collide_with[i]->info.collisions.self_nu);
+      assert(lbo->collide_with[i]->info.collisions.cross_nu[my_idx_in_other[i]]);
+    }
+
+    struct gkyl_array *cross_nu_ho = mkarr(false, app->basis.num_basis, app->local_ext.volume);
+    for (int i=0; i<lbo->num_cross_collisions; ++i) {
+      gkyl_proj_on_basis *proj = gkyl_proj_on_basis_new(&app->grid, &app->basis,
+        app->poly_order+1, 1, gks->info.collisions.cross_nu[i], gks->info.collisions.cross_nu_ctx);
+      gkyl_proj_on_basis_advance(proj, 0.0, &app->local, cross_nu_ho);
+      gkyl_proj_on_basis_release(proj);
+      gkyl_array_copy(lbo->cross_nu[i], cross_nu_ho);
+
+      gkyl_array_scale(lbo->cross_nu[i], nu_frac);
+      gkyl_array_accumulate(lbo->nu_sum, 1.0, lbo->cross_nu[i]);
+
+      // Compute alpha_E using reference parameters.
+      assert(gks->info.collisions.den_ref);
+      assert(lbo->collide_with[i]->info.collisions.den_ref);
+      assert(gks->info.collisions.temp_ref);
+      assert(lbo->collide_with[i]->info.collisions.temp_ref);
+      double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
+      double den_s = gks->info.collisions.den_ref;
+      double den_r = lbo->collide_with[i]->info.collisions.den_ref;
+      double vtsq_s = gks->info.collisions.temp_ref/mass_self;
+      double vtsq_r = lbo->collide_with[i]->info.collisions.temp_ref/mass_other;
+
+      lbo->alpha_E_fac[i] = ( alpha_E_norm[i] * den_s * den_r / pow(sqrt(vtsq_s+vtsq_r),3.0) ) * pow(sqrt(2.0),app->cdim);
+    }
+    gkyl_array_release(cross_nu_ho);
+
+    // Set pointers to functions chosen at runtime.
+    lbo->cross_nu_func = gklbo_cross_nu_calc_constNu;
+    lbo->alpha_E_func = gklbo_alpha_E_constNu;
+  }
+  else {
+    // Cross-collision frequency computed in time.
+    lbo->norm_nu_cross = true;
+
+    // Ensure the other species this collides with didn't provide self_nu nor cross_nu.
+    for (int i=0; i<lbo->num_cross_collisions; ++i) {
+      assert(!(lbo->collide_with[i]->info.collisions.self_nu));
+      assert(!(lbo->collide_with[i]->info.collisions.cross_nu[my_idx_in_other[i]]));
+    }
+
+    for (int i=0; i<lbo->num_cross_collisions; ++i) {
+      double mass_self = gks->info.mass, mass_other = lbo->collide_with[i]->info.mass;
+
+      lbo->norm_nu_fac_cross[i] = alpha_E_norm[i]
+        * (mass_self+mass_other)/(lbo->delta_sr*lbo->betaGreenep1*mass_self);
+
+      lbo->alpha_E_fac[i] = (lbo->delta_sr*lbo->betaGreenep1*mass_self)/(mass_self+mass_other);
+    }
+
+    // Set pointers to functions chosen at runtime.
+    lbo->cross_nu_func = gklbo_cross_nu_calc_normNu;
+    lbo->alpha_E_func = gklbo_alpha_E_normNu;
+  }
+
+  // Cross-primitive moment calculator.
+  lbo->cross_calc = gkyl_prim_lbo_gyrokinetic_cross_calc_new(&gks->grid, 
+    &app->basis, &gks->basis, &app->local, app->use_gpu);
+
+  // Methods chosen at runtime.
+  lbo->cross_moms_func = gklbo_cross_moms_enabled;
 }
 
 void

--- a/gyrokinetic/apps/gkyl_gyrokinetic.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic.h
@@ -84,6 +84,8 @@ struct gkyl_gyrokinetic_collisionless {
 struct gkyl_gyrokinetic_collisions {
   enum gkyl_collision_id collision_id; // type of collisions (see gkyl_eqn_type.h)
   bool write_diagnostics; // Whether to output diagnostics.
+  bool do_not_add_to_dfdt; // If true, the collision operator will not be added to df/dt.
+    // Used to ignore the collisional updates of this species, while updating cross-species collisions.
 
   double nu_frac; // Rescales collision frequencies (default = 1).
 


### PR DESCRIPTION
Responding to #967, I'm adding an option to remove species collisions from the dfdt update and CFL calculation.

The large number of lines changed is because this function was wrapped in a giant if statement, which is a fail condition and can be refactored to the top of the file, reducing the layering and indenting. 

To condense the changes, the meaningful thing that this flag does is set
```
  if (lbo->do_not_add_to_dfdt) {
    lbo->rhs_func = gklbo_rhs_disabled;
  }
```
Disabling the RHS still means the cross moments are computed, but `gkyl_dg_updater_lbo_gyrokinetic_advance` is not called to advance the CFL rate. We still want to call `gkyl_prim_lbo_cross_calc_advance` because this is the object that evaluates the moments used for cross-species collisions, which we need for other species.