### PR TITLE
BUGFIX: 2x2v numeric B minimizing map

### DIFF
--- a/gyrokinetic/zero/gkyl_position_map_priv.h
+++ b/gyrokinetic/zero/gkyl_position_map_priv.h
@@ -781,8 +781,8 @@ position_map_constB_z_numeric_moving_average(double t, const double *xn, double 
   const double theta_c = xn[0];
   const double sigma = gpm->constB_ctx->gaussian_std;
   const double max_width = gpm->constB_ctx->gaussian_max_integration_width;
-  const double tmin = gpm->grid.lower[0];
-  const double tmax = gpm->grid.upper[0];
+  const double tmin = gpm->constB_ctx->theta_min;
+  const double tmax = gpm->constB_ctx->theta_max;
   
   // Shrink the half-width symmetrically to stay within bounds
   // This ensures the integration window is always centered at theta_c

--- a/gyrokinetic/zero/position_map.c
+++ b/gyrokinetic/zero/position_map.c
@@ -266,6 +266,9 @@ gkyl_position_map_optimize(struct gkyl_position_map* gpm, struct gkyl_rect_grid 
 
   if (gpm->id == GKYL_PMAP_CONSTANT_DB_POLYNOMIAL && gpm->to_optimize == true)
   {
+    double psi_center = 0.5 * (gpm->constB_ctx->psi_min + gpm->constB_ctx->psi_max);
+    double alpha_center = 0.5 * (gpm->constB_ctx->alpha_min + gpm->constB_ctx->alpha_max);
+
     gpm->maps[0] = gpm->constB_ctx->maps_backup[0];
     gpm->ctxs[0] = gpm->constB_ctx->ctxs_backup[0];
     gpm->maps[1] = gpm->constB_ctx->maps_backup[1];
@@ -277,14 +280,17 @@ gkyl_position_map_optimize(struct gkyl_position_map* gpm, struct gkyl_rect_grid 
     gpm->bmag_ctx->cbasis = &gpm->basis;
     gpm->bmag_ctx->cgrid = &gpm->grid;
 
-    gpm->constB_ctx->psi    = (gpm->constB_ctx->psi_min + gpm->constB_ctx->psi_max) / 2;
-    gpm->constB_ctx->alpha  = (gpm->constB_ctx->alpha_min + gpm->constB_ctx->alpha_max) / 2;
+    gpm->constB_ctx->psi    = psi_center;
+    gpm->constB_ctx->alpha  = alpha_center;
 
     calculate_mirror_throat_location_polynomial(gpm->constB_ctx, gpm->bmag_ctx);
     calculate_optimal_mapping_polynomial(gpm->constB_ctx, gpm->bmag_ctx);
   }
   else if (gpm->id == GKYL_PMAP_CONSTANT_DB_NUMERIC && gpm->to_optimize == true)
   {
+    double psi_center = pow(0.5 * (sqrt(gpm->constB_ctx->psi_min) + sqrt(gpm->constB_ctx->psi_max)), 2.0);
+    double alpha_center = 0.5 * (gpm->constB_ctx->alpha_min + gpm->constB_ctx->alpha_max);
+
     gpm->maps[0] = gpm->constB_ctx->maps_backup[0];
     gpm->ctxs[0] = gpm->constB_ctx->ctxs_backup[0];
     gpm->maps[1] = gpm->constB_ctx->maps_backup[1];
@@ -296,8 +302,8 @@ gkyl_position_map_optimize(struct gkyl_position_map* gpm, struct gkyl_rect_grid 
     gpm->bmag_ctx->cbasis        = &gpm->basis;
     gpm->bmag_ctx->cgrid         = &gpm->grid;
 
-    gpm->constB_ctx->psi    = (gpm->constB_ctx->psi_min + gpm->constB_ctx->psi_max) / 2;
-    gpm->constB_ctx->alpha  = (gpm->constB_ctx->alpha_min + gpm->constB_ctx->alpha_max) / 2;
+    gpm->constB_ctx->psi    = psi_center;
+    gpm->constB_ctx->alpha  = alpha_center;
 
     find_B_field_extrema(gpm);
     refine_B_field_extrema(gpm);


### PR DESCRIPTION
The theta range was not being set correctly for the numeric B map. The Gaussian filter was hiding these errors and defaulting to the normal map, but the filter works now.

I also changed the psi selection to choose the mean radius rather than mean psi.

Before
<img width="283" height="451" alt="image" src="https://github.com/user-attachments/assets/88c48e91-5bf2-4124-93a1-38acd398a757" />


After fix

<img width="301" height="449" alt="image" src="https://github.com/user-attachments/assets/10e78476-03d3-41f7-9cce-a579d33f3131" />
