### PR TITLE
Tok Geo Tracing Fix + Divertor Cell Compression

### DIFF
--- a/gyrokinetic/zero/gk_geometry_tok.c
+++ b/gyrokinetic/zero/gk_geometry_tok.c
@@ -160,16 +160,16 @@ gkyl_gk_geometry_tok_new(struct gkyl_gk_geometry_inp *geometry_inp)
       case GKYL_GEOMETRY_TOKAMAK_DN_SOL_OUT_LO:
       case GKYL_GEOMETRY_TOKAMAK_DN_SOL_IN_UP:
         len = geometry_inp->geo_grid.upper[2] - geometry_inp->geo_grid.lower[2];
-        zcenter = geometry_inp->geo_grid.lower[2];
-        zcut = len;
+        zcenter = geometry_inp->position_map->xpt_ctx->compress_divertor ? geometry_inp->geo_grid.lower[2] + len/2.0 : geometry_inp->geo_grid.lower[2];
+        zcut = geometry_inp->position_map->xpt_ctx->compress_divertor ? len/2.0 : len;
         break;
       case GKYL_GEOMETRY_TOKAMAK_PF_LO_L:
       case GKYL_GEOMETRY_TOKAMAK_PF_UP_R:
       case GKYL_GEOMETRY_TOKAMAK_DN_SOL_OUT_UP:
       case GKYL_GEOMETRY_TOKAMAK_DN_SOL_IN_LO:
         len = geometry_inp->geo_grid.upper[2] - geometry_inp->geo_grid.lower[2];
-        zcenter = geometry_inp->geo_grid.upper[2];
-        zcut = len;
+        zcenter = geometry_inp->position_map->xpt_ctx->compress_divertor ? geometry_inp->geo_grid.upper[2] - len/2.0 : geometry_inp->geo_grid.upper[2];
+        zcut = geometry_inp->position_map->xpt_ctx->compress_divertor ? len/2.0 : len;
         break;
       default:
         break;

--- a/gyrokinetic/zero/gkyl_position_map.h
+++ b/gyrokinetic/zero/gkyl_position_map.h
@@ -34,6 +34,7 @@ struct gkyl_position_map_inp {
   double compression_factor; // For PMAP_XPT_Compression. Specifies how much smaller the cells are
                              // near the X-point
   double radial_compression_factor; // Factor by which cells are compressed radially near xpt
+  bool compress_divertor; // Whether to apply compression at divertor plates for PMAP_XPT compression
 };
 struct gkyl_position_map_inew_inp {
   struct gkyl_position_map_inp pmap_info;
@@ -98,6 +99,7 @@ struct gkyl_position_map_xpt_ctx {
   void *ctxs_backup[3]; // Backup of the context for each position mapping function.
   double compression_factor; // Factor by which cells near X-point are compressed
   double radial_compression_factor; // Factor by which cells are compressed in radial direction at separatrix
+  bool compress_divertor; // Whether to apply compression at divertor plates
   double zcut; // Half-wavelength of sinusoidal mapping
   double zcenter; // Location of largest cells
   double w; // Radial width of domain in psi

--- a/gyrokinetic/zero/gkyl_tok_geo_priv.h
+++ b/gyrokinetic/zero/gkyl_tok_geo_priv.h
@@ -544,7 +544,7 @@ contour_func(double Z, void *ctx)
   double dR[4] = { 0 }, dZ[4] = { 0 };
   
   int nr = gkyl_tok_geo_R_psiZ(c->geo, c->psi, Z, 4, R, dRdZ, dR, dZ);
-  double drdz = nr == 1 ? dR[0] : choose_closest(c->last_R, R, dRdZ,nr);
+  double drdz = nr == 1 ? dRdZ[0] : choose_closest(c->last_R, R, dRdZ,nr);
   
   return nr>0 ? sqrt(1+drdz*drdz) : 0.0;
 }
@@ -558,7 +558,7 @@ phi_contour_func(double Z, void *ctx)
   double dR[4] = { 0 }, dZ[4] = { 0 };
   
   int nr = gkyl_tok_geo_R_psiZ(c->geo, c->psi, Z, 4, R, dRdZ, dR, dZ);
-  double drdz = nr == 1 ? dR[0] : choose_closest(c->last_R, R, dRdZ, nr);
+  double drdz = nr == 1 ? dRdZ[0] : choose_closest(c->last_R, R, dRdZ, nr);
   double r_curr = nr == 1 ? R[0] : choose_closest(c->last_R, R, R, nr);
 
   if (c->geo->use_cubics) {
@@ -608,7 +608,7 @@ dphidtheta_integrand(double Z, void *ctx)
   double dR[4] = { 0 }, dZ[4] = { 0 };
   
   int nr = gkyl_tok_geo_R_psiZ(c->geo, c->psi, Z, 4, R, dRdZ, dR, dZ);
-  double drdz = nr == 1 ? dR[0] : choose_closest(c->last_R, R, dRdZ, nr);
+  double drdz = nr == 1 ? dRdZ[0] : choose_closest(c->last_R, R, dRdZ, nr);
   double r_curr = nr == 1 ? R[0] : choose_closest(c->last_R, R, R, nr);
 
   if (c->geo->use_cubics) {

--- a/gyrokinetic/zero/position_map.c
+++ b/gyrokinetic/zero/position_map.c
@@ -150,6 +150,7 @@ gkyl_position_map_new(struct gkyl_position_map_inp pmap_info, struct gkyl_rect_g
       }
       gpm->xpt_ctx->compression_factor = pmap_info.compression_factor;
       gpm->xpt_ctx->radial_compression_factor = pmap_info.radial_compression_factor;
+      gpm->xpt_ctx->compress_divertor = pmap_info.compress_divertor;
   }
 
   gpm->grid = grid;


### PR DESCRIPTION
This PR first fixes a typo in the field line tracing and then also adds an option to compress cells near the divertor as part of the nonuniform tokamak grids.

The typo was causing some regions where only one root is found (outer PF region for STEP for example) to be traced wrong. The divertor compression is just a useful option. 