### PR TITLE
Remove IWL enums (from input file)

### DIFF
--- a/gyrokinetic/apps/gk_field_2x3x.c
+++ b/gyrokinetic/apps/gk_field_2x3x.c
@@ -13,75 +13,6 @@
 #include <time.h>
 
 static void
-gk_field_3x_write_twistshift(struct gkyl_gyrokinetic_app *app, struct gk_field *f)
-{
-  // Write the discretized shift (for TS BCs) to file.
-  int comm_rank, comm_size;
-  gkyl_comm_get_rank(app->comm, &comm_rank);
-  gkyl_comm_get_size(app->comm, &comm_size);
-
-  const char *vars[] = {"x","y","z"};
-  const char *edge[] = {"lower","upper"};
-  const char *fmt = "%s-bc_%s%s_twistshift.gkyl";
-
-  struct gk_species *gks = &app->species[0];
-  for (int i = 0; i < 2*app->cdim; i++) {
-    if (gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_IWL ||
-        gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
-
-      int dir = gks->info.bcs[i].dir;
-      int edi = gks->info.bcs[i].edge;
-      if (comm_rank == 0 && edi == GKYL_LOWER_EDGE) {
-        struct gkyl_bc_twistshift *bc_ts = f->bc_ts_lo;
-        
-        struct gkyl_rect_grid shear_grid;
-        struct gkyl_range shear_r;
-        struct gkyl_basis shift_b;
-        struct gkyl_array *shift_dg = gkyl_bc_twistshift_get_shift_objects(bc_ts, &shear_grid, &shear_r, &shift_b);
-
-        // Twistshift updater stores the shift on a restricted range (the core) but a full
-        // grid. Create a restricted grid for I/O.
-        struct gkyl_rect_grid shear_grid_core;
-        double lower[1], upper[1];
-        int cells[] = {shear_r.volume};
-        if (app->gk_geom->geqdsk_sign_convention == 0) {
-          // x increases towards SOL.
-          lower[0] = shear_grid.lower[0];
-          upper[0] = shear_grid.lower[0] + shear_grid.dx[0]*cells[0];
-          gkyl_rect_grid_init(&shear_grid_core, shear_grid.ndim, lower, upper, cells);
-        }
-        else {
-          // x increases towards SOL.
-          lower[0] = shear_grid.upper[0] - shear_grid.dx[0]*cells[0];
-          upper[0] = shear_grid.upper[0];
-          gkyl_rect_grid_init(&shear_grid_core, shear_grid.ndim, lower, upper, cells);
-        }
-
-        // Package metadata for shift file.
-        struct gkyl_msgpack_map_elem io_meta_shift_dg[] = {
-          { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = shift_b.poly_order },
-          { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = shift_b.id }
-        };
-        int io_meta_shift_dg_len = sizeof(io_meta_shift_dg)/sizeof(io_meta_shift_dg[0]);
-        int io_meta_shift_len[] = {app->io_meta_basic_len, io_meta_shift_dg_len};
-        const struct gkyl_msgpack_map_elem* io_meta_shift[] = {app->io_meta_basic, io_meta_shift_dg};
-        struct gkyl_msgpack_data *mt_shift = gkyl_msgpack_create_union(sizeof(io_meta_shift_len)/sizeof(int),
-          io_meta_shift_len, io_meta_shift);
-
-        int sz = gkyl_calc_strlen(fmt, app->name, vars[dir], edge[edi]);
-        char fileNm[sz+1]; // ensures no buffer overflow
-        sprintf(fileNm, fmt, app->name, vars[dir], edge[edi]);
-
-        gkyl_grid_sub_array_write(&shear_grid_core, &shear_r, mt_shift, shift_dg, fileNm);
-
-        gkyl_array_release(shift_dg);
-        gkyl_msgpack_data_release(mt_shift);
-      }
-    }
-  }
-}
-
-static void
 gk_field_fem_projection_par_rho_ts_2x(gkyl_gyrokinetic_app *app, struct gk_field *field,
   struct gkyl_array *arr_dg, struct gkyl_array *arr_fem)
 {
@@ -319,21 +250,7 @@ gk_field_2x3x_add_TS_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field 
     f->fem_projection_par_rho_func = gk_field_fem_projection_par;
     f->fem_projection_par_phi_func = gk_field_fem_projection_par_phi_ts_3x;
 
-    // Take the TS function from the parallel BC of the first species.
     int par_dir = app->cdim-1; // Parallel direction index.
-    struct gk_species *gks = &app->species[0];
-    const struct gkyl_gyrokinetic_bc *par_lower_bc, *par_upper_bc;
-    for (int i = 0; i < 2*app->cdim; i++) {
-      if ( gks->info.bcs[i].dir == par_dir && gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
-        if (gks->info.bcs[i].edge == GKYL_LOWER_EDGE) {
-          par_lower_bc = (const struct gkyl_gyrokinetic_bc *) &gks->info.bcs[i];
-        }
-        if (gks->info.bcs[i].edge == GKYL_UPPER_EDGE) {
-          par_upper_bc = (const struct gkyl_gyrokinetic_bc *) &gks->info.bcs[i];
-        }
-      }
-    }
-
     int ghost[] = {1, 1, 1};
     // TS BC updater for lower edge.
     struct gkyl_bc_twistshift_inp T_LU_lo = {
@@ -351,8 +268,8 @@ gk_field_2x3x_add_TS_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field 
     if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
       T_LU_lo.shift_dg = app->delta_ts_x_lo;
     else {
-      T_LU_lo.shift_func = par_lower_bc->aux_profile;
-      T_LU_lo.shift_func_ctx = par_lower_bc->aux_ctx;
+      T_LU_lo.shift_func     = app->gk_geom->parallel_lower_bc_shift_func;
+      T_LU_lo.shift_func_ctx = app->gk_geom->parallel_lower_bc_shift_ctx;
     }
     f->bc_ts_lo = gkyl_bc_twistshift_new(&T_LU_lo);
 
@@ -372,8 +289,8 @@ gk_field_2x3x_add_TS_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field 
     if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
       T_UL_up.shift_dg = app->delta_ts_x_up;
     else {
-      T_UL_up.shift_func = par_upper_bc->aux_profile;
-      T_UL_up.shift_func_ctx = par_upper_bc->aux_ctx;
+      T_UL_up.shift_func     = app->gk_geom->parallel_upper_bc_shift_func;
+      T_UL_up.shift_func_ctx = app->gk_geom->parallel_upper_bc_shift_ctx;
     }
     f->bc_ts_up = gkyl_bc_twistshift_new(&T_UL_up);
 
@@ -383,9 +300,6 @@ gk_field_2x3x_add_TS_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field 
     f->gfss_bc_op_core_up = gkyl_bc_basic_gyrokinetic_new(par_dir, GKYL_UPPER_EDGE, GKYL_BC_GK_FIELD_BOUNDARY_VALUE,
       app->basis_on_dev, &app->global_upper_skin[par_dir], &app->global_upper_ghost[par_dir],
       app->basis.num_basis, app->cdim, app->use_gpu);
-
-    // Write the discrete shift to file.
-    gk_field_3x_write_twistshift(app, f);
   }
 
   // Parallel smoother for the charge density.
@@ -428,19 +342,7 @@ gk_field_2x3x_add_IWL_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field
     f->fem_projection_par_rho_func = gk_field_fem_projection_par;
     f->fem_projection_par_phi_func = gk_field_fem_projection_par_phi_iwl_3x;
 
-    // Take the TS function from the parallel BC of the first species.
     int par_dir = app->cdim-1; // Parallel direction index.
-    struct gk_species *gks = &app->species[0];
-    const struct gkyl_gyrokinetic_bc *par_lower_bc;
-    for (int i = 0; i < 2*app->cdim; i++) {
-      if ( gks->info.bcs[i].dir == par_dir && gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_IWL) {
-        if (gks->info.bcs[i].edge == GKYL_LOWER_EDGE) {
-          par_lower_bc = (const struct gkyl_gyrokinetic_bc *) &gks->info.bcs[i];
-          break;
-        }
-      }
-    }
-
     // TS BC updater for up to low TS for the lower edge. This sets ghost_L = T_LU(ghost_L).
     int ghost[] = {1, 1, 1};
     struct gkyl_bc_twistshift_inp T_LU_lo = {
@@ -458,8 +360,8 @@ gk_field_2x3x_add_IWL_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field
     if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
       T_LU_lo.shift_dg = app->delta_ts_x_lo;
     else {
-      T_LU_lo.shift_func = par_lower_bc->aux_profile;
-      T_LU_lo.shift_func_ctx = par_lower_bc->aux_ctx;
+      T_LU_lo.shift_func     = app->gk_geom->parallel_lower_bc_shift_func;
+      T_LU_lo.shift_func_ctx = app->gk_geom->parallel_lower_bc_shift_ctx;
     }
     f->bc_ts_lo = gkyl_bc_twistshift_new(&T_LU_lo);
 
@@ -469,9 +371,6 @@ gk_field_2x3x_add_IWL_updaters(struct gkyl_gyrokinetic_app *app, struct gk_field
     f->gfss_bc_op_core_up = gkyl_bc_basic_gyrokinetic_new(par_dir, GKYL_UPPER_EDGE, GKYL_BC_GK_FIELD_BOUNDARY_VALUE,
       app->basis_on_dev, &app->global_upper_skin_par_core, &app->global_upper_ghost_par_core,
       app->basis.num_basis, app->cdim, app->use_gpu);
-
-    // Write the discrete shift to file.
-    gk_field_3x_write_twistshift(app, f);
   }
 
   // Parallel smoother for the charge density.
@@ -537,22 +436,8 @@ gk_field_fem_release_2x3x(const gkyl_gyrokinetic_app *app, struct gk_field *f)
 
   gkyl_array_integrate_release(f->calc_em_energy);
 
-  // Release TS updaters.
-  if (f->bc_par_phi == GKYL_BC_GK_FIELD_TWISTSHIFT) {
-    gkyl_free(f->fem_parproj_bias_line_list.bl);
-    gkyl_fem_parproj_release(f->fem_parproj_rho_core);
-    gkyl_fem_parproj_release(f->fem_parproj_phi_core);
-
-    if (app->cdim == 3) {
-      gkyl_bc_twistshift_release(f->bc_ts_lo);
-      gkyl_bc_twistshift_release(f->bc_ts_up);
-      gkyl_bc_basic_gyrokinetic_release(f->gfss_bc_op_core_up);
-      gkyl_array_release(f->bc_buffer);
-    }
-  }
-  
-  // Release IWL updaters.
-  if (f->bc_par_phi == GKYL_BC_GK_FIELD_IWL) {
+  if (app->gk_geom->has_LCFS) {
+    // Release IWL updaters.
     gkyl_free(f->fem_parproj_bias_line_list.bl);
     gkyl_fem_parproj_release(f->fem_parproj_rho_core);
     gkyl_fem_parproj_release(f->fem_parproj_phi_core);
@@ -565,6 +450,20 @@ gk_field_fem_release_2x3x(const gkyl_gyrokinetic_app *app, struct gk_field *f)
       gkyl_array_release(f->bc_buffer);
     }
   }
+  else if (f->bc_par_phi == GKYL_BC_GK_FIELD_TWISTSHIFT) {
+    // Release TS updaters.
+    gkyl_free(f->fem_parproj_bias_line_list.bl);
+    gkyl_fem_parproj_release(f->fem_parproj_rho_core);
+    gkyl_fem_parproj_release(f->fem_parproj_phi_core);
+
+    if (app->cdim == 3) {
+      gkyl_bc_twistshift_release(f->bc_ts_lo);
+      gkyl_bc_twistshift_release(f->bc_ts_up);
+      gkyl_bc_basic_gyrokinetic_release(f->gfss_bc_op_core_up);
+      gkyl_array_release(f->bc_buffer);
+    }
+  }
+  
   
   if (f->use_flr) {
     gk_field_flr_release(app, f);
@@ -726,28 +625,22 @@ gk_field_fem_new_2x3x(struct gkyl_gyrokinetic_app *app, struct gk_field *f)
   for (int s=0; s<app->num_species; s++) {
     struct gk_species *gks = &app->species[s];
     for (int i = 0; i < 2*app->cdim; i++) {
-      if ( gks->info.bcs[i].dir == app->cdim-1 ) {
-        if (gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_TWISTSHIFT ) {
-          f->bc_par_phi = GKYL_BC_GK_FIELD_TWISTSHIFT;
-          break;
-	}
-        if (gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_IWL ) {
-          f->bc_par_phi = GKYL_BC_GK_FIELD_IWL;
-          break;
-	}
+      if ( gks->info.bcs[i].dir == app->cdim-1 && gks->info.bcs[i].type == GKYL_BC_GK_SPECIES_TWISTSHIFT ) {
+        f->bc_par_phi = GKYL_BC_GK_FIELD_TWISTSHIFT;
+        break;
       }
     }
     if (f->bc_par_phi)
       break;
   }
 
-  if (f->bc_par_phi == GKYL_BC_GK_FIELD_TWISTSHIFT) {
-    // Updaters to enforce twist-and-shift BCs.
-    gk_field_2x3x_add_TS_updaters(app, f, &poisson_bcs);
-  }
-  else if (f->bc_par_phi == GKYL_BC_GK_FIELD_IWL) {
+  if (app->gk_geom->has_LCFS) {
     // Updaters to enforce twist-and-shift and sheath BCs.
     gk_field_2x3x_add_IWL_updaters(app, f, &poisson_bcs);
+  }
+  else if (f->bc_par_phi == GKYL_BC_GK_FIELD_TWISTSHIFT) {
+    // Updaters to enforce twist-and-shift BCs.
+    gk_field_2x3x_add_TS_updaters(app, f, &poisson_bcs);
   }
 
   // Set the pointer to the function that computes phi.

--- a/gyrokinetic/apps/gk_neut_species_fluid.c
+++ b/gyrokinetic/apps/gk_neut_species_fluid.c
@@ -228,7 +228,7 @@ gk_neut_species_fluid_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app,
   ns->local = app->local;
 
   // Keep a copy of num_periodic_dir and periodic_dirs in species so we can
-  // modify it in GK_IWL BCs without modifying the app's.
+  // modify it in IWL BCs without modifying the app's.
   ns->num_periodic_dir = app->num_periodic_dir;
   for (int d=0; d<ns->num_periodic_dir; ++d)
     ns->periodic_dirs[d] = app->periodic_dirs[d];

--- a/gyrokinetic/apps/gk_neut_species_kinetic.c
+++ b/gyrokinetic/apps/gk_neut_species_kinetic.c
@@ -675,7 +675,7 @@ gk_neut_species_kinetic_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *ap
     s->local, s->local_ext, s->local_vel, s->local_ext_vel, app->use_gpu);
 
   // Keep a copy of num_periodic_dir and periodic_dirs in species so we can
-  // modify it in GK_IWL BCs without modifying the app's.
+  // modify it in IWL BCs without modifying the app's.
   s->num_periodic_dir = app->num_periodic_dir;
   for (int d=0; d<s->num_periodic_dir; ++d)
     s->periodic_dirs[d] = app->periodic_dirs[d];

--- a/gyrokinetic/apps/gk_neut_species_scaling.c
+++ b/gyrokinetic/apps/gk_neut_species_scaling.c
@@ -230,10 +230,9 @@ gk_neut_species_scaling_cross_init(struct gkyl_gyrokinetic_app *app, struct gk_n
       sca->boundaries_edge[j] = edge;
   
       // Specific scenario if we are in a inner wall limited case. We select only SOL range in parallel direction.
-      if (edge == GKYL_LOWER_EDGE? gks_ion->lower_bc[dir].type == GKYL_BC_GK_SPECIES_IWL
-                                 : gks_ion->upper_bc[dir].type == GKYL_BC_GK_SPECIES_IWL)
-      {
-        sca->boundaries_conf_ghost[j] = edge == GKYL_LOWER_EDGE ? app->local_lower_ghost_par_sol : app->local_upper_ghost_par_sol;
+      if (app->gk_geom->has_LCFS) {
+        sca->boundaries_conf_ghost[j] = edge == GKYL_LOWER_EDGE? app->local_lower_ghost_par_sol
+                                                               : app->local_upper_ghost_par_sol;
       }
     }
 

--- a/gyrokinetic/apps/gk_species.c
+++ b/gyrokinetic/apps/gk_species.c
@@ -208,13 +208,6 @@ gk_species_apply_bc_dynamic(gkyl_gyrokinetic_app *app, const struct gk_species *
         case GKYL_BC_GK_SPECIES_TWISTSHIFT:
           gkyl_bc_twistshift_advance(species->bc_ts_lo, f, f);
           break;
-        case GKYL_BC_GK_SPECIES_IWL:
-          gkyl_bc_sheath_gyrokinetic_advance(species->bc_sheath_lo, app->field->phi_smooth, 
-            app->field->phi_wall_lo, f, &app->local);
-          if (cdim == 3) {
-            gkyl_bc_twistshift_advance(species->bc_ts_lo, f, f);
-          }
-          break;
         case GKYL_BC_GK_SPECIES_COPY:
         case GKYL_BC_GK_SPECIES_REFLECT:
         case GKYL_BC_GK_SPECIES_ABSORB:
@@ -237,13 +230,6 @@ gk_species_apply_bc_dynamic(gkyl_gyrokinetic_app *app, const struct gk_species *
         case GKYL_BC_GK_SPECIES_TWISTSHIFT:
           gkyl_bc_twistshift_advance(species->bc_ts_up, f, f);
           break;
-        case GKYL_BC_GK_SPECIES_IWL:
-          gkyl_bc_sheath_gyrokinetic_advance(species->bc_sheath_up, app->field->phi_smooth, 
-            app->field->phi_wall_up, f, &app->local);
-          if (cdim == 3) {
-            gkyl_bc_twistshift_advance(species->bc_ts_up, f, f);
-          }
-          break;
         case GKYL_BC_GK_SPECIES_COPY:
         case GKYL_BC_GK_SPECIES_REFLECT:
         case GKYL_BC_GK_SPECIES_ABSORB:
@@ -258,6 +244,12 @@ gk_species_apply_bc_dynamic(gkyl_gyrokinetic_app *app, const struct gk_species *
           break;
       }      
     }
+  }
+
+  if (app->gk_geom->has_LCFS && app->cdim == 3) {
+    // Apply twistshift.
+    gkyl_bc_twistshift_advance(species->bc_ts_lo, f, f);
+    gkyl_bc_twistshift_advance(species->bc_ts_up, f, f);
   }
 
   gkyl_comm_array_sync(species->comm, &species->local, &species->local_ext, f);
@@ -645,12 +637,6 @@ gk_species_release_dynamic(const gkyl_gyrokinetic_app* app, const struct gk_spec
     else if (s->lower_bc[d].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) { 
       gkyl_bc_twistshift_release(s->bc_ts_lo);
     }
-    else if (s->lower_bc[d].type == GKYL_BC_GK_SPECIES_IWL) { 
-      gkyl_bc_sheath_gyrokinetic_release(s->bc_sheath_lo);
-      if (app->cdim == 3) {
-        gkyl_bc_twistshift_release(s->bc_ts_lo);
-      }
-    }
     else if ( (s->lower_bc[d].type == GKYL_BC_GK_SPECIES_COPY) ||
               (s->lower_bc[d].type == GKYL_BC_GK_SPECIES_ABSORB) ||
               (s->lower_bc[d].type == GKYL_BC_GK_SPECIES_REFLECT) ||
@@ -664,18 +650,18 @@ gk_species_release_dynamic(const gkyl_gyrokinetic_app* app, const struct gk_spec
     else if (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
       gkyl_bc_twistshift_release(s->bc_ts_up);
     }
-    else if (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_IWL) {
-      gkyl_bc_sheath_gyrokinetic_release(s->bc_sheath_up);
-      if (app->cdim == 3) {
-        gkyl_bc_twistshift_release(s->bc_ts_up);
-      }
-    }
     else if ( (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_COPY) ||
               (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_ABSORB) ||
               (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_REFLECT) ||
               (s->upper_bc[d].type == GKYL_BC_GK_SPECIES_FIXED_FUNC) ) {
       gkyl_bc_basic_gyrokinetic_release(s->bc_up[d]);
     }
+  }
+
+  if (app->gk_geom->has_LCFS && app->cdim == 3) {
+    // Free twishift memory.
+    gkyl_bc_twistshift_release(s->bc_ts_lo);
+    gkyl_bc_twistshift_release(s->bc_ts_up);
   }
   
   if (app->use_gpu) {
@@ -796,10 +782,8 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
   gks->is_first_L2norm_write_call = true;
   
   for (int dir=0; dir<app->cdim; ++dir) {
-    if (
-        gks->lower_bc[dir].type == GKYL_BC_GK_SPECIES_IWL || gks->upper_bc[dir].type == GKYL_BC_GK_SPECIES_IWL ||
-        gks->lower_bc[dir].type == GKYL_BC_GK_SPECIES_TWISTSHIFT || gks->upper_bc[dir].type == GKYL_BC_GK_SPECIES_TWISTSHIFT
-	) {
+    if (gk_app_inp->geometry.has_LCFS ||
+        (gks->lower_bc[dir].type == GKYL_BC_GK_SPECIES_TWISTSHIFT || gks->upper_bc[dir].type == GKYL_BC_GK_SPECIES_TWISTSHIFT)) {
       // Make the parallel direction periodic so that we sync before applying TS BC.
       gks->periodic_dirs[gks->num_periodic_dir] = app->cdim-1; // The last direction is the parallel one.
       gks->num_periodic_dir += 1;
@@ -845,9 +829,10 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
   for (int d=0; d<cdim; ++d) {
     // Lower BC.
     if (gks->lower_bc[d].type == GKYL_BC_GK_SPECIES_SHEATH) {
+      struct gkyl_range *sol_skin = gk_app_inp->geometry.has_LCFS? &gks->local_lower_skin_par_sol : &gks->local_lower_skin[d];
+      struct gkyl_range *sol_ghost = gk_app_inp->geometry.has_LCFS? &gks->local_lower_ghost_par_sol : &gks->local_lower_ghost[d];
       gks->bc_sheath_lo = gkyl_bc_sheath_gyrokinetic_new(d, GKYL_LOWER_EDGE, gks->basis_on_dev, 
-        &gks->local_lower_skin[d], &gks->local_lower_ghost[d], gks->vel_map,
-        cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
+        sol_skin, sol_ghost, gks->vel_map, cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
     }
     else if (gks->lower_bc[d].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
       assert(cdim == 3);
@@ -866,41 +851,12 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
       if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
         tsinp.shift_dg = app->delta_ts_x_lo;
       else {
-        tsinp.shift_func = gks->lower_bc[d].aux_profile;
-        tsinp.shift_func_ctx = gks->lower_bc[d].aux_ctx;
+        tsinp.shift_func     = app->gk_geom->parallel_lower_bc_shift_func;
+        tsinp.shift_func_ctx = app->gk_geom->parallel_lower_bc_shift_ctx;
       }
 
       gks->bc_ts_lo = gkyl_bc_twistshift_new(&tsinp);
       
-    }
-    else if (gks->lower_bc[d].type == GKYL_BC_GK_SPECIES_IWL) {
-      gks->bc_sheath_lo = gkyl_bc_sheath_gyrokinetic_new(d, GKYL_LOWER_EDGE, gks->basis_on_dev, 
-        &gks->local_lower_skin_par_sol, &gks->local_lower_ghost_par_sol, gks->vel_map,
-        cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
-
-      if (cdim == 3) {
-        // For 3x2v we need a twistshift BC in the core.
-        struct gkyl_bc_twistshift_inp tsinp = {
-          .bc_dir = d,
-          .shift_dir = 1, // y shift.
-          .shear_dir = 0, // shift varies with x.
-          .edge = GKYL_LOWER_EDGE,
-          .cdim = cdim,
-          .bcdir_ext_update_r = gks->local_par_ext_core,
-          .num_ghost = ghost,
-          .basis = gks->basis,
-          .grid = gks->grid,
-          .use_gpu = app->use_gpu,
-        };
-        if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
-          tsinp.shift_dg = app->delta_ts_x_lo;
-        else {
-          tsinp.shift_func = gks->lower_bc[d].aux_profile;
-          tsinp.shift_func_ctx = gks->lower_bc[d].aux_ctx;
-        }
-
-        gks->bc_ts_lo = gkyl_bc_twistshift_new(&tsinp);
-      }
     }
     else if ( (gks->lower_bc[d].type == GKYL_BC_GK_SPECIES_COPY) ||
               (gks->lower_bc[d].type == GKYL_BC_GK_SPECIES_ABSORB) ||
@@ -933,9 +889,10 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
 
     // Upper BC.
     if (gks->upper_bc[d].type == GKYL_BC_GK_SPECIES_SHEATH) {
+      struct gkyl_range *sol_skin = gk_app_inp->geometry.has_LCFS? &gks->local_upper_skin_par_sol : &gks->local_upper_skin[d];
+      struct gkyl_range *sol_ghost = gk_app_inp->geometry.has_LCFS? &gks->local_upper_ghost_par_sol : &gks->local_upper_ghost[d];
       gks->bc_sheath_up = gkyl_bc_sheath_gyrokinetic_new(d, GKYL_UPPER_EDGE, gks->basis_on_dev, 
-        &gks->local_upper_skin[d], &gks->local_upper_ghost[d], gks->vel_map,
-        cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
+        sol_skin, sol_ghost, gks->vel_map, cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
     }
     else if (gks->upper_bc[d].type == GKYL_BC_GK_SPECIES_TWISTSHIFT) {
       assert(cdim == 3);
@@ -954,40 +911,11 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
       if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
         tsinp.shift_dg = app->delta_ts_x_up;
       else {
-        tsinp.shift_func = gks->upper_bc[d].aux_profile;
-        tsinp.shift_func_ctx = gks->upper_bc[d].aux_ctx;
+        tsinp.shift_func     = app->gk_geom->parallel_upper_bc_shift_func;
+        tsinp.shift_func_ctx = app->gk_geom->parallel_upper_bc_shift_ctx;
       }
 
       gks->bc_ts_up = gkyl_bc_twistshift_new(&tsinp);
-    }
-    else if (gks->upper_bc[d].type == GKYL_BC_GK_SPECIES_IWL) {
-      gks->bc_sheath_up = gkyl_bc_sheath_gyrokinetic_new(d, GKYL_UPPER_EDGE, gks->basis_on_dev, 
-        &gks->local_upper_skin_par_sol, &gks->local_upper_ghost_par_sol, gks->vel_map,
-        cdim, 2.0*(gks->info.charge/gks->info.mass), app->use_gpu);
-
-      if (cdim == 3) {
-        // For 3x2v we need a twistshift BC in the core.
-        struct gkyl_bc_twistshift_inp tsinp = {
-          .bc_dir = d,
-          .shift_dir = 1, // y shift.
-          .shear_dir = 0, // shift varies with x.
-          .edge = GKYL_UPPER_EDGE,
-          .cdim = cdim,
-          .bcdir_ext_update_r = gks->local_par_ext_core,
-          .num_ghost = ghost,
-          .basis = gks->basis,
-          .grid = gks->grid,
-          .use_gpu = app->use_gpu,
-        };
-        if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
-          tsinp.shift_dg = app->delta_ts_x_up;
-        else {
-          tsinp.shift_func = gks->upper_bc[d].aux_profile;
-          tsinp.shift_func_ctx = gks->upper_bc[d].aux_ctx;
-        }
-
-        gks->bc_ts_up = gkyl_bc_twistshift_new(&tsinp);
-      }
     }
     else if ( (gks->upper_bc[d].type == GKYL_BC_GK_SPECIES_COPY) ||
               (gks->upper_bc[d].type == GKYL_BC_GK_SPECIES_ABSORB) ||
@@ -1017,6 +945,50 @@ gk_species_init_dynamic(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app 
         gk_species_projection_release(app, &gk_proj_bc_up);
       }
     }
+  }
+
+  if (gk_app_inp->geometry.has_LCFS && app->cdim == 3) {
+    // Allocate a twistshift operator in the core.
+    int par_dir = app->cdim-1;
+    struct gkyl_bc_twistshift_inp tsinp_lo = {
+      .bc_dir = par_dir,
+      .shift_dir = 1, // y shift.
+      .shear_dir = 0, // shift varies with x.
+      .edge = GKYL_LOWER_EDGE,
+      .cdim = cdim,
+      .bcdir_ext_update_r = gks->local_par_ext_core,
+      .num_ghost = ghost,
+      .basis = gks->basis,
+      .grid = gks->grid,
+      .use_gpu = app->use_gpu,
+    };
+    if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
+      tsinp_lo.shift_dg = app->delta_ts_x_lo;
+    else {
+      tsinp_lo.shift_func     = app->gk_geom->parallel_lower_bc_shift_func;
+      tsinp_lo.shift_func_ctx = app->gk_geom->parallel_lower_bc_shift_ctx;
+    }
+    gks->bc_ts_lo = gkyl_bc_twistshift_new(&tsinp_lo);
+    
+    struct gkyl_bc_twistshift_inp tsinp_up = {
+      .bc_dir = par_dir,
+      .shift_dir = 1, // y shift.
+      .shear_dir = 0, // shift varies with x.
+      .edge = GKYL_UPPER_EDGE,
+      .cdim = cdim,
+      .bcdir_ext_update_r = gks->local_par_ext_core,
+      .num_ghost = ghost,
+      .basis = gks->basis,
+      .grid = gks->grid,
+      .use_gpu = app->use_gpu,
+    };
+    if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK)
+      tsinp_up.shift_dg = app->delta_ts_x_up;
+    else {
+      tsinp_up.shift_func     = app->gk_geom->parallel_upper_bc_shift_func;
+      tsinp_up.shift_func_ctx = app->gk_geom->parallel_upper_bc_shift_ctx;
+    }
+    gks->bc_ts_up = gkyl_bc_twistshift_new(&tsinp_up);
   }
 
   // Set function pointers.
@@ -1452,7 +1424,7 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
   gkyl_velocity_map_write(gks->vel_map, gks->comm, app->name, gks->info.name);
   
   // Keep a copy of num_periodic_dir and periodic_dirs in species so we can
-  // modify it in GK_IWL BCs without modifying the app's.
+  // modify it in IWL without modifying the app's.
   gks->num_periodic_dir = app->num_periodic_dir;
   for (int d=0; d<gks->num_periodic_dir; ++d)
     gks->periodic_dirs[d] = app->periodic_dirs[d];

--- a/gyrokinetic/apps/gk_species_bflux.c
+++ b/gyrokinetic/apps/gk_species_bflux.c
@@ -653,7 +653,7 @@ gk_species_bflux_init(struct gkyl_gyrokinetic_app *app, void *species,
           bflux->boundaries_phase_skin[num_bound] = e==0? &gk_s->local_lower_skin[d] : &gk_s->local_upper_skin[d];
           bflux->boundaries_phase_ghost[num_bound] = e==0? &gk_s->local_lower_ghost[d] : &gk_s->local_upper_ghost[d];
           bflux->boundaries_conf_skin_fullx[num_bound] = bflux->boundaries_conf_skin[num_bound];
-          if (e == 0? gk_s->lower_bc[d].type == GKYL_BC_GK_SPECIES_IWL : gk_s->upper_bc[d].type == GKYL_BC_GK_SPECIES_IWL) {
+          if (app->gk_geom->has_LCFS) {
             // Use SOL ranges only for parallel boundary fluxes.
             bflux->boundaries_conf_skin[num_bound] = e==0? &app->local_lower_skin_par_sol : &app->local_upper_skin_par_sol;
             bflux->boundaries_conf_ghost[num_bound] = e==0? &app->local_lower_ghost_par_sol : &app->local_upper_ghost_par_sol;

--- a/gyrokinetic/apps/gk_species_projection.c
+++ b/gyrokinetic/apps/gk_species_projection.c
@@ -359,8 +359,8 @@ init_maxwellian_gaussian(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
   struct gkyl_gyrokinetic_bc *bc_up = gk_fetch_bc_with_dir_edge(s->info.bcs, 2*app->cdim, app->cdim-1, GKYL_UPPER_EDGE);
   if (bc_lo != 0 && bc_up != 0) {
     // Apply periodicity condition if both edges are IWL.
-    fg_ctx.is_dir_periodic[app->cdim-1] = (bc_lo->type == GKYL_BC_GK_SPECIES_IWL && bc_up->type == GKYL_BC_GK_SPECIES_IWL)
-      || (bc_lo->type == GKYL_BC_GK_SPECIES_TWISTSHIFT && bc_up->type == GKYL_BC_GK_SPECIES_TWISTSHIFT);
+    fg_ctx.is_dir_periodic[app->cdim-1] = app->gk_geom->has_LCFS ||
+      (bc_lo->type == GKYL_BC_GK_SPECIES_TWISTSHIFT && bc_up->type == GKYL_BC_GK_SPECIES_TWISTSHIFT);
   }
 
   // Set periodicity also according to the global app settings.

--- a/gyrokinetic/apps/gk_species_source.c
+++ b/gyrokinetic/apps/gk_species_source.c
@@ -516,9 +516,7 @@ gk_species_source_init(struct gkyl_gyrokinetic_app *app, struct gk_species *s,
           adapt_src->edge[j] = edge;
 
           // Specific scenario if we are in a inner wall limited case. We select only SOL range in parallel direction.
-          if (edge == GKYL_LOWER_EDGE? s->lower_bc[dir].type == GKYL_BC_GK_SPECIES_IWL
-                                     : s->upper_bc[dir].type == GKYL_BC_GK_SPECIES_IWL) 
-          {
+          if (app->gk_geom->has_LCFS) {
             adapt_src->boundaries_phase_ghost[j] = edge == GKYL_LOWER_EDGE? s->local_lower_ghost_par_sol
                                                                           : s->local_upper_ghost_par_sol;
             adapt_src->boundaries_conf_ghost[j] = edge == GKYL_LOWER_EDGE? app->local_lower_ghost_par_sol

--- a/gyrokinetic/apps/gkyl_gyrokinetic.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic.h
@@ -234,6 +234,12 @@ struct gkyl_gyrokinetic_geometry {
   bool has_LCFS; // Whether the geometry has a last closed flux surface (LCFS).
   double x_LCFS; // x coordinate of the LCFS.
 
+  // Twist-shift functions for the tokamak core.
+  void (*parallel_lower_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void (*parallel_upper_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void *parallel_lower_bc_shift_ctx; // Context for parallel_lower_bc_shift_func.
+  void *parallel_upper_bc_shift_ctx; // Context for parallel_upper_bc_shift_func.
+
   struct gkyl_efit_inp efit_info; // Context with RZ data such as efit file for a tokamak or mirror.
   struct gkyl_tok_geo_grid_inp tok_grid_info; // Context for tokamak geometry with computational domain info.
   struct gkyl_mirror_geo_grid_inp mirror_grid_info; // Context for mirror geometry with computational domain info.

--- a/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
+++ b/gyrokinetic/apps/gkyl_gyrokinetic_priv.h
@@ -1424,7 +1424,7 @@ struct gkyl_gyrokinetic_app {
   struct gkyl_array *jacobtot_inv_weak; // 1/(J.B) computed via weak mul and div.
   double omegaH_gf; // Geometry and field model dependent part of omega_H.
   // Shift (for TS BC) as a function of x, and objects associated with it.
-  struct gkyl_range delta_ts_x_local, delta_ts_x_local_ext;
+  struct gkyl_range delta_ts_x_rng;
   struct gkyl_basis delta_ts_x_basis;
   struct gkyl_rect_grid delta_ts_x_grid;
   struct gkyl_array *delta_ts_x_lo, *delta_ts_x_up;

--- a/gyrokinetic/apps/gyrokinetic.c
+++ b/gyrokinetic/apps/gyrokinetic.c
@@ -116,38 +116,40 @@ void
 gyrokinetic_deflate_delta_ts(struct gkyl_gyrokinetic_app* app, struct gkyl_array *delta_ts)
 {
   // Deflate the array that holds the shift for TS BCs from 3D to 1D.
+  if (app->cdim < 3)
+    return; // Nothing to deflate.
+ 
   int par_dir = app->cdim-1;
-  if (app->cdim == 2) {
-    gkyl_array_copy_range_to_range(app->delta_ts_x_lo, delta_ts, &app->delta_ts_x_local, &app->local_lower_skin[par_dir]);
-    gkyl_array_copy_range_to_range(app->delta_ts_x_up, delta_ts, &app->delta_ts_x_local, &app->local_upper_skin[par_dir]);
-  }
-  else if (app->cdim == 3) {
-    // First copy the surface delta_ts from its 3D array to a 2D array.
-    struct gkyl_range local_skin_perp;
-    struct gkyl_translate_dim *transd_2d_1d;
-    struct gkyl_array *buffer_perp;
-    // Lower z boundary.
-    gkyl_range_init(&local_skin_perp, app->cdim-1, app->local_lower_skin[par_dir].lower, app->local_lower_skin[par_dir].upper); 
-    buffer_perp = mkarr(app->use_gpu, delta_ts->ncomp, local_skin_perp.volume);
-    gkyl_array_copy_range_to_range(buffer_perp, delta_ts, &local_skin_perp, &app->local_lower_skin[par_dir]);
+  // First copy the surface delta_ts from its 3D array to a 2D array.
+  struct gkyl_range local_skin_perp;
+  struct gkyl_translate_dim *transd_2d_1d;
+  struct gkyl_array *buffer_perp;
 
-    transd_2d_1d = gkyl_translate_dim_new(app->cdim-1, app->gk_geom->surf_basis,
-      1, app->delta_ts_x_basis, 1, GKYL_NO_EDGE, app->use_gpu);
-    gkyl_translate_dim_advance(transd_2d_1d, &local_skin_perp, &app->delta_ts_x_local, buffer_perp, 1, app->delta_ts_x_lo);
-    gkyl_translate_dim_release(transd_2d_1d);
-    gkyl_array_release(buffer_perp);
+  // Lower z boundary.
+  struct gkyl_range *local_skin_lower = app->gk_geom->has_LCFS? &app->local_lower_skin_par_core
+                                                              : &app->local_lower_skin[par_dir];
+  gkyl_range_init(&local_skin_perp, app->cdim-1, local_skin_lower->lower, local_skin_lower->upper); 
+  buffer_perp = mkarr(app->use_gpu, delta_ts->ncomp, local_skin_perp.volume);
+  gkyl_array_copy_range_to_range(buffer_perp, delta_ts, &local_skin_perp, local_skin_lower);
 
-    // Upper z boundary.
-    gkyl_range_init(&local_skin_perp, app->cdim-1, app->local_upper_skin[par_dir].lower, app->local_upper_skin[par_dir].upper); 
-    buffer_perp = mkarr(app->use_gpu, delta_ts->ncomp, local_skin_perp.volume);
-    gkyl_array_copy_range_to_range(buffer_perp, delta_ts, &local_skin_perp, &app->local_upper_skin[par_dir]);
+  transd_2d_1d = gkyl_translate_dim_new(app->cdim-1, app->gk_geom->surf_basis,
+    1, app->delta_ts_x_basis, 1, GKYL_NO_EDGE, app->use_gpu);
+  gkyl_translate_dim_advance(transd_2d_1d, &local_skin_perp, &app->delta_ts_x_rng, buffer_perp, 1, app->delta_ts_x_lo);
+  gkyl_translate_dim_release(transd_2d_1d);
+  gkyl_array_release(buffer_perp);
 
-    transd_2d_1d = gkyl_translate_dim_new(app->cdim-1, app->gk_geom->surf_basis,
-      1, app->delta_ts_x_basis, 1, GKYL_NO_EDGE, app->use_gpu);
-    gkyl_translate_dim_advance(transd_2d_1d, &local_skin_perp, &app->delta_ts_x_local, buffer_perp, 1, app->delta_ts_x_up);
-    gkyl_translate_dim_release(transd_2d_1d);
-    gkyl_array_release(buffer_perp);
-  }
+  // Upper z boundary.
+  struct gkyl_range *local_skin_upper = app->gk_geom->has_LCFS? &app->local_upper_skin_par_core
+                                                              : &app->local_upper_skin[par_dir];
+  gkyl_range_init(&local_skin_perp, app->cdim-1, local_skin_upper->lower, local_skin_upper->upper); 
+  buffer_perp = mkarr(app->use_gpu, delta_ts->ncomp, local_skin_perp.volume);
+  gkyl_array_copy_range_to_range(buffer_perp, delta_ts, &local_skin_perp, local_skin_upper);
+
+  transd_2d_1d = gkyl_translate_dim_new(app->cdim-1, app->gk_geom->surf_basis,
+    1, app->delta_ts_x_basis, 1, GKYL_NO_EDGE, app->use_gpu);
+  gkyl_translate_dim_advance(transd_2d_1d, &local_skin_perp, &app->delta_ts_x_rng, buffer_perp, 1, app->delta_ts_x_up);
+  gkyl_translate_dim_release(transd_2d_1d);
+  gkyl_array_release(buffer_perp);
 }
 
 gkyl_gyrokinetic_app*
@@ -321,6 +323,10 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
     .comm = app->comm,
     .has_LCFS = gk->geometry.has_LCFS,
     .x_LCFS = gk->geometry.x_LCFS,
+    .parallel_lower_bc_shift_func = gk->geometry.parallel_lower_bc_shift_func,
+    .parallel_upper_bc_shift_func = gk->geometry.parallel_upper_bc_shift_func,
+    .parallel_lower_bc_shift_ctx  = gk->geometry.parallel_lower_bc_shift_ctx ,
+    .parallel_upper_bc_shift_ctx  = gk->geometry.parallel_upper_bc_shift_ctx ,
   };
   strcpy(geometry_inp.geometry_path, gk->geometry.geometry_path);
   for(int i = 0; i<3; i++)
@@ -458,44 +464,6 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
   };
   app->io_meta_len = sizeof(io_meta)/sizeof(io_meta[0]);
   app->io_meta = gkyl_msgpack_map_elem_clone(app->io_meta_len, io_meta);
-
-  if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK) {
-    // Create grid, basis and range on which the 1D shift will be defined.
-    gkyl_rect_grid_init(&app->delta_ts_x_grid, 1, app->grid.lower, app->grid.upper, app->grid.cells);
-    int num_ghost[] = { 1, 1, 1 };
-    gkyl_create_grid_ranges(&app->delta_ts_x_grid, num_ghost, &app->delta_ts_x_local_ext, &app->delta_ts_x_local);
-    gkyl_cart_modal_serendip(&app->delta_ts_x_basis, 1, app->basis.poly_order);
-    // Here we define the deflated shift on the global/local range (not the
-    // extended range) because that's what the updater expects.
-    app->delta_ts_x_lo = mkarr(app->use_gpu, app->delta_ts_x_basis.num_basis, app->delta_ts_x_local.volume);
-    app->delta_ts_x_up = mkarr(app->use_gpu, app->delta_ts_x_basis.num_basis, app->delta_ts_x_local.volume);
-
-    if (!gyrokinetic_str_ends_in_bnum(app->name)) {
-      // Sync the numerical shift.
-      int par_dir = app->cdim-1;
-      struct gkyl_array *delta_ts = app->gk_geom->geo_surf[par_dir].deltats;
-      gkyl_array_copy_range_to_range(delta_ts, delta_ts,
-        &app->local_upper_skin[par_dir], &app->local_upper_ghost[par_dir]);
-      int shift_periodic_dirs[] = {par_dir};
-      int shift_num_periodic_dirs = 1;
-      gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, shift_num_periodic_dirs,
-        shift_periodic_dirs, delta_ts);
-
-      struct gkyl_array *buffer = mkarr(app->use_gpu, delta_ts->ncomp, delta_ts->size);
-
-      gkyl_array_copy_range_to_range(buffer, delta_ts, &app->local_upper_skin[par_dir], &app->local_upper_ghost[par_dir]);
-      gkyl_array_accumulate_range(delta_ts, -1.0, buffer, &app->local_upper_skin[par_dir]);
-
-      gkyl_array_copy_range_to_range(buffer, delta_ts, &app->local_lower_skin[par_dir], &app->local_lower_ghost[par_dir]);
-      gkyl_array_accumulate_range(delta_ts, -1.0, buffer, &app->local_lower_skin[par_dir]);
-      gkyl_array_release(buffer);
-
-      // Deflate delta_ts.
-      gyrokinetic_deflate_delta_ts(app, delta_ts);
-    }
-  }
-
-  gkyl_gyrokinetic_app_write_geometry(app, &geometry_inp);
 
   // Allocate 1/(J.B) using weak mul/div.
   struct gkyl_array *tmp = mkarr(app->use_gpu, app->basis.num_basis, app->local_ext.volume);
@@ -650,6 +618,45 @@ gkyl_gyrokinetic_app_new_geom(struct gkyl_gk *gk)
     upper_bcdir_ext[par_dir] = app->local_ext_core.upper[par_dir];
     gkyl_sub_range_init(&app->local_par_ext_core, &app->local_ext_core, lower_bcdir_ext, upper_bcdir_ext);
   }
+
+  if (app->cdim == 3 && app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK) {
+    // Create grid, range and basis on which the 1D shift will be defined.
+    gkyl_rect_grid_init(&app->delta_ts_x_grid, 1, app->grid.lower, app->grid.upper, app->grid.cells);
+    struct gkyl_range *ts_s_rng = gk->geometry.has_LCFS? &app->local_core : &app->local;
+    gkyl_range_init(&app->delta_ts_x_rng, 1, ts_s_rng->lower, ts_s_rng->upper);
+    gkyl_cart_modal_serendip(&app->delta_ts_x_basis, 1, app->basis.poly_order);
+    // Here we define the deflated shift on the global/local range (not the
+    // extended range) because that's what the updater expects.
+    app->delta_ts_x_lo = mkarr(app->use_gpu, app->delta_ts_x_basis.num_basis, app->delta_ts_x_rng.volume);
+    app->delta_ts_x_up = mkarr(app->use_gpu, app->delta_ts_x_basis.num_basis, app->delta_ts_x_rng.volume);
+
+    if (!gyrokinetic_str_ends_in_bnum(app->name)) {
+      // Sync the numerical shift.
+      int par_dir = app->cdim-1;
+      struct gkyl_array *delta_ts = app->gk_geom->geo_surf[par_dir].deltats;
+      gkyl_array_copy_range_to_range(delta_ts, delta_ts,
+        &app->local_upper_skin[par_dir], &app->local_upper_ghost[par_dir]);
+      int shift_periodic_dirs[] = {par_dir};
+      int shift_num_periodic_dirs = 1;
+      gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext, shift_num_periodic_dirs,
+        shift_periodic_dirs, delta_ts);
+
+      struct gkyl_array *buffer = mkarr(app->use_gpu, delta_ts->ncomp, delta_ts->size);
+
+      gkyl_array_copy_range_to_range(buffer, delta_ts, &app->local_upper_skin[par_dir], &app->local_upper_ghost[par_dir]);
+      gkyl_array_accumulate_range(delta_ts, -1.0, buffer, &app->local_upper_skin[par_dir]);
+
+      gkyl_array_copy_range_to_range(buffer, delta_ts, &app->local_lower_skin[par_dir], &app->local_lower_ghost[par_dir]);
+      gkyl_array_accumulate_range(delta_ts, -1.0, buffer, &app->local_lower_skin[par_dir]);
+      gkyl_array_release(buffer);
+
+      // Deflate delta_ts.
+      gyrokinetic_deflate_delta_ts(app, delta_ts);
+    }
+  }
+
+  // Write geometric quantities to file.
+  gkyl_gyrokinetic_app_write_geometry(app, &geometry_inp);
 
   return app;
 }
@@ -912,7 +919,7 @@ gkyl_gyrokinetic_app_new_solver(struct gkyl_gk *gk, gkyl_gyrokinetic_app *app)
     }
   }
 
-  // Initialize EIRENE
+  // Initialize EIRENE.
   app->eirene = gk_eirene_init(app, gk);
 
   // Set the appropriate update function for taking a single time step
@@ -929,7 +936,7 @@ gkyl_gyrokinetic_app_new_solver(struct gkyl_gk *gk, gkyl_gyrokinetic_app *app)
   // Pre-compute time-independent factors in omega_H.
   gkyl_gyrokinetic_app_omegaH_init(app); 
 
-  // initialize stat object
+  // Initialize stat object.
   app->stat = (struct gkyl_gyrokinetic_stat) {
     .use_gpu = app->use_gpu,
     .stage_2_dt_diff = { DBL_MAX, 0.0 },
@@ -1183,14 +1190,107 @@ gyrokinetic_app_geometry_copy_and_write_surf(gkyl_gyrokinetic_app* app, struct g
   gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, arr_host_doubled, fileNm);
 }
 
+static void
+gyrokinetic_app_write_ts_shift_mapc2p(struct gkyl_gyrokinetic_app *app)
+{
+  // Write the discretized shift (for TS BCs) to file for mapc2p geo.
+  int par_dir = app->cdim-1;
+  bool has_LCFS = app->gk_geom->has_LCFS;
+  bool bc_has_twistshift = app->gk_geom->parallel_lower_bc_shift_func && app->gk_geom->parallel_upper_bc_shift_func;
+
+  int comm_rank, comm_size;
+  gkyl_comm_get_rank(app->comm, &comm_rank);
+  gkyl_comm_get_size(app->comm, &comm_size);
+
+  const char *vars[] = {"x","y","z"};
+  const char *edge[] = {"lower","upper"};
+  const char *fmt = "%s-bc_%s%s_twistshift.gkyl";
+
+  for (int eI = 0; eI < 2; eI++) {
+    int ghost[] = {1, 1, 1};
+    // TS BC updater.
+    struct gkyl_bc_twistshift_inp ts_inp = {
+      .bc_dir = par_dir,
+      .shift_dir = 1, // y shift.
+      .shear_dir = 0, // shift varies with x.
+      .edge = eI == 0? GKYL_LOWER_EDGE : GKYL_UPPER_EDGE,
+      .cdim = app->cdim,
+      .bcdir_ext_update_r = app->global_par_ext,
+      .num_ghost = ghost, // one ghost per config direction
+      .basis = app->basis,
+      .grid = app->grid,
+      .shift_func = eI == 0? app->gk_geom->parallel_lower_bc_shift_func : app->gk_geom->parallel_upper_bc_shift_func,
+      .shift_func_ctx = eI == 0? app->gk_geom->parallel_lower_bc_shift_ctx : app->gk_geom->parallel_upper_bc_shift_ctx,
+      .use_gpu = app->use_gpu,
+    };
+    struct gkyl_bc_twistshift *bc_ts_op = gkyl_bc_twistshift_new(&ts_inp);
+
+    struct gkyl_array *delta_ts_x = eI == 0? app->delta_ts_x_lo : app->delta_ts_x_up;
+    delta_ts_x = gkyl_bc_twistshift_get_shift_objects(bc_ts_op,
+      &app->delta_ts_x_grid, &app->delta_ts_x_rng, &app->delta_ts_x_basis);
+
+    struct gkyl_rect_grid delta_ts_x_grid_core;
+    if (has_LCFS) {
+      // Twistshift updater stores the shift on a restricted range (the core)
+      // but on a full grid. Create a restricted grid for I/O.
+      double lower[1], upper[1];
+      int cells[] = {app->delta_ts_x_rng.volume};
+      if (app->gk_geom->geqdsk_sign_convention == 0) {
+        // x increases towards SOL.
+        lower[0] = app->delta_ts_x_grid.lower[0];
+        upper[0] = app->delta_ts_x_grid.lower[0] + app->delta_ts_x_grid.dx[0]*cells[0];
+        gkyl_rect_grid_init(&delta_ts_x_grid_core, app->delta_ts_x_grid.ndim, lower, upper, cells);
+      }
+      else {
+        // x increases towards SOL.
+        lower[0] = app->delta_ts_x_grid.upper[0] - app->delta_ts_x_grid.dx[0]*cells[0];
+        upper[0] = app->delta_ts_x_grid.upper[0];
+        gkyl_rect_grid_init(&delta_ts_x_grid_core, app->delta_ts_x_grid.ndim, lower, upper, cells);
+      }
+    }
+    else
+      delta_ts_x_grid_core = app->delta_ts_x_grid;
+
+    // Package metadata for shift file.
+    struct gkyl_msgpack_map_elem io_meta_shift_dg[] = {
+      { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = app->delta_ts_x_basis.poly_order },
+      { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = app->delta_ts_x_basis.id }
+    };
+    int io_meta_shift_dg_len = sizeof(io_meta_shift_dg)/sizeof(io_meta_shift_dg[0]);
+    int io_meta_shift_len[] = {app->io_meta_basic_len, io_meta_shift_dg_len};
+    const struct gkyl_msgpack_map_elem* io_meta_shift[] = {app->io_meta_basic, io_meta_shift_dg};
+    struct gkyl_msgpack_data *mt_shift = gkyl_msgpack_create_union(sizeof(io_meta_shift_len)/sizeof(int),
+      io_meta_shift_len, io_meta_shift);
+
+    if ((eI == 0 && comm_rank == 0) || (eI == 1 && comm_rank == comm_size-1)) {
+      int sz = gkyl_calc_strlen(fmt, app->name, vars[par_dir], edge[eI]);
+      char fileNm[sz+1]; // ensures no buffer overflow
+      sprintf(fileNm, fmt, app->name, vars[par_dir], edge[eI]);
+      gkyl_grid_sub_array_write(&delta_ts_x_grid_core, &app->delta_ts_x_rng, mt_shift, delta_ts_x, fileNm);
+    }
+
+    gkyl_array_release(delta_ts_x);
+    gkyl_msgpack_data_release(mt_shift);
+    gkyl_bc_twistshift_release(bc_ts_op);
+  }
+}
+
 void
 gyrokinetic_app_write_ts_shift(gkyl_gyrokinetic_app* app)
 {
-  if (app->cdim > 1 && app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK) {
-    int rank;
-    gkyl_comm_get_rank(app->comm, &rank);
-    int comm_sz;
-    gkyl_comm_get_size(app->comm, &comm_sz);
+  int par_dir = app->cdim-1;
+  bool has_LCFS = app->gk_geom->has_LCFS;
+  bool bc_has_twistshift = app->gk_geom->parallel_lower_bc_shift_func && app->gk_geom->parallel_upper_bc_shift_func;
+
+  if (app->cdim < 3 || (!(bc_has_twistshift || has_LCFS)))
+    return; // Nothing to write.
+
+  if (app->gk_geom->geometry_id == GKYL_GEOMETRY_MAPC2P)
+    gyrokinetic_app_write_ts_shift_mapc2p(app);
+  else if (app->gk_geom->geometry_id == GKYL_GEOMETRY_TOKAMAK) {
+    int comm_rank, comm_size;;
+    gkyl_comm_get_rank(app->comm, &comm_rank);
+    gkyl_comm_get_size(app->comm, &comm_size);
 
     // Write the shift for TS BCs.
     struct gkyl_array *delta_ts_x_ho = mkarr(false, app->delta_ts_x_lo->ncomp, app->delta_ts_x_lo->size);
@@ -1206,24 +1306,49 @@ gyrokinetic_app_write_ts_shift(gkyl_gyrokinetic_app* app)
     const struct gkyl_msgpack_map_elem* io_meta_ts[] = {app->io_meta_basic, io_meta_x, app->gk_geom->io_meta};
     struct gkyl_msgpack_data *mt_x = gkyl_msgpack_create_union(sizeof(io_meta_ts_len)/sizeof(int), io_meta_ts_len, io_meta_ts);
 
-    if (rank == 0) {
-      const char *fmt = "%s-%s.gkyl";
-      int sz = gkyl_calc_strlen(fmt, app->name, "delta_ts_lo");
+    const char *vars[] = {"x","y","z"};
+    const char *edge[] = {"lower","upper"};
+    const char *fmt = "%s-bc_%s%s_twistshift.gkyl";
+
+    struct gkyl_rect_grid delta_ts_x_grid_core;
+    if (has_LCFS) {
+      // Twistshift updater stores the shift on a restricted range (the core)
+      // but on a full grid. Create a restricted grid for I/O.
+      double lower[1], upper[1];
+      int cells[] = {app->delta_ts_x_rng.volume};
+      if (app->gk_geom->geqdsk_sign_convention == 0) {
+        // x increases towards SOL.
+        lower[0] = app->delta_ts_x_grid.lower[0];
+        upper[0] = app->delta_ts_x_grid.lower[0] + app->delta_ts_x_grid.dx[0]*cells[0];
+        gkyl_rect_grid_init(&delta_ts_x_grid_core, app->delta_ts_x_grid.ndim, lower, upper, cells);
+      }
+      else {
+        // x increases towards SOL.
+        lower[0] = app->delta_ts_x_grid.upper[0] - app->delta_ts_x_grid.dx[0]*cells[0];
+        upper[0] = app->delta_ts_x_grid.upper[0];
+        gkyl_rect_grid_init(&delta_ts_x_grid_core, app->delta_ts_x_grid.ndim, lower, upper, cells);
+      }
+    }
+    else
+      delta_ts_x_grid_core = app->delta_ts_x_grid;
+
+    if (comm_rank == 0) {
+      int sz = gkyl_calc_strlen(fmt, app->name, vars[par_dir], edge[0]);
       char fileNm[sz+1]; // ensures no buffer overflow
-      sprintf(fileNm, fmt, app->name, "delta_ts_lo");
-      gkyl_grid_sub_array_write(&app->delta_ts_x_grid, &app->delta_ts_x_local, mt_x, app->delta_ts_x_lo, fileNm);
+      sprintf(fileNm, fmt, app->name, vars[par_dir], edge[0]);
+      gkyl_grid_sub_array_write(&delta_ts_x_grid_core, &app->delta_ts_x_rng, mt_x, app->delta_ts_x_lo, fileNm);
     }
 
-    if (rank == comm_sz-1) {
-      const char *fmt = "%s-%s.gkyl";
-      int sz = gkyl_calc_strlen(fmt, app->name, "delta_ts_up");
+    if (comm_rank == comm_size-1) {
+      int sz = gkyl_calc_strlen(fmt, app->name, vars[par_dir], edge[1]);
       char fileNm[sz+1]; // ensures no buffer overflow
-      sprintf(fileNm, fmt, app->name, "delta_ts_up");
-      gkyl_grid_sub_array_write(&app->delta_ts_x_grid, &app->delta_ts_x_local, mt_x, app->delta_ts_x_up, fileNm);
+      sprintf(fileNm, fmt, app->name, vars[par_dir], edge[1]);
+      gkyl_grid_sub_array_write(&delta_ts_x_grid_core, &app->delta_ts_x_rng, mt_x, app->delta_ts_x_up, fileNm);
     }
     gkyl_msgpack_data_release(mt_x);
     gkyl_array_release(delta_ts_x_ho);
   }
+  
 }
 
 void
@@ -1307,10 +1432,6 @@ gkyl_gyrokinetic_app_write_geometry(gkyl_gyrokinetic_app* app, struct gkyl_gk_ge
     gyrokinetic_app_geometry_copy_and_write_surf(app, app->gk_geom->geo_surf[dir].deltats     , arr_surf_ho1, arr_surf_ho2 , "deltats"     , dir, mt);
   }
 
-  // Write twistshift shift.
-  if (!gyrokinetic_str_ends_in_bnum(app->name))
-    gyrokinetic_app_write_ts_shift(app);
-
   // Write out nodes. This has to be done from rank 0 so we need to gather mc2p.
   struct gkyl_array *mc2p_global = mkarr(app->use_gpu, app->gk_geom->geo_corn.mc2p->ncomp, app->global_ext.volume);
   gkyl_comm_array_allgather(app->comm, &app->local, &app->global, app->gk_geom->geo_corn.mc2p, mc2p_global);
@@ -1368,6 +1489,10 @@ gkyl_gyrokinetic_app_write_geometry(gkyl_gyrokinetic_app* app, struct gkyl_gk_ge
     gkyl_nodal_ops_release(n2m);
     gkyl_array_release(mc2pint_nodal);
   }
+
+  // Write twistshift shift.
+  if (!gyrokinetic_str_ends_in_bnum(app->name))
+    gyrokinetic_app_write_ts_shift(app);
 
   gkyl_array_release(mc2p_global);
   gkyl_array_release(mc2p_global_ho);

--- a/gyrokinetic/apps/gyrokinetic_lw.c
+++ b/gyrokinetic/apps/gyrokinetic_lw.c
@@ -138,7 +138,6 @@ static const struct gkyl_str_int_pair gk_bcs[] = {
   { "speciesZeroFlux", GKYL_BC_GK_SPECIES_ZERO_FLUX }, // Zero flux.
   { "speciesSheath", GKYL_BC_GK_SPECIES_SHEATH }, // Sheath.
   { "speciesRecycle", GKYL_BC_GK_SPECIES_RECYCLE }, // Recycling.
-  { "speciesIWL", GKYL_BC_GK_SPECIES_IWL }, // Inner wall limited.
   { "speciesPeriodic", GKYL_BC_GK_SPECIES_PERIODIC }, // Periodic.
   { "speciesTwistshift", GKYL_BC_GK_SPECIES_TWISTSHIFT }, // Twist-shift.
   // Field BCs.

--- a/gyrokinetic/creg/rt_gk_d3d_iwl_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_d3d_iwl_2x2v_p1.c
@@ -632,8 +632,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 4,
@@ -722,8 +722,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 4,

--- a/gyrokinetic/creg/rt_gk_d3d_iwl_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_d3d_iwl_3x2v_p1.c
@@ -714,8 +714,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
-      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_lo, .aux_ctx = &ctx },
-      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_up, .aux_ctx = &ctx },
+      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
+      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
     },
 
     .num_diag_moments = 1,
@@ -802,8 +802,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
-      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_lo, .aux_ctx = &ctx },
-      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_up, .aux_ctx = &ctx },
+      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
+      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
     },
 
     .num_diag_moments = 1,
@@ -871,6 +871,10 @@ main(int argc, char **argv)
       .bfield_ctx = &ctx,
       .has_LCFS = true,
       .x_LCFS = ctx.x_LCFS, // Location of last closed flux surface.
+      .parallel_lower_bc_shift_func = bc_shift_func_lo,
+      .parallel_upper_bc_shift_func = bc_shift_func_up,
+      .parallel_lower_bc_shift_ctx = &ctx,
+      .parallel_upper_bc_shift_ctx = &ctx,
     },
 
     .num_periodic_dir = 1,

--- a/gyrokinetic/creg/rt_gk_ltx_iwl_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_ltx_iwl_2x2v_p1.c
@@ -359,8 +359,8 @@ int main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 5,
@@ -428,8 +428,8 @@ int main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
     
     .num_diag_moments = 5,

--- a/gyrokinetic/creg/rt_gk_ltx_iwl_num_miller_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_ltx_iwl_num_miller_3x2v_p1.c
@@ -168,7 +168,7 @@ create_ctx(void)
   double qe = -eV; // electron charge
 
   // Geometry and magnetic field.
-  double Lz        = 2.0*(M_PI-1e-14);    // Domain size along magnetic field.
+  double Lz = 2.0*(M_PI-1e-14);    // Domain size along magnetic field.
   double Ly = 2.0*M_PI/8.0;
   double B0 = 0.24;
   double psi_LCFS = 0.003172759514520552; // psi at LCFS. Taken from efit
@@ -346,8 +346,8 @@ int main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 5,
@@ -408,8 +408,8 @@ int main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
     
     .num_diag_moments = 5,
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
 
   // field
   struct gkyl_gyrokinetic_field field = {
-    //.gkfield_id = GKYL_GK_FIELD_ES_IWL,
+    .gkfield_id = GKYL_GK_FIELD_ES,
     .poisson_bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_FIELD_DIRICHLET, .value = {0.0}, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_FIELD_DIRICHLET, .value = {0.0}, },
@@ -460,8 +460,8 @@ int main(int argc, char **argv)
       .geometry_id = GKYL_GEOMETRY_TOKAMAK,
       .efit_info = efit_inp,
       .tok_grid_info = grid_inp,
-      //.has_LCFS = true,
-      //.x_LCFS = ctx.psi_LCFS, // Location of last closed flux surface.
+      .has_LCFS = true,
+      .x_LCFS = ctx.psi_LCFS, // Location of last closed flux surface.
     },
 
     .num_periodic_dir = 1,

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_2x2v_p1.c
@@ -640,8 +640,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
     },
 
     .num_diag_moments = 9,
@@ -721,8 +721,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB },
-      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL },
-      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL },
+      { .dir = 1, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
+      { .dir = 1, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH },
     },
 
     .num_diag_moments = 9,

--- a/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_tcv_iwl_adapt_source_3x2v_p1.c
@@ -681,8 +681,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_lo, .aux_ctx = &ctx, },
-      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_up, .aux_ctx = &ctx, },
+      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 9,
@@ -766,8 +766,8 @@ main(int argc, char **argv)
     .bcs = {
       { .dir = 0, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
       { .dir = 0, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_ABSORB, },
-      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_lo, .aux_ctx = &ctx, },
-      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_IWL, .aux_profile = bc_shift_func_up, .aux_ctx = &ctx, },
+      { .dir = 2, .edge = GKYL_LOWER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
+      { .dir = 2, .edge = GKYL_UPPER_EDGE, .type = GKYL_BC_GK_SPECIES_SHEATH, },
     },
 
     .num_diag_moments = 9,
@@ -828,6 +828,10 @@ main(int argc, char **argv)
     .bfield_ctx = &ctx,
     .has_LCFS = true,
     .x_LCFS = ctx.x_LCFS,
+    .parallel_lower_bc_shift_func = bc_shift_func_lo,
+    .parallel_upper_bc_shift_func = bc_shift_func_up,
+    .parallel_lower_bc_shift_ctx = &ctx,
+    .parallel_upper_bc_shift_ctx = &ctx,
   };
 
   // Parallelism

--- a/gyrokinetic/zero/gk_geometry.c
+++ b/gyrokinetic/zero/gk_geometry.c
@@ -57,6 +57,12 @@ gkyl_gk_geometry_new(struct gk_geometry* geo_host, struct gkyl_gk_geometry_inp *
     }
   }
 
+  // Function pointers to twistshift function.
+  up->parallel_lower_bc_shift_func = geometry_inp->parallel_lower_bc_shift_func;
+  up->parallel_upper_bc_shift_func = geometry_inp->parallel_upper_bc_shift_func;
+  up->parallel_lower_bc_shift_ctx  = geometry_inp->parallel_lower_bc_shift_ctx;
+  up->parallel_upper_bc_shift_ctx  = geometry_inp->parallel_upper_bc_shift_ctx;
+
   if (up->grid.ndim > 1) {
     gkyl_cart_modal_serendip(&up->surf_basis, up->grid.ndim-1, up->basis.poly_order);
     up->num_surf_basis = up->surf_basis.num_basis;

--- a/gyrokinetic/zero/gk_geometry_mapc2p.c
+++ b/gyrokinetic/zero/gk_geometry_mapc2p.c
@@ -390,6 +390,12 @@ gk_geometry_mapc2p_init(struct gkyl_gk_geometry_inp *geometry_inp)
     }
   }
 
+  // Function pointers to twistshift function.
+  up->parallel_lower_bc_shift_func = geometry_inp->parallel_lower_bc_shift_func;
+  up->parallel_upper_bc_shift_func = geometry_inp->parallel_upper_bc_shift_func;
+  up->parallel_lower_bc_shift_ctx  = geometry_inp->parallel_lower_bc_shift_ctx ;
+  up->parallel_upper_bc_shift_ctx  = geometry_inp->parallel_upper_bc_shift_ctx ;
+
   gk_geometry_set_nodal_ranges(up) ;
 
   // Initialize surface basis abd allocate surface geo

--- a/gyrokinetic/zero/gkyl_gk_bc_type.h
+++ b/gyrokinetic/zero/gkyl_gk_bc_type.h
@@ -16,7 +16,6 @@ enum gkyl_gyrokinetic_bc_type {
   GKYL_BC_GK_SPECIES_ZERO_FLUX, // Zero flux.
   GKYL_BC_GK_SPECIES_SHEATH, // Sheath.
   GKYL_BC_GK_SPECIES_RECYCLE, // Recycling.
-  GKYL_BC_GK_SPECIES_IWL, // Inner wall limited.
   GKYL_BC_GK_SPECIES_PERIODIC, // Periodic.
   GKYL_BC_GK_SPECIES_TWISTSHIFT, // Twist-shift.
   GKYL_BC_GK_SPECIES_BOUNDARY_VALUE, // Skin value at the boundary.
@@ -26,7 +25,6 @@ enum gkyl_gyrokinetic_bc_type {
   GKYL_BC_GK_FIELD_NEUMANN, // Nemann.
   GKYL_BC_GK_FIELD_DIRICHLET_VARYING, // Spatially varying Dirichlet.
   GKYL_BC_GK_FIELD_BOUNDARY_VALUE, // Skin value at the boundary.
-  GKYL_BC_GK_FIELD_IWL, // Inner wall limited.
   GKYL_BC_GK_FIELD_TWISTSHIFT, // Twist-shift.
 };
 

--- a/gyrokinetic/zero/gkyl_gk_geometry.h
+++ b/gyrokinetic/zero/gkyl_gk_geometry.h
@@ -183,6 +183,12 @@ struct gk_geometry {
                  // in the eqdsk.
   int idx_LCFS_lo; // Index of the cell that abuts the LCFS from below.
 
+  // Functions defining the twistshift for parallel BCs.
+  void (*parallel_lower_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void (*parallel_upper_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void *parallel_lower_bc_shift_ctx; // Context for parallel_lower_bc_shift_func.
+  void *parallel_upper_bc_shift_ctx; // Context for parallel_upper_bc_shift_func.
+
   struct gkyl_msgpack_map_elem* io_meta; // Metadata for I/O.
   int io_meta_len; // Number of elements in io_meta.
 
@@ -217,6 +223,12 @@ struct gkyl_gk_geometry_inp {
   void *bfield_ctx; // Context for bfield function.
   // Pointer to bfield function.
   void (*bfield_func)(double t, const double *xc, double *xp, void *ctx);
+
+  // Functions defining the twistshift for parallel BCs.
+  void (*parallel_lower_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void (*parallel_upper_bc_shift_func)(double t, const double *xn, double *fout, void *ctx);
+  void *parallel_lower_bc_shift_ctx; // Context for parallel_lower_bc_shift_func.
+  void *parallel_upper_bc_shift_ctx; // Context for parallel_upper_bc_shift_func.
 
   struct gkyl_efit_inp efit_info; // Context with RZ data such as efit file for a tokamak or mirror.
   struct gkyl_tok_geo_grid_inp tok_grid_info; // Context for tokamak geometry with computational domain info.


### PR DESCRIPTION
Remove the IWL species and field enums from input files and from the app. Clopen is a property of the geometry, and it's been cumbersome to have it given to the app through the species BC. Here we fix that.

Now, for clopen IWL calculations, one should:
- Specify the SOL BC in the species BC table.
- Pass the LCFS location to the geometry table (we already did that).
- For 3x: pass the twistshift shift via the geometry table.

The app will know to apply periodicity (2x) or twistshift (3x) in the core.

Similar treatment should be followed in input files with numerical geometry. This new approach also made it a bit easier to write out the shift in both cases.