### PR TITLE
HOTFIX: remove mc2nu mapping inside loss cone updater on CPU

### DIFF
--- a/gyrokinetic/zero/loss_cone_mask_gyrokinetic.c
+++ b/gyrokinetic/zero/loss_cone_mask_gyrokinetic.c
@@ -18,15 +18,6 @@
 //          = 0.5*mass*pow(vpar,2)/(bmag_max-bmag[0]) + charge*(phi-phi_m)/(bmag_max-bmag[0]);
 //
 
-// Identity comp to phys coord mapping, for when user doesn't provide a map.
-static inline void
-c2p_pos_identity(const double *xcomp, double *xphys, void *ctx)
-{
-  struct gkyl_loss_cone_mask_gyrokinetic *up = ctx;
-  int cdim = up->cdim;
-  for (int d=0; d<cdim; d++) xphys[d] = xcomp[d];
-}
-
 // create range to loop over quadrature points.
 static inline struct gkyl_range
 get_qrange(int cdim, int dim, int num_quad, int num_quad_v, bool *is_vdim_p2)
@@ -216,15 +207,6 @@ gkyl_loss_cone_mask_gyrokinetic_inew(const struct gkyl_loss_cone_mask_gyrokineti
     up->num_basis_phase = inp->phase_basis->num_basis;
   }
   up->use_gpu = inp->use_gpu;
-
-  if (inp->c2p_pos_func == 0) {
-    up->c2p_pos = c2p_pos_identity;
-    up->c2p_pos_ctx = up;
-  }
-  else {
-    up->c2p_pos = inp->c2p_pos_func;
-    up->c2p_pos_ctx = inp->c2p_pos_func_ctx;
-  }
 
   // Initialize data needed for conf-space quadrature.
   up->tot_quad_conf = init_quad_values(up->cdim, inp->conf_basis, inp->qtype, num_quad,
@@ -437,7 +419,6 @@ gkyl_loss_cone_mask_gyrokinetic_advance(gkyl_loss_cone_mask_gyrokinetic *up,
         // Convert comp position coordinate to phys pos coord.
         gkyl_rect_grid_cell_center(up->grid_phase, pidx, xc);
         log_to_comp(up->cdim, xcomp_d, up->grid_phase->dx, xc, xmu);
-        up->c2p_pos(xmu, xmu, up->c2p_pos_ctx);
 
         // Convert comp velocity coordinate to phys velocity coord.
         const struct gkyl_velocity_map *gvm = up->vel_map;

--- a/gyrokinetic/zero/loss_cone_mask_gyrokinetic_cu.cu
+++ b/gyrokinetic/zero/loss_cone_mask_gyrokinetic_cu.cu
@@ -146,7 +146,6 @@ gkyl_loss_cone_mask_gyrokinetic_ker(struct gkyl_rect_grid grid_phase,
 
       // Convert comp position coordinate to phys pos coord.
       log_to_comp(cdim, xcomp_d, grid_phase.dx, xc, xmu);
-//      up->c2p_pos(xmu, xmu, up->c2p_pos_ctx);
   
       // Convert comp velocity coordinate to phys velocity coord.
       double xcomp[1];
@@ -213,7 +212,6 @@ gkyl_loss_cone_mask_gyrokinetic_quad_ker(struct gkyl_rect_grid grid_phase,
     // Convert comp position coordinate to phys pos coord.
     gkyl_rect_grid_cell_center(&grid_phase, pidx, xc);
     log_to_comp(cdim, xcomp_d, grid_phase.dx, xc, xmu);
-//    up->c2p_pos(xmu, xmu, up->c2p_pos_ctx);
 
     // Convert comp velocity coordinate to phys velocity coord.
     double xcomp[1];


### PR DESCRIPTION
The c2p here should not be there. The c2p is used to convert xn into physical coordinates. This is wrong in space, but okay in velocity, because the magnetic field maximum is found in computational coordinates, so it should be compared against computational coordinates. Code compiles. This isn't the cleanest version, but I will clean it up more in the gk-oap-2x-tandem-kinetic branch.

Code compiles on linux CPU laptop

The location of maximum B is computed here. Note that there is a log_to_comp, but there is no mc2nu function or non-uniform mapping.
<img width="2100" height="2302" alt="image" src="https://github.com/user-attachments/assets/3ffd4a83-ffc4-480d-8694-312957cbfd39" />