### PR TITLE
[microfix] add a condition for cdim to be 3 to write the shift in GK field 3x2v 

### DIFF
--- a/gyrokinetic/apps/gk_field_2x3x.c
+++ b/gyrokinetic/apps/gk_field_2x3x.c
@@ -124,7 +124,8 @@ gk_field_2x3x_add_TSBC_and_SSFG_updaters(struct gkyl_gyrokinetic_app *app, struc
     app->basis, &app->lower_skin_par_core,  &app->lower_ghost_par_core, app->use_gpu);
 
   // Write the discrete shift to file.
-  gk_field_2x3x_write_twistshift(app, f);
+  if (app->cdim == 3)
+    gk_field_2x3x_write_twistshift(app, f);
 }
 
 static void


### PR DESCRIPTION
The 2x2v GK regression test are segfaulting since the merge of the write twist-shift function because if `cdim==2`, the `bc_sheath` updater is not allocated so `gk_field_2x3x_write_twistshift` is looking for unallocated arrays.

This PR just add condition for `cdim==3`. We could also remove the condition and make `gk_field_2x3x_write_twistshift` to be deactivated but since it is called only at the initial state I think that this would be an overkill.