### PR TITLE
Fixing a couple of bugs which can affect Braginskii and cold fluid simulations

### DIFF
--- a/moments/zero/sources_explicit.c
+++ b/moments/zero/sources_explicit.c
@@ -2291,6 +2291,7 @@ explicit_e_field_source_update_euler(const gkyl_moment_em_coupling* mom_em, doub
   for (int i = 0; i < nfluids; i++) {
     double *f = fluid_s[i];
     const double q = mom_em->param[i].charge;
+    const double m = mom_em->param[i].mass;
 
     double rho = f[0];
 
@@ -2305,9 +2306,9 @@ explicit_e_field_source_update_euler(const gkyl_moment_em_coupling* mom_em, doub
       double vy = uy / gamma;
       double vz = uz / gamma;
 
-      e_field_new[0] += dt * (-(1.0 / epsilon0) * q * rho * vx);
-      e_field_new[1] += dt * (-(1.0 / epsilon0) * q * rho * vy);
-      e_field_new[2] += dt * (-(1.0 / epsilon0) * q * rho * vz);
+      e_field_new[0] += dt * (-(1.0 / epsilon0) * (q/m) * rho * vx);
+      e_field_new[1] += dt * (-(1.0 / epsilon0) * (q/m) * rho * vy);
+      e_field_new[2] += dt * (-(1.0 / epsilon0) * (q/m) * rho * vz);
     }
   }
 }

--- a/moments/zero/sources_implicit.c
+++ b/moments/zero/sources_implicit.c
@@ -597,7 +597,7 @@ implicit_source_coupling_update(const gkyl_moment_em_coupling* mom_em, double t_
     fluid_rhs[i][0] = rho + (0.5 * dt * rho_rhs);
     fluid_rhs[i][1] = mom_x + (0.5 * dt * mom_x_rhs);
     fluid_rhs[i][2] = mom_y + (0.5 * dt * mom_y_rhs);
-    fluid_rhs[i][3] = mom_z + (0.5 * dt * mom_x_rhs);
+    fluid_rhs[i][3] = mom_z + (0.5 * dt * mom_z_rhs);
 
     if (mom_em->param[i].type == GKYL_EQN_EULER) {
       double energy = f[4];


### PR DESCRIPTION
The explicit source coupling not correctly using z momentum sources when including transport terms and the cold fluid explicit EM update not correctly updating the electric field (needed to use q/m instead of just q so mass factor is not folded into current accumulation).