### PR TITLE
MB Diffusion Fix

### DIFF
--- a/gyrokinetic/apps/gyrokinetic_multib.c
+++ b/gyrokinetic/apps/gyrokinetic_multib.c
@@ -832,6 +832,14 @@ and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot
 
     if (has_anomalous_diff) {
       any_anomalous_diff = true;
+      // Divide diffD by dz before the transfer
+      for (int b=0; b<mbapp->num_local_blocks; ++b) {
+        struct gkyl_gyrokinetic_app *sbapp = mbapp->singleb_apps[b];
+        int d  = 0;
+        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, sbapp->grid.dx[1], &sbapp->global);
+      }
+
+      // Sync
       struct gkyl_array *gkad_nu[mbapp->num_local_blocks];
       for (int b=0; b<mbapp->num_local_blocks; ++b) {
         struct gkyl_gyrokinetic_app *sbapp = mbapp->singleb_apps[b];
@@ -839,6 +847,14 @@ and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot
       }
       gkyl_multib_comm_conn_array_transfer(mbapp->comm, mbapp->num_local_blocks, mbapp->local_blocks,
         mbapp->mbcc_sync_conf->send, mbapp->mbcc_sync_conf->recv, gkad_nu, gkad_nu);
+
+      // Multiply by diffD dz after the transfer to achieve rescaling
+      for (int b=0; b<mbapp->num_local_blocks; ++b) {
+        struct gkyl_gyrokinetic_app *sbapp = mbapp->singleb_apps[b];
+        int d  = 0;
+        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, 1.0/sbapp->grid.dx[1], &sbapp->global_ext);
+      }
+
     }
   }
 

--- a/gyrokinetic/apps/gyrokinetic_multib.c
+++ b/gyrokinetic/apps/gyrokinetic_multib.c
@@ -836,7 +836,7 @@ and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot
       for (int b=0; b<mbapp->num_local_blocks; ++b) {
         struct gkyl_gyrokinetic_app *sbapp = mbapp->singleb_apps[b];
         int d  = 0;
-        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, sbapp->grid.dx[1], &sbapp->global);
+        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, sbapp->grid.dx[sbapp->cdim-1], &sbapp->global);
       }
 
       // Sync
@@ -852,7 +852,7 @@ and the maximum number of cuts in a block is %d\n\n", tot_max[0], num_ranks, tot
       for (int b=0; b<mbapp->num_local_blocks; ++b) {
         struct gkyl_gyrokinetic_app *sbapp = mbapp->singleb_apps[b];
         int d  = 0;
-        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, 1.0/sbapp->grid.dx[1], &sbapp->global_ext);
+        gkyl_array_scale_range(sbapp->species[i].anom_diff.diffD, 1.0/sbapp->grid.dx[sbapp->cdim-1], &sbapp->global_ext);
       }
 
     }


### PR DESCRIPTION
For anomalous diffusion, the diffusion coefficient in computational coordinates is nu = g^{xx} J D. This differs by a factor of dz at radial MB boundaries (The same factor which appears in the surface elements at the boundary). The diffusion coefficient in the ghost cell needs to be rescaled by this ratio to ensure particle conservation. With this fix, my production simulations finally settle to the right particle and energy output in steady state. 