### PR TITLE
Improving KANN usability with a few utilities and tests

### DIFF
--- a/core/creg/rt_kann_mlp.c
+++ b/core/creg/rt_kann_mlp.c
@@ -1,0 +1,179 @@
+// Construct a MLP with KANN and fit a simple 1D function
+#include <kann.h>
+#include <knutils.h>
+
+#include <stdlib.h>
+#include <unistd.h>
+
+struct xrange {
+  float xleft, xright;
+  int N;
+};
+
+static inline float
+xrange_n(struct xrange xr, int n)
+{
+  float dx = (xr.xright-xr.xleft)/(xr.N-1);
+  return xr.xleft + dx*n;
+}
+
+// function to fit
+static inline float
+ufunc(float x)
+{
+  return 1.0f/(1.0f+100.0f*x*x);
+}
+
+struct train_inp {
+  int ntrain;
+  int nwidth;
+  int ndepth;
+  float learning_rate;
+};
+
+void
+train_ann(struct train_inp *nn_inp, const char *nn_name)
+{
+  kad_node_t *t_net;
+  t_net = kann_layer_input(1);
+
+  for (int i=0; i<nn_inp->ndepth; ++i) {
+    t_net = kann_layer_dense(t_net, nn_inp->nwidth);
+    t_net = kad_tanh(t_net);
+  }
+  
+  t_net = kann_layer_cost(t_net, 1, KANN_C_MSE);
+  kann_t *ann = kann_new(t_net, 0);
+
+  // allocate memory for input/output vectors
+  int N = nn_inp->ntrain; // training samples
+  struct kn_vec *inp = kn_vec_new(N, 1);
+  struct kn_vec *out = kn_vec_new(N, 1);
+
+  struct xrange xr = {
+    .xleft = -1.0,
+    .xright = 1.0,
+    .N = N
+  };
+
+  // initialize input/output mapping
+  for (int i=0; i<N; ++i) {
+    inp->vals[i][0] = xrange_n(xr, i);
+    out->vals[i][0] = ufunc(inp->vals[i][0]);
+  }
+
+  // hyper-parameters for training
+  float lr = nn_inp->learning_rate; // learning rate
+  int mini_size = 64;
+  int max_epoch = 50;
+  int max_drop_streak = 10;
+  float frac_val = 0.1f; // fraction of samples to use for validation
+  
+  // run training
+  kann_train_fnn1(ann, lr, mini_size, max_epoch, max_drop_streak, frac_val, N, inp->vals, out->vals);
+  kann_save(nn_name, ann); // save to file
+  
+  kn_vec_release(inp);
+  kn_vec_release(out);
+  kann_delete(ann);  
+}
+
+// run inference on N input values
+void
+infer_ann(const char *nn_name, const struct kn_vec *inp, struct kn_vec *out)
+{
+  kann_t *ann = kann_load(nn_name);
+  const float *ov;
+  for (int i=0; i<inp->nvec; ++i) {
+    ov = kann_apply1(ann, inp->vals[i]);
+    for (int j=0; j<out->N; ++j) out->vals[i][j] = ov[j];
+  }
+  kann_delete(ann);
+}
+
+void
+write_to_gplot(const struct kn_vec *inp, const struct kn_vec *out)
+{
+  FILE *fp = fopen("gplot.gp", "w");
+  fprintf(fp, "set macros\n");
+  fprintf(fp, "set style line 1 lc rgb '#0060ad' lt 1 lw 2 pt 5   # blue\n");
+  fprintf(fp, "set style line 2 lc rgb '#dd181f' lt 1 lw 2 pt 7   # red\n");
+  fprintf(fp, "BLUE = \"1\"\n");
+  fprintf(fp, "RED = \"2\"\n");
+  fprintf(fp, "set grid\n");
+  fprintf(fp, "plot \"data.txt\" using 1:2 with points pt 9 ps 3 title \"NN\", [-1:1] 1/(1+100*x**2) with lines ls @BLUE title \"Exact\"");
+  fclose(fp);  
+  
+  fp = fopen("data.txt", "w");
+  for (int i=0; i<inp->nvec; ++i)
+    fprintf(fp, "%.5g %.5g\n", inp->vals[i][0], out->vals[i][0]);
+  fclose(fp);  
+}
+
+int
+main(int argc, char *argv[])
+{
+  int p_train = 0, p_infer = 0, p_verbose = 0, c;
+  while ((c = getopt(argc, argv, "+htiv")) != -1) {
+    switch (c)
+    {
+      case 'h':
+        fprintf(stdout, "rt_kann_mlp -i -t -v\n");
+        fprintf(stdout, "  -t Run Training\n");
+        fprintf(stdout, "  -i Run Inference\n");
+        fprintf(stdout, "  -v Verbose mode\n");
+        exit(0);
+        break;      
+      
+      case 't':
+        p_train = 1;
+        break;
+
+      case 'i':
+        p_infer = 1;
+        break;
+
+      case 'v':
+        p_verbose = 3;
+        break;
+      
+      case '?':
+        break;
+    }
+  }
+
+  kann_set_verbose_level(p_verbose);
+
+  if (p_train) {
+    fprintf(stdout, "*** Training\n");
+    train_ann( &(struct train_inp) {
+        .ntrain = 1001,
+        .ndepth = 2,
+        .nwidth = 256,
+        .learning_rate = 1e-3f
+      },
+      "example1.kann"
+    );
+  }
+
+  if (p_infer) {
+    fprintf(stdout, "*** Inference\n");
+    // run inference
+    int nvec = 11;
+    struct kn_vec *inp = kn_vec_new(nvec, 1);
+    struct kn_vec *out = kn_vec_new(nvec, 1);
+
+    struct xrange xr = { .xleft = -1.0, .xright = 1.0, .N = inp->nvec };
+    for (int i=0; i<inp->nvec; ++i)
+      inp->vals[i][0] = xrange_n(xr, i);
+  
+    infer_ann("example1.kann", inp, out);
+    write_to_gplot(inp, out);
+    
+    kn_vec_release(inp);
+    kn_vec_release(out);
+
+  }
+  
+  return 0;
+}

--- a/core/minus/kann.c
+++ b/core/minus/kann.c
@@ -8,7 +8,7 @@
 
 static int kann_verbose = 0;
 
-void kann_set_verbose_leve(int level) { kann_verbose = level; }
+void kann_set_verbose_level(int level) { kann_verbose = level; }
 
 /******************************************
  *** @@BASIC: fundamental KANN routines ***

--- a/core/minus/kann.c
+++ b/core/minus/kann.c
@@ -6,7 +6,9 @@
 #include <stdarg.h>
 #include "kann.h"
 
-int kann_verbose = 0;
+static int kann_verbose = 0;
+
+void kann_set_verbose_leve(int level) { kann_verbose = level; }
 
 /******************************************
  *** @@BASIC: fundamental KANN routines ***

--- a/core/minus/kann.h
+++ b/core/minus/kann.h
@@ -53,7 +53,7 @@ typedef struct {
 } kann_t;
 
 /* level = 3 for verbose output */
-void kann_set_verbose_leve(int level);
+void kann_set_verbose_level(int level);
 
 #define kann_size_var(a) kad_size_var((a)->n, (a)->v)
 #define kann_size_const(a) kad_size_const((a)->n, (a)->v)

--- a/core/minus/kann.h
+++ b/core/minus/kann.h
@@ -52,7 +52,8 @@ typedef struct {
 	void *mt;         /* auxiliary data for multi-threading; NULL if multi-threading disabled */
 } kann_t;
 
-extern int kann_verbose;
+/* level = 3 for verbose output */
+void kann_set_verbose_leve(int level);
 
 #define kann_size_var(a) kad_size_var((a)->n, (a)->v)
 #define kann_size_const(a) kad_size_const((a)->n, (a)->v)

--- a/core/minus/knutils.c
+++ b/core/minus/knutils.c
@@ -1,0 +1,29 @@
+#include <knutils.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+struct
+kn_vec* kn_vec_new(int nvec, int N)
+{
+  struct kn_vec *vec = malloc(sizeof(*vec));
+  vec->nvec = nvec;
+  vec->N = N;
+
+  vec->vals = malloc(nvec*sizeof(float*));
+  vec->data = calloc(nvec*N, sizeof(float));
+
+  vec->vals[0] = &vec->data[0];
+  for (int i=1; i<nvec; ++i)
+    vec->vals[i] = vec->vals[i-1] + N;
+
+  return vec;
+}
+
+void
+kn_vec_release(struct kn_vec *vec)
+{
+  free(vec->vals);
+  free(vec->data);
+  free(vec);
+}

--- a/core/minus/knutils.h
+++ b/core/minus/knutils.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Struct to hold data passed to KANN functions: nvec float vectors
+// with N elements each
+struct kn_vec {
+  int nvec; // number of vectors
+  int N; // length of each vector
+  float **vals; // for passing into kann functions
+  float *data; // actual data (do not use directly)
+};
+
+/**
+ * Create a new kn_vec to hold @a nvec vectors, each of size @a N.
+ *
+ * @param nvec Number of vectors to create
+ * @param N Length of each vector.
+ * @return New kn_vec
+ */
+struct kn_vec* kn_vec_new(int nvec, int N);
+
+/**
+ * Release kn_vec.
+ *
+ * @param vec Vector to release.
+ */
+void kn_vec_release(struct kn_vec *vec);


### PR DESCRIPTION
I have added some basic data-structures to KANN to allow using it more cleanly. Probably this needs some more work specially to get it work on GPUs (for which we need to use our infra). But this PR gets the code in place. 

I have also added a regression test to core/creg to illustrate how to use KANN to train a simple MLP. We will add more tests as we work on RNNs, BEACONS and other architectures. The  regression test produces Gnuplot output that can be plotted if one has Gnuplot installed. Run using:

`./build/core/creg/rt_kann_mlp -itv
`

The flags make the code to run 't'raining, 'i'nferrence in a 'v'erbose manner. The plot can be created by:

`gnuplot -p gplot.gp
`

It should look like this plot.

<img width="662" height="598" alt="KANN-ML-regression" src="https://github.com/user-attachments/assets/3c76ddc9-13ff-4bf7-97f6-b85d64b22c13" />
