### PR TITLE
BUG: there are different numbers of quadrature points and basis functions

### DIFF
--- a/core/zero/array_dg_reduce.c
+++ b/core/zero/array_dg_reduce.c
@@ -28,7 +28,7 @@ gkyl_array_dg_reducec(double *out, const struct gkyl_array *arr, int comp,
 
   double *arr_d = arr->data;
 
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
 
   switch (op) {
     case GKYL_MIN:
@@ -94,7 +94,7 @@ gkyl_array_dg_reducec_range(double *out, const struct gkyl_array *arr, int comp,
 
   double *arr_d = arr->data;
 
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
 
   struct gkyl_range_iter iter;
   gkyl_range_iter_init(&iter, range);

--- a/core/zero/array_dg_reduce_cu.cu
+++ b/core/zero/array_dg_reduce_cu.cu
@@ -60,7 +60,7 @@ dg_arrayMax_blockRedAtomic_cub(const struct gkyl_array* inp, double* out, int co
 
   long nCells = inp->size;
   size_t nComp = inp->ncomp;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   const double *inp_d = (const double*) inp->data;
@@ -101,7 +101,7 @@ dg_arrayMax_range_blockRedAtomic_cub(const struct gkyl_array* inp, double* out,
   __shared__ typename BlockReduceT::TempStorage temp;
 
   long nCells = range.volume;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   int idx[GKYL_MAX_DIM];
@@ -166,7 +166,7 @@ dg_arrayMin_blockRedAtomic_cub(const struct gkyl_array* inp, double* out, int co
 
   long nCells = inp->size;
   size_t nComp = inp->ncomp;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   const double *inp_d = (const double*) inp->data;
@@ -207,7 +207,7 @@ dg_arrayMin_range_blockRedAtomic_cub(const struct gkyl_array* inp, double* out,
   __shared__ typename BlockReduceT::TempStorage temp;
 
   long nCells = range.volume;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   int idx[GKYL_MAX_DIM];
@@ -272,7 +272,7 @@ dg_arraySum_blockRedAtomic_cub(const struct gkyl_array* inp, double* out, int co
 
   long nCells = inp->size;
   size_t nComp = inp->ncomp;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   const double *inp_d = (const double*) inp->data;
@@ -312,7 +312,7 @@ int comp, const struct gkyl_basis *basis, struct gkyl_range range)
   __shared__ typename BlockReduceT::TempStorage temp;
 
   long nCells = range.volume;
-  int num_nodes = pow(basis->poly_order+1,basis->ndim);
+  int num_nodes = basis->num_quad;
   const int num_nodes_max = 27; // MF 2025/01/15: hard coded to p=2 3x for now.
 
   int idx[GKYL_MAX_DIM];

--- a/core/zero/cart_modal_gkhybrid.c
+++ b/core/zero/cart_modal_gkhybrid.c
@@ -15,6 +15,7 @@ gkyl_cart_modal_gkhybrid(struct gkyl_basis *basis, int cdim, int vdim)
   basis->ndim = ndim;
   basis->poly_order = 1;
   basis->num_basis = num_basis_list[ndim].count[1];
+  basis->num_quad = num_quad_list[ndim].count[1];
   strcpy(basis->id, "gkhybrid");
   basis->b_type = GKYL_BASIS_MODAL_GKHYBRID;
 

--- a/core/zero/cart_modal_gkhybrid_cu.cu
+++ b/core/zero/cart_modal_gkhybrid_cu.cu
@@ -20,7 +20,8 @@ gkyl_cart_modal_gkhybrid_cu_dev_kern(struct gkyl_basis *basis, int cdim, int vdi
   basis->ndim = cdim+vdim;
   basis->poly_order = 1;
   basis->num_basis = num_basis_list[ndim].count[1];
-  basis->b_type = GKYL_BASIS_MODAL_GKHYBRID;  
+  basis->num_quad = num_quad_list[ndim].count[1];
+  basis->b_type = GKYL_BASIS_MODAL_GKHYBRID;
   
   // function pointers
   basis->eval = ev_list[ndim].ev[1];

--- a/core/zero/cart_modal_hybrid.c
+++ b/core/zero/cart_modal_hybrid.c
@@ -15,6 +15,7 @@ gkyl_cart_modal_hybrid(struct gkyl_basis *basis, int cdim, int vdim)
   basis->ndim = ndim;
   basis->poly_order = 1;
   basis->num_basis = num_basis_list[cdim].count[vdim];
+  basis->num_quad = num_quad_list[ndim].count[1];
   strcpy(basis->id, "hybrid");
   basis->b_type = GKYL_BASIS_MODAL_HYBRID;
 

--- a/core/zero/cart_modal_hybrid_cu.cu
+++ b/core/zero/cart_modal_hybrid_cu.cu
@@ -19,6 +19,7 @@ gkyl_cart_modal_hybrid_cu_dev_kern(struct gkyl_basis *basis, int cdim, int vdim)
   basis->ndim = cdim+vdim;
   basis->poly_order = 1;
   basis->num_basis = num_basis_list[cdim].count[vdim];
+  basis->num_quad = num_quad_list[cdim].count[vdim];
   basis->b_type = GKYL_BASIS_MODAL_HYBRID;  
   
   // function pointers

--- a/core/zero/cart_modal_serendip.c
+++ b/core/zero/cart_modal_serendip.c
@@ -14,6 +14,7 @@ gkyl_cart_modal_serendip(struct gkyl_basis *basis, int ndim, int poly_order)
   basis->ndim = ndim;
   basis->poly_order = poly_order;
   basis->num_basis = num_basis_list[ndim].count[poly_order];
+  basis->num_quad = num_quad_list[ndim].count[poly_order];
   strcpy(basis->id, "serendipity");
   basis->b_type = GKYL_BASIS_MODAL_SERENDIPITY;
 

--- a/core/zero/cart_modal_serendip_cu.cu
+++ b/core/zero/cart_modal_serendip_cu.cu
@@ -19,6 +19,7 @@ gkyl_cart_modal_serendip_cu_dev_kern(struct gkyl_basis *basis, int ndim, int pol
   basis->ndim = ndim;
   basis->poly_order = poly_order;
   basis->num_basis = num_basis_list[ndim].count[poly_order];
+  basis->num_quad = num_quad_list[ndim].count[poly_order];
   basis->b_type = GKYL_BASIS_MODAL_SERENDIPITY;  
   
   // function pointers

--- a/core/zero/cart_modal_tensor.c
+++ b/core/zero/cart_modal_tensor.c
@@ -15,6 +15,7 @@ gkyl_cart_modal_tensor(struct gkyl_basis *basis, int ndim, int poly_order)
   basis->ndim = ndim;
   basis->poly_order = poly_order;
   basis->num_basis = pow(poly_order+1, ndim);
+  basis->num_quad = num_quad_list[ndim].count[poly_order];
   strcpy(basis->id, "tensor");
   basis->b_type = GKYL_BASIS_MODAL_TENSOR;
 

--- a/core/zero/cart_modal_tensor_cu.cu
+++ b/core/zero/cart_modal_tensor_cu.cu
@@ -18,6 +18,7 @@ gkyl_cart_modal_tensor_cu_dev_kern(struct gkyl_basis *basis, int ndim, int poly_
   basis->ndim = ndim;
   basis->poly_order = poly_order;
   basis->num_basis = pow(poly_order+1, ndim);
+  basis->num_quad = num_quad_list[ndim].count[poly_order];
   basis->b_type = GKYL_BASIS_MODAL_TENSOR;  
   
   // function pointers

--- a/core/zero/gkyl_basis.h
+++ b/core/zero/gkyl_basis.h
@@ -15,7 +15,7 @@ typedef void (*node_quad_surf_list_t)(double *node_coords);
  * Basis function object
  */
 struct gkyl_basis {
-  unsigned ndim, poly_order, num_basis;
+  unsigned ndim, poly_order, num_basis, num_quad;
   char id[64]; // "serendipity", "tensor", "hybrid, "gkhybrid"
   enum gkyl_basis_type b_type; // identifier for basis function
     

--- a/core/zero/gkyl_cart_modal_gkhybrid_priv.h
+++ b/core/zero/gkyl_cart_modal_gkhybrid_priv.h
@@ -106,6 +106,17 @@ static struct { void (*n2m[4])(const double *fquad, double *fmodal, long linc2);
   { NULL, quad_to_modal_3x2v_gkhyb_p1, NULL, NULL },
 };
 
+// Number of quadrature nodes: num_quad_list[ndim].count[poly_order]
+GKYL_CU_D
+static struct { int count[4]; } num_quad_list[] = {
+  { 0, 0, 0, 0 },
+  { 0, 0, 0, 0 },
+  { 0, 6, 0, 0 },
+  { 0, 12, 0, 0 },
+  { 0, 24, 0, 0 },
+  { 0, 48, 0, 0 },
+};
+
 // modal basis -> Gauss-Legendre quadrature nodes nodal basis conversion functions: ev_list[ndim].ev[poly_order]
 GKYL_CU_D
 static struct { void (*n2m[4])(const double *fmodal, double *fquad, long linc2); } m2qn_list[] = {

--- a/core/zero/gkyl_cart_modal_hybrid_priv.h
+++ b/core/zero/gkyl_cart_modal_hybrid_priv.h
@@ -83,6 +83,15 @@ static struct { void (*n2m[4])(const double *fquad, double *fmodal, long linc2);
   { NULL, quad_to_modal_3x1v_hyb_p1, quad_to_modal_3x2v_hyb_p1, quad_to_modal_3x3v_hyb_p1 },
 };
 
+// Number of quadrature nodes: num_quad_list[ndim].count[poly_order]
+GKYL_CU_D
+static struct { int count[4]; } num_quad_list[] = {
+  { 0, 0, 0, 0 },
+  { 0, 6, 18, 54 },
+  { 0, 12, 36, 108 },
+  { 0, 24, 72, 216 },
+};
+
 // modal basis -> Gauss-Legendre quadrature nodes nodal basis conversion functions: ev_list[ndim].ev[poly_order]
 GKYL_CU_D
 static struct { void (*n2m[4])(const double *fmodal, double *fquad, long linc2); } m2qn_list[] = {

--- a/core/zero/gkyl_cart_modal_serendip_priv.h
+++ b/core/zero/gkyl_cart_modal_serendip_priv.h
@@ -159,6 +159,18 @@ static struct { void (*n2m[4])(const double *fquad, double *fmodal, long linc2);
   { NULL, quad_to_modal_6d_ser_p1, NULL, NULL },
 };
 
+// Number of quadrature nodes: num_quad_list[ndim].count[poly_order]
+GKYL_CU_D
+static struct { int count[4]; } num_quad_list[] = {
+  { 0, 0, 0, 0 },
+  { 0, 2, 3, 0 },
+  { 0, 4, 9, 0 },
+  { 0, 8, 27, 0 },
+  { 0, 16, 81, 0 },
+  { 0, 32, 243, 0 },
+  { 0, 64, 0, 0 },
+};
+
 // modal basis -> Gauss-Legendre quadrature nodes nodal basis conversion functions: ev_list[ndim].ev[poly_order]
 GKYL_CU_D
 static struct { void (*n2m[4])(const double *fmodal, double *fquad, long linc2); } m2qn_list[] = {

--- a/core/zero/gkyl_cart_modal_tensor_priv.h
+++ b/core/zero/gkyl_cart_modal_tensor_priv.h
@@ -99,6 +99,18 @@ static struct { void (*n2m[4])(const double *fquad, double *fmodal, long linc2);
   { NULL, quad_to_modal_6d_ser_p1, NULL, NULL }, // TODO
 };
 
+// Number of quadrature nodes: num_quad_list[ndim].count[poly_order]
+GKYL_CU_D
+static struct { int count[4]; } num_quad_list[] = {
+  { 0, 0, 0, 0 },
+  { 0, 2, 3, 0 },
+  { 0, 4, 8, 0 },
+  { 0, 8, 27, 0 },
+  { 0, 16, 81, 0 },
+  { 0, 32, 0, 0 },
+  { 0, 64, 0, 0 },
+};
+
 // modal basis -> Gauss-Legendre quadrature nodes nodal basis conversion functions: ev_list[ndim].ev[poly_order]
 GKYL_CU_D
 static struct { void (*n2m[4])(const double *fmodal, double *fquad, long linc2); } m2qn_list[] = {

--- a/core/zero/nodal_ops.c
+++ b/core/zero/nodal_ops.c
@@ -357,7 +357,7 @@ gkyl_nodal_ops_m2n_surface(const struct gkyl_nodal_ops *nodal_ops,
 
     for (int i=0; i<num_comp; ++i) {
       // transform to modal expansion
-      for (int k=0; k<num_basis; ++k){
+      for (int k=0; k<cbasis->num_quad; ++k){
         cbasis->modal_to_quad_nodal(&arr_p[num_basis*i], fnodal, k);
       }
       // copy so nodal values for each return value are contiguous
@@ -513,7 +513,7 @@ gkyl_nodal_ops_m2n_interior(const struct gkyl_nodal_ops *nodal_ops,
 
     for (int i=0; i<num_comp; ++i) {
       // transform to modal expansion
-      for (int k=0; k<num_basis; ++k){
+      for (int k=0; k<cbasis->num_quad; ++k){
         cbasis->modal_to_quad_nodal(&arr_p[num_basis*i], fnodal, k);
       }
       // copy so nodal values for each return value are contiguous


### PR DESCRIPTION
Luckily, this was not a widely used function, and its only use cases were coincidentally cases where num_basis==num_quad (p1), but this is not true in general. I went through all the `modal_to_quad` functions and counted their cases, setting the number of cases to the number of quadrature points for that basis set. Importantly, `modal_to_quad` takes a modal expansion and computes the values at quadrature points. It takes an index, which is the index of the quadrature point. To loop over the number of quadrature points, we must know how many there are.

Fixes #1008 