### PR TITLE
Remove const int from some variables

### DIFF
--- a/core/unit/ctest_alloc.c
+++ b/core/unit/ctest_alloc.c
@@ -43,7 +43,7 @@ test_aligned_realloc()
 void test_mem_buff(bool use_gpu)
 {
   // Create a new memory buffer.
-  const int nelem = 7;
+  int nelem = 7;
   gkyl_mem_buff mbuff = use_gpu? gkyl_mem_buff_cu_new(nelem * sizeof(double))
                                : gkyl_mem_buff_new(nelem * sizeof(double));
 
@@ -78,7 +78,7 @@ void test_mem_buff(bool use_gpu)
     gkyl_free(mbuff_p2_ho);
 
   // Resize.
-  const int nelem_new = nelem*3;
+  int nelem_new = nelem*3;
   mbuff = gkyl_mem_buff_resize(mbuff, nelem_new * sizeof(double));
 
   // Assign new values.

--- a/core/unit/ctest_gauss_quad.c
+++ b/core/unit/ctest_gauss_quad.c
@@ -6,7 +6,8 @@
 static void
 test_g1()
 {
-  double w[gkyl_gauss_max], x[gkyl_gauss_max];
+  int gauss_max = gkyl_gauss_max;
+  double w[gauss_max], x[gauss_max];
   
   for (unsigned n=1; n<=gkyl_gauss_max; ++n) {
     // use the generic routine to get the ordinates and weights

--- a/core/zero/gkyl_gauss_quad_data.h
+++ b/core/zero/gkyl_gauss_quad_data.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 // Maximum order ordinate/weight data
-static const int gkyl_gauss_max = 8;
+enum { gkyl_gauss_max = 8 };
 
 // Ordinates
 static const double gkyl_gauss_ordinates_1[] =

--- a/gyrokinetic/unit/ctest_bc_twistshift.c
+++ b/gyrokinetic/unit/ctest_bc_twistshift.c
@@ -216,12 +216,12 @@ test_bc_twistshift_3x_fig6_wcells(const int *cells, enum gkyl_edge_loc edge,
   double B0 = 1.0; // Magnetic field magnitude.
   int bc_dir = 2; // Direction in which to apply TS.
 
-  const int poly_order = 1;
+  int poly_order = 1;
   const double lower[] = {-2.0, -1.50, -3.0};
   const double upper[] = { 2.0,  1.50,  3.0};
-  const int vdim = 0;
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int cdim = ndim - vdim;
+  int vdim = 0;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int cdim = ndim - vdim;
 
   double lower_conf[cdim], upper_conf[cdim];
   int cells_conf[cdim];
@@ -455,12 +455,12 @@ test_bc_twistshift_3x2v_fig6_wcells(const int *cells, enum gkyl_edge_loc edge,
   double B0 = 1.0; // Magnetic field magnitude.
   int bc_dir = 2; // Direction in which to apply TS.
 
-  const int poly_order = 1;
+  int poly_order = 1;
   const double lower[] = {-2.0, -1.50, -3.0, -5.0*vt, 0.};
   const double upper[] = { 2.0,  1.50,  3.0,  5.0*vt, mass*(pow(5.0*vt,2))/(2.0*B0)};
-  const int vdim = 2;
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int cdim = ndim - vdim;
+  int vdim = 2;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int cdim = ndim - vdim;
 
   double lower_conf[cdim], upper_conf[cdim];
   int cells_conf[cdim];
@@ -874,12 +874,12 @@ test_bc_twistshift_3x_fig11_wcells(const int *cells, enum gkyl_edge_loc edge,
   double B0 = 1.0; // Magnetic field magnitude.
   int bc_dir = 2; // Direction in which to apply TS.
 
-  const int poly_order = 1;
+  int poly_order = 1;
   const double lower[] = {-2.0, -1.50, -3.0};
   const double upper[] = { 2.0,  1.50,  3.0};
-  const int vdim = 0;
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int cdim = ndim - vdim;
+  int vdim = 0;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int cdim = ndim - vdim;
 
   double lower_conf[cdim], upper_conf[cdim];
   int cells_conf[cdim];
@@ -1190,12 +1190,12 @@ test_bc_twistshift_3x2v_fig11_wcells(const int *cells, enum gkyl_edge_loc edge,
   double B0 = 1.0; // Magnetic field magnitude.
   int bc_dir = 2; // Direction in which to apply TS.
 
-  const int poly_order = 1;
+  int poly_order = 1;
   const double lower[] = {-2.0, -1.50, -3.0, -5.0*vt, 0.};
   const double upper[] = { 2.0,  1.50,  3.0,  5.0*vt, mass*(pow(5.0*vt,2))/(2.0*B0)};
-  const int vdim = 2;
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int cdim = ndim - vdim;
+  int vdim = 2;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int cdim = ndim - vdim;
 
   double lower_conf[cdim], upper_conf[cdim];
   int cells_conf[cdim];

--- a/gyrokinetic/unit/ctest_correct_maxwellian_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_correct_maxwellian_gyrokinetic.c
@@ -95,10 +95,10 @@ void test_1x1v(int poly_order, bool use_gpu)
   double vt = sqrt(10.0*1.602e-19/9.1e-31); // reference temperature
   double lower[] = {-M_PI, -4.0*vt}, upper[] = {M_PI, 4.0*vt};
   int cells[] = {4, 16};
-  const int vdim = 1;
+  int vdim = 1;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -355,10 +355,10 @@ void test_1x2v(int poly_order, bool use_gpu)
   double vt = sqrt(10.0*1.602e-19/9.1e-31); // reference temperature
   double lower[] = {-M_PI, -4.0*vt, 0.0}, upper[] = {M_PI, 4.0*vt, 4.0*vt*vt*mass};
   int cells[] = {4, 16, 16};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -614,10 +614,10 @@ void test_2x2v(int poly_order, bool use_gpu)
   double vt = sqrt(10.0*1.602e-19/9.1e-31); // reference temperature
   double lower[] = {-M_PI, -M_PI, -4.0*vt, 0.0}, upper[] = {M_PI, M_PI, 4.0*vt, 4.0*vt*vt*mass};
   int cells[] = {4, 4, 16, 16};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];

--- a/gyrokinetic/unit/ctest_dg_interpolate.c
+++ b/gyrokinetic/unit/ctest_dg_interpolate.c
@@ -85,7 +85,7 @@ test_1x(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
   double lower[] = {0.0}, upper[] = {1.0};
   double mass = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
+  int ndim = sizeof(lower)/sizeof(lower[0]);
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -202,7 +202,7 @@ test_2x(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
   double lower[] = {0.0, -M_PI}, upper[] = {1.0, M_PI};
   double mass = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
+  int ndim = sizeof(lower)/sizeof(lower[0]);
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -336,7 +336,7 @@ static void calc_moms_vlasov(struct gkyl_rect_grid *grid, struct gkyl_basis *con
 void
 test_1x1v_vlasov(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double x_min = 0.0;
   double x_max = 1.0;
   double vx_min = -6.0;
@@ -344,8 +344,8 @@ test_1x1v_vlasov(const int *cells, const int *cells_tar, int poly_order, bool us
   double lower[] = {x_min, vx_min}, upper[] = {x_max, vx_max};
   double mass = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -571,7 +571,7 @@ void eval_distf_1x2v_vlasov(double t, const double *xn, double* restrict fout, v
 void
 test_1x2v_vlasov(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double x_min = 0.0;
   double x_max = 1.0;
   double vx_min = -6.0;
@@ -581,8 +581,8 @@ test_1x2v_vlasov(const int *cells, const int *cells_tar, int poly_order, bool us
   double lower[] = {x_min, vx_min, vy_min}, upper[] = {x_max, vx_max, vy_max};
   double mass = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -905,7 +905,7 @@ static void calc_moms_gk(struct gkyl_rect_grid *grid, struct gkyl_basis *confBas
 void
 test_1x1v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double x_min = 0.0;
   double x_max = 1.0;
   double vpar_min = -6.0;
@@ -914,8 +914,8 @@ test_1x1v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gp
   double mass = 1.0;
   double charge = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -1176,7 +1176,7 @@ void eval_distf_1x2v_gk(double t, const double *xn, double* restrict fout, void 
 void
 test_1x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double x_min = 0.0;
   double x_max = 1.0;
   double vpar_min = -6.0;
@@ -1186,8 +1186,8 @@ test_1x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gp
   double mass = 1.0;
   double charge = 1.0;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -1446,7 +1446,7 @@ void eval_distf_2x2v_gk(double t, const double *xn, double* restrict fout, void 
 void
 test_2x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 2;
+  int cdim = 2;
 //  double x_min = 0.0;
 //  double x_max = 1.0;
 //  double y_min = 0.0;
@@ -1465,8 +1465,8 @@ test_2x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gp
   double mass = 1.67e-27*3.973;
   double charge = 1.602e-19;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.
@@ -1725,7 +1725,7 @@ void eval_distf_3x2v_gk(double t, const double *xn, double* restrict fout, void 
 void
 test_3x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gpu)
 {
-  const int cdim = 3;
+  int cdim = 3;
 //  double x_min = 0.0;
 //  double x_max = 1.0;
 //  double y_min = 0.0;
@@ -1757,8 +1757,8 @@ test_3x2v_gk(const int *cells, const int *cells_tar, int poly_order, bool use_gp
   double mass = 1.67e-27*3.973;
   double charge = 1.602e-19;
 
-  const int ndim = sizeof(lower)/sizeof(lower[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(lower)/sizeof(lower[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.

--- a/gyrokinetic/unit/ctest_dg_rad_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_dg_rad_gyrokinetic.c
@@ -121,10 +121,10 @@ test_1x(int poly_order, bool use_gpu, double te, int atomic_z,
   double lower[] = {-1.0, -4*vth, 0.0};
   double upper[] = {1.0, 4*vth, 9*vth*vth*GKYL_ELECTRON_MASS};
   int cells[] = {2, 256, 128};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -453,10 +453,10 @@ test_2x(int poly_order, bool use_gpu, double te)
   double lower[] = {-2.0, -1.0, -4*vth, 0.0};
   double upper[] = {2.0, 1.0, 4*vth, 9*vth*vth*GKYL_ELECTRON_MASS};
   int cells[] = {2, 2, 256, 128};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];

--- a/gyrokinetic/unit/ctest_fem_parproj.c
+++ b/gyrokinetic/unit/ctest_fem_parproj.c
@@ -64,7 +64,7 @@ static void check_continuity_par(struct gkyl_range range, struct gkyl_basis basi
   if (basis.poly_order > 1) return;
   int ndim = basis.ndim;
   int pardir = ndim-1;
-  const int num_nodes_perp_max = 4; // 3x p=1.
+  int num_nodes_perp_max = 4; // 3x p=1.
   int num_nodes_perp = 1;
   if (ndim == 2)
     num_nodes_perp = 2;
@@ -176,7 +176,7 @@ void check_dirichlet_bc(struct gkyl_range local, struct gkyl_range local_ext, st
 
   int ndim = basis.ndim;
   int pardir = ndim-1;
-  const int num_nodes_perp_max = 4; // 3x p=1.
+  int num_nodes_perp_max = 4; // 3x p=1.
   int num_nodes_perp = 1;
   if (ndim == 2)
     num_nodes_perp = 2;
@@ -256,7 +256,7 @@ void check_dirichlet_bc_bias(struct gkyl_rect_grid grid, struct gkyl_range local
 
   int ndim = basis.ndim;
   int pardir = ndim-1;
-  const int num_nodes_perp_max = 4; // 3x p=1.
+  int num_nodes_perp_max = 4; // 3x p=1.
   int num_nodes_perp = 1;
   if (ndim == 2)
     num_nodes_perp = 2;

--- a/gyrokinetic/unit/ctest_integrated_moms.c
+++ b/gyrokinetic/unit/ctest_integrated_moms.c
@@ -88,9 +88,9 @@ test_2x_option(bool use_gpu)
   double lower[] = {0.0, 0.0, -vpar_max_ion, 0.0};
   double upper[] = {1.0, 1.0, vpar_max_ion, mu_max_ion};
   int cells[] = {10, 16, 16, 20};
-  const int vdim = 2;
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int vdim = 2;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim], vLower[vdim], vUpper[vdim];
   int confCells[cdim], vCells[vdim];

--- a/gyrokinetic/unit/ctest_mom_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_mom_gyrokinetic.c
@@ -67,10 +67,10 @@ test_mom_gyrokinetic()
   int poly_order = 1;
   double lower[] = {-M_PI, -2.0, 0.0}, upper[] = {M_PI, 2.0, 2.0};
   int cells[] = {4, 2, 2};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -196,10 +196,10 @@ test_1x1v(int polyOrder, bool use_gpu)
   int poly_order = 1;
   double lower[] = {-M_PI, -2.0}, upper[] = {M_PI, 2.0};
   int cells[] = {4, 2};
-  const int vdim = 1;
+  int vdim = 1;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -448,10 +448,10 @@ test_1x2v(int poly_order, bool use_gpu)
   double charge = 1.0;
   double lower[] = {-M_PI, -2.0, 0.0}, upper[] = {M_PI, 2.0, 2.0};
   int cells[] = {4, 2, 2};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -682,10 +682,10 @@ test_2x2v(int poly_order, bool use_gpu)
   double charge = 1.0;
   double lower[] = {-M_PI, -M_PI, -2.0, 0.0}, upper[] = {M_PI, M_PI, 2.0, 2.0};
   int cells[] = {4, 4, 2, 2};
-  const int vdim = 2;
+  int vdim = 2;
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim - vdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim - vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];

--- a/gyrokinetic/unit/ctest_positivity_shift_gyrokinetic.c
+++ b/gyrokinetic/unit/ctest_positivity_shift_gyrokinetic.c
@@ -84,14 +84,14 @@ void eval_distf_1x2v(double t, const double *xn, double* restrict fout, void *ct
 void
 test_1x2v(int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double vpar_max = 6.0;
   double mu_max = 36.0;
   double lower[] = {0.1, -vpar_max, 0.0}, upper[] = {1.0, vpar_max, mu_max};
   int cells[] = {2, 12, 8};
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.

--- a/gyrokinetic/unit/ctest_proj_gk_maxwellian_on_basis.c
+++ b/gyrokinetic/unit/ctest_proj_gk_maxwellian_on_basis.c
@@ -64,9 +64,9 @@ test_1x2v_gk(int poly_order, bool use_gpu)
   double mass = 1.0;
   double lower[] = {0.1, -6.0, 0.0}, upper[] = {1.0, 6.0, 6.0};
   int cells[] = {2, 16, 16};
-  const int vdim = 2;
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim-vdim;
+  int vdim = 2;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim-vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];
@@ -305,9 +305,9 @@ test_3x2v_gk(int poly_order, bool use_gpu)
   double mass = 1.0;
   double lower[] = {0.1, 0.1, 0.1, -6.0, 0.0}, upper[] = {1.0, 1.0, 1.0, 6.0, 6.0};
   int cells[] = {2, 2, 2, 16, 16};
-  const int vdim = 2;
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int cdim = ndim-vdim;
+  int vdim = 2;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int cdim = ndim-vdim;
 
   double confLower[cdim], confUpper[cdim];
   int confCells[cdim];

--- a/vlasov/unit/ctest_positivity_shift_vlasov.c
+++ b/vlasov/unit/ctest_positivity_shift_vlasov.c
@@ -57,13 +57,13 @@ void eval_distf_1x2v(double t, const double *xn, double* restrict fout, void *ct
 void
 test_1x2v(int poly_order, bool use_gpu)
 {
-  const int cdim = 1;
+  int cdim = 1;
   double vx_max = 6.0, vy_max = 6.0;
   double lower[] = {0.0, -vx_max, -vy_max}, upper[] = {1.0, vx_max, vy_max};
   int cells[] = {2, 12, 8};
 
-  const int ndim = sizeof(cells)/sizeof(cells[0]);
-  const int vdim = ndim-cdim;
+  int ndim = sizeof(cells)/sizeof(cells[0]);
+  int vdim = ndim-cdim;
 
   struct test_ctx proj_ctx = {
     .n0 = 1.0, // Density.

--- a/vlasov/unit/ctest_velocity_map.c
+++ b/vlasov/unit/ctest_velocity_map.c
@@ -57,9 +57,9 @@ test_vmap_1x2v_p1(bool use_gpu)
   int poly_order = 1;
   double lower[] = {-M_PI, -1.0, 0.0}, upper[] = {M_PI, 1.0, 1.0};
   int cells[] = {2, 12, 6};
-  const int vdim = 2;
-  const int pdim = sizeof(lower)/sizeof(lower[0]);
-  const int cdim = pdim - vdim;
+  int vdim = 2;
+  int pdim = sizeof(lower)/sizeof(lower[0]);
+  int cdim = pdim - vdim;
 
   double lower_conf[cdim], upper_conf[cdim];
   int cells_conf[cdim];


### PR DESCRIPTION
A newer compiler is throwing "variable length array folded to constant array as an extension" warnings when we use `const int` in like
```
const int cdim = 2;

int cells[cdim];
```

This PR removes const from these. Also, a const int parameter in the gauss_quad_data is apparently better defined as enum.

Affected unit tests run as before.
make install and make unit run as before too.