### PR TITLE
Checks for IWL Plate Functions

### DIFF
--- a/gyrokinetic/creg/rt_gk_ltx_iwl_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_ltx_iwl_2x2v_p1.c
@@ -53,14 +53,18 @@ struct gk_app_ctx {
   int num_failures_max; // Maximum allowable number of consecutive small time-steps.
 };
 
+// For IWL, this function must return the corner of the limiter plate at the IMP
+// on the LCFS when s=0
 void pfunc_upper(double s, double* RZ){
-    RZ[0] = 0.14047;
-    RZ[1] = -(s-0.061)*0.6;
+  RZ[0] = 0.1406517200151616;
+  RZ[1] = -s*0.6;
 }
 
+// For IWL, this function must return the corner of the limiter plate at the IMP
+// on the LCFS when s=0
 void pfunc_lower(double s, double* RZ){
-    RZ[0] = 0.14047;
-    RZ[1] = (s-0.061)*0.6;
+  RZ[0] = 0.1406517200151616;
+  RZ[1] = s*0.6;
 }
 
 // Electron source profiles.
@@ -176,7 +180,7 @@ create_ctx(void)
   // Geometry and magnetic field.
   double Lz        = 2.0*(M_PI-1e-14);    // Domain size along magnetic field.
   double B0 = 0.24;
-  double psi_LCFS = -5.4760172700000003e-03; // psi at LCFS. Taken from efit
+  double psi_LCFS = -0.0054760172700000; // psi at LCFS. Taken from efit
   double psi_min = psi_LCFS - 0.0004; // inner flux surface of domain
   double psi_max = psi_LCFS + 0.0012; // outer flux surface of domain
   double Lx = psi_max - psi_min;
@@ -215,7 +219,7 @@ create_ctx(void)
 
   // Grid parameters
   int Nx = 8;
-  int Nz = 16;
+  int Nz = 12;
   int Nvpar = 12;
   int Nmu = 8;
   int poly_order = 1;

--- a/gyrokinetic/zero/gkyl_tok_geo.h
+++ b/gyrokinetic/zero/gkyl_tok_geo.h
@@ -99,6 +99,8 @@ struct gkyl_tok_geo {
   // Flag and functions to specify the plate location/shape in RZ coordinates
   // The functions should specify R(s) and Z(s) on the plate where s is a parameter \in [0,1]
   // For single null, the "lower" plate is the outboard plate and the "upper plate" is the inboard plate
+  // For IWL, when s=0, the plate function must return the coordinates of the corner of the limiter plate
+  // at the inboard midplane which lies on the LCFS.
   bool plate_spec;
   plate_func plate_func_lower;
   plate_func plate_func_upper;

--- a/gyrokinetic/zero/tok_geo_utils.c
+++ b/gyrokinetic/zero/tok_geo_utils.c
@@ -1,4 +1,5 @@
 #include <gkyl_tok_geo_priv.h>
+#include <assert.h>
 
 // Helper functions for finding turning points when necessary
 
@@ -873,8 +874,25 @@ tok_find_endpoints(struct gkyl_tok_geo_grid_inp* inp, struct gkyl_tok_geo *geo, 
     arc_ctx->rright = inp->rright;
     arc_ctx->rleft = inp->rleft;
 
+    double R_lcfs[4], dRdZ_lcfs[4];
+    double dR_lcfs[4], dZ_lcfs[4];
+    int nr_lcfs = gkyl_tok_geo_R_psiZ(geo, geo->efit->sibry, geo->efit->zmaxis, 4, R_lcfs, dRdZ_lcfs, dR_lcfs, dZ_lcfs);
+    double r_lcfs = nr_lcfs == 1 ? R_lcfs[0] : choose_closest(arc_ctx->rleft, R_lcfs, R_lcfs, nr_lcfs);
+    double rz_lcfs[2];
+
+    geo->plate_func_upper(0.0, rz_lcfs);
+    if(fabs(rz_lcfs[0] - r_lcfs) > 1e-6) {
+      fprintf(stderr, "The upper plate function has an error. It must return (R(s=0),Z(s=0)) = (%1.16f, %1.16f). \n", R_lcfs[0], geo->efit->zmaxis);
+      assert(false);
+    }
+    geo->plate_func_lower(0.0, rz_lcfs);
+    if(fabs(rz_lcfs[0] - r_lcfs) > 1e-6) {
+      fprintf(stderr, "The lower plate function has an error. It must return (R(s=0),Z(s=0)) = (%1.16f, %1.16f). \n", R_lcfs[0], geo->efit->zmaxis);
+      assert(false);
+    }
+
     double rmin_old = geo->rmin;
-    if (geo->plate_spec && ( (arc_ctx->psi > geo->efit->sibry && geo->efit->sibry > geo->efit->simag) || (arc_ctx->psi < geo->efit->sibry && geo->efit->sibry < geo->efit->simag) )){
+    if (geo->plate_spec && ( (arc_ctx->psi >= geo->efit->sibry && geo->efit->sibry >= geo->efit->simag) || (arc_ctx->psi <= geo->efit->sibry && geo->efit->sibry <= geo->efit->simag) )){
       set_upper_iwl_plate(geo, arc_ctx, pctx, arc_ctx->psi);
       set_lower_iwl_plate(geo, arc_ctx, pctx, arc_ctx->psi);
     }


### PR DESCRIPTION
Fix the numerical IWL LTX reg test: the plate functions had mistakes and the LCFS value was just a little bit off. Add some warnings/checks and a convention for the IWL plates to make it easier to construct them correctly. The iwl plate functions should return the corner of the limiter plate (see comments in the header file and reg test) when input parameter s=0.