### PR TITLE
Add URL to repo with code to generate radiation fits.

### DIFF
--- a/gyrokinetic/data/adas/README.md
+++ b/gyrokinetic/data/adas/README.md
@@ -1,7 +1,9 @@
-ADAS data
+giADAS data
 ---------
 
 ADAS data is not included in gkylzero and must be downloaded by user.
 
 To download ADAS data and convert to format accessible by gkylzero,
 run machines/mkdeps.<machine_name>.sh with flag --download-adas=yes
+
+Radiation fits are produced with [code maintained by J. Roeltgen](in: https://github.com/jRoeltgen/radiation_operator.git), requiring Matlab.

--- a/gyrokinetic/data/adas/README.md
+++ b/gyrokinetic/data/adas/README.md
@@ -6,4 +6,4 @@ ADAS data is not included in gkylzero and must be downloaded by user.
 To download ADAS data and convert to format accessible by gkylzero,
 run machines/mkdeps.<machine_name>.sh with flag --download-adas=yes
 
-Radiation fits are produced with [code maintained by J. Roeltgen](in: https://github.com/jRoeltgen/radiation_operator.git), requiring Matlab.
+Radiation fits are produced with [code maintained by J. Roeltgen](https://github.com/jRoeltgen/radiation_operator.git), requiring Matlab.


### PR DESCRIPTION
This points to the code that generates the radiation fits. Currently with Matlab.
There's some active effort to translate this to python, but it's not ready. So we point to the Maltab code for now.